### PR TITLE
docs: Add instructions to run from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 - [Screenshot](#screenshot)
 - [Installation](#installation)
+- [Running from source](#running-from-source)
 - [FAQ](#faq)
 <!--toc:end-->
 
@@ -32,7 +33,7 @@
 
 ```pwsh
 # Test the main branch
-uvx --from git+https://github.com/NSPC911/rovr.git -q rovr --python 3.13
+uvx git+https://github.com/NSPC911/rovr.git
 # Install
 ## uv (my fav)
 uv tool install rovr
@@ -45,17 +46,20 @@ pip install rovr
 ### Running from source
 
 ```pwsh
-cd /path/to/rovr
 uv run poe run
 ```
 
-Running in dev mode to see debug output, logs, and events from rovr
+Running in dev mode to see debug outputs and logs
 ```pwsh
-# Runs a separate console to capture debug output from your TUI app
-uv run poe log
-# Runs your app in development mode and sends debug info to the console
+# Runs it in development mode, allowing a connected console
+# to capture the output of its print statements
 uv run poe dev
+# Runs a separate console to capture print statements
+uv run poe log
+# capture everything
+uv run textual console
 ```
+For more info on Textual's console, refer to https://textual.textualize.io/guide/devtools/#console
 
 ### FAQ
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ pipx install rovr
 pip install rovr
 ```
 
+### Running from source
+
+```pwsh
+cd /path/to/rovr
+uv run poe run
+```
+
+Running in dev mode to see debug output, logs, and events from rovr
+```pwsh
+# Runs a separate console to capture debug output from your TUI app
+uv run poe log
+# Runs your app in development mode and sends debug info to the console
+uv run poe dev
+```
+
 ### FAQ
 
 1. There isn't X theme/Why isn't Y theme available?


### PR DESCRIPTION
## Why ?
It took me some time to understand and figure this out. Better documented in ReadMe
## How it looks

<img width="958" height="306" alt="image" src="https://github.com/user-attachments/assets/fac890c0-92de-4193-a9e0-f14598f3ca60" />


