### PR TITLE
feat: Specify start dir tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ uv run textual console
 ```
 For more info on Textual's console, refer to https://textual.textualize.io/guide/devtools/#console
 
+### Testing
+
+```pwsh
+# Run all tests
+uv run poe test
+# Run a specific test
+uv run pytest src/rovr/tests/test_init.py -v
+```
+
 ### FAQ
 
 1. There isn't X theme/Why isn't Y theme available?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dev = [
   "commitizen>=4.8.3",
   "json-schema-for-humans>=1.4.1",
   "poethepoet>=0.36.0",
+  "pytest>=8.0.0",
+  "pytest-asyncio>=0.23.0",
   "ruff>=0.11.12",
   "textual-dev>=1.7.0",
 ]
@@ -64,10 +66,11 @@ update_changelog_on_bump = true
 major_version_zero = false
 
 [tool.poe.tasks]
-dev = "textual run --dev rovr.app:Application"
+dev = "textual run --dev rovr.__main__:main"
 run = "rovr"
 log = "textual console -x WORKER -x SYSTEM -x DEBUG -x EVENT"
 "gen-schema" = "docs/scripts/generate_schema.py"
+test = "pytest src/rovr/tests/"
 
 [tool.ruff.lint]
 select = [

--- a/src/rovr/__main__.py
+++ b/src/rovr/__main__.py
@@ -39,11 +39,17 @@ try:
         is_flag=True,
         help="Show the current version of rovr.",
     )
+    @click.argument(
+        "path",
+        type=str,
+        required=False
+    )
     def main(
         with_features: list[str],
         without_features: list[str],
         config_path: bool,
         show_version: bool,
+        path: str,
     ) -> None:
         """A post-modern terminal file explorer"""
 
@@ -64,7 +70,10 @@ try:
 
         from rovr.app import Application
 
-        Application(watch_css=True).run()
+        # Need to move this 'path' in the cofig dict, or a new runtime_config dict
+        # Eventually there will be many options coming via args, but we cant keep sending all of 
+        # them via this Application's __init__ function here
+        Application(watch_css=True, startup_path=path).run()
 
 except KeyboardInterrupt:
     pass

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -205,6 +205,8 @@ class FileList(SelectionList, inherit_bindings=False):
             session.sessionLastHighlighted[cwd] = (
                 self.app.query_one("#file_list").options[0].value
             )
+        
+        self.scroll_to_highlight()
         self.app.tabWidget.active_tab.label = (
             path.basename(cwd) if path.basename(cwd) != "" else cwd.strip("/")
         )

--- a/src/rovr/functions/path.py
+++ b/src/rovr/functions/path.py
@@ -203,6 +203,17 @@ def get_recursive_files(
             return files, folders
         return files
 
+def ensure_existing_directory(directory: str) -> str:
+    while not (path.exists(directory) and path.isdir(directory)) :
+        parent = path.dirname(directory)
+        # If we can't even access the root then there is a bigger problem
+        # and this could result in infinite loop
+        if parent == directory :
+            break
+        
+        directory = parent
+    return directory
+
 
 def _should_include_macos_mount_point(partition: "psutil._common.sdiskpart") -> bool:
     """

--- a/src/rovr/tests/test_init.py
+++ b/src/rovr/tests/test_init.py
@@ -1,0 +1,94 @@
+import tempfile
+import dataclasses 
+import pytest
+
+from os import path, getcwd, chdir
+from pathlib import Path
+
+import rovr.tests.utils as testutils
+from rovr.app import Application
+from rovr.core.file_list import FileList
+from rovr.functions import path as path_utils
+
+@dataclasses.dataclass
+class TestCase:
+    name: str
+    init_directory: Path  
+    startup_arg: str
+    expected_cwd: Path
+    expected_focus: str
+
+@pytest.mark.asyncio
+async def test_app_init_with_path():
+    # Create a temporary directory with a test file
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Todo: Do we need realpath here to resolve symlinks ?
+        temp_dir = Path(path.realpath(temp_dir))
+        dir1 = Path(temp_dir) / "dir1"
+        file1_a = Path(temp_dir) / "file1.txt"
+        file1_b = dir1 / "file1.txt"
+        file2_a = dir1 / ".file2"
+        testutils.setup_test_dir(dir1)
+        testutils.setup_test_files(file1_a, file1_b, file2_a)
+        
+        # Dataclass tests > parameterized test  
+        # more readable, more type safe
+        test_cases: list[TestCase] = [
+            TestCase(
+                name="No argument",
+                init_directory=dir1,
+                startup_arg="",
+                expected_cwd=dir1,
+                expected_focus=path.basename(file2_a),
+            ),
+            TestCase(
+                name="Absolute Path",
+                init_directory=temp_dir,
+                startup_arg=str(dir1),
+                expected_cwd=dir1,
+                expected_focus=path.basename(file2_a),
+            ),
+            TestCase(
+                name="Relative path",
+                init_directory=dir1,
+                startup_arg="..",
+                expected_cwd=temp_dir,
+                expected_focus=path.basename(dir1),
+            ),
+            TestCase(
+                name="Relative path of file",
+                init_directory=temp_dir,
+                startup_arg="dir1/.file2",
+                expected_cwd=dir1,
+                expected_focus=path.basename(file2_a),
+            ),
+            TestCase(
+                name="Non existing directory",
+                init_directory=temp_dir,
+                startup_arg="dir1/not/existing/path",
+                expected_cwd=dir1,
+                expected_focus=path.basename(file2_a),
+            ),
+        ]            
+        for t in test_cases:
+            await run_test(t)
+            print("Passed ", t.name)
+
+async def run_test(t: TestCase) -> None:
+    chdir(t.init_directory)
+    app = Application(startup_path=t.startup_arg)
+    
+    async with app.run_test() as pilot:
+        # Wait for the app to fully initialize
+        await pilot.pause()
+        assert getcwd() == str(t.expected_cwd), "cwd not changed as expected"
+        
+        file_list: FileList = app.query_one("#file_list")
+        assert file_list.option_count > 0, "File list is not populated"
+        assert file_list.highlighted is not None, "No highglighted object in non empty directory"
+        # Verify the target file is highlighted
+        highlighted_option = file_list.get_option_at_index(file_list.highlighted)
+        highlighted_id: str = highlighted_option.id
+        actual_filename = path_utils.decompress(highlighted_id)
+        
+        assert actual_filename == t.expected_focus, "Wrong item is highlighted"

--- a/src/rovr/tests/utils.py
+++ b/src/rovr/tests/utils.py
@@ -1,0 +1,13 @@
+from os import mkdir
+from pathlib import Path
+TEST_FILE_CONTENT_1 = "file data"
+
+# Let the exceptions roam wild
+def setup_test_dir(*args: Path):
+    for dir in args:
+        mkdir(dir)   
+
+# Let the exceptions roam wild
+def setup_test_files(*args: Path):
+    for file in args:
+        file.write_text(TEST_FILE_CONTENT_1) 

--- a/uv.lock
+++ b/uv.lock
@@ -276,6 +276,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -608,6 +617,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "poethepoet"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -695,6 +713,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
 ]
 
 [[package]]
@@ -813,6 +859,8 @@ dev = [
     { name = "commitizen" },
     { name = "json-schema-for-humans" },
     { name = "poethepoet" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "textual-dev" },
 ]
@@ -842,6 +890,8 @@ dev = [
     { name = "commitizen", specifier = ">=4.8.3" },
     { name = "json-schema-for-humans", specifier = ">=1.4.1" },
     { name = "poethepoet", specifier = ">=0.36.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "ruff", specifier = ">=0.11.12" },
     { name = "textual-dev", specifier = ">=1.7.0" },
 ]


### PR DESCRIPTION
Add unit test to verify that the start dir feature works, and to make sure that no regression are introduced in code in the future.

Testing guide used
- https://textual.textualize.io/guide/testing/


<details><summary>Test run</summary>
<p>

```
➜  carto git:(specify-start-dir) uv run poe test
Poe => pytest src/rovr/tests/
======================================== test session starts ========================================
platform darwin -- Python 3.13.7, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/nitin/Programming/carto
configfile: pyproject.toml
plugins: asyncio-1.1.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item

src/rovr/tests/test_init.py .                                                                 [100%]

========================================= warnings summary ==========================================
.venv/lib/python3.13/site-packages/jsonschema/validators.py:1326
  /Users/nitin/Programming/carto/.venv/lib/python3.13/site-packages/jsonschema/validators.py:1326: DeprecationWarning: The metaschema specified by $schema was not found. Using the latest draft to validate, but this will raise an error in the future.
    cls = validator_for(schema)

src/rovr/tests/test_init.py:13
  /Users/nitin/Programming/carto/src/rovr/tests/test_init.py:13: PytestCollectionWarning: cannot collect test class 'TestCase' because it has a __init__ constructor (from: src/rovr/tests/test_init.py)
    @dataclasses.dataclass

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================== 1 passed, 2 warnings in 2.86s ===================================
➜  carto git:(specify-start-dir)
```

</p>
</details> 


