### PR TITLE
fix: Follow up from PR #58 - Adjust width based on the first score

### DIFF
--- a/src/rovr/screens/zd_to_directory.py
+++ b/src/rovr/screens/zd_to_directory.py
@@ -126,12 +126,17 @@ class ZDToDirectory(ModalScreen):
         zoxide_options.add_class("empty")
         options = []
         if zoxide_output.stdout:
+            first_score_width = 0
             for line in zoxide_output.stdout.splitlines():
                 path, score = self._parse_zoxide_line(line, show_scores)
-
                 if show_scores and score:
+
+                    # This ensures that we dont add only necessary padding
+                    # first score is going to be the largest, so we take its width
+                    if first_score_width == 0:
+                        first_score_width = len(score)
                     # Fixed size to make it look good.
-                    display_text = f" {score:>6} | {path}"
+                    display_text = f" {score:>{first_score_width}} | {path}"
                 else:
                     display_text = f" {path}"
 

--- a/src/rovr/screens/zd_to_directory.py
+++ b/src/rovr/screens/zd_to_directory.py
@@ -95,6 +95,13 @@ class ZDToDirectory(ModalScreen):
             return path, score_str
         else:
             # This should ideally never happen
+            self.notify(
+                # Not printing the entire line as that could be too big for UI
+                # message. We anyway have the lines in logs
+                "Unexpected tokens count while parsing zoxide lines",
+                title="Zoxide Plugin",
+                severity="error",
+            )
             print(f"Problems while parsing zoxide line - '{line}'")
             return line, None
 

--- a/src/rovr/screens/zd_to_directory.py
+++ b/src/rovr/screens/zd_to_directory.py
@@ -138,7 +138,7 @@ class ZDToDirectory(ModalScreen):
                 path, score = self._parse_zoxide_line(line, show_scores)
                 if show_scores and score:
 
-                    # This ensures that we dont add only necessary padding
+                    # This ensures that we only add necessary padding
                     # first score is going to be the largest, so we take its width
                     if first_score_width == 0:
                         first_score_width = len(score)


### PR DESCRIPTION
Old PR
- https://github.com/NSPC911/rovr/pull/58

Follow up for

(1) Adjust padding dynamacally
(2) Add  toast message for failure


Screenshots for toast

<img width="892" height="549" alt="image" src="https://github.com/user-attachments/assets/44932e99-4f19-4be9-bac8-c36d47563ba1" />


Screenshots for Adjust padding dynamacally

Big

<img width="530" height="314" alt="image" src="https://github.com/user-attachments/assets/8ab25b53-a2a1-45d0-83f4-19090f9d8614" />

Small

<img width="536" height="293" alt="image" src="https://github.com/user-attachments/assets/14184e3a-b192-413b-9688-741143db1bf6" />



Todos
- Add video and screenshots.