### PR TITLE
fix: Use None during splitting zoxide output

### DIFF
--- a/src/rovr/screens/zd_to_directory.py
+++ b/src/rovr/screens/zd_to_directory.py
@@ -89,7 +89,7 @@ class ZDToDirectory(ModalScreen):
 
         # Example "  <floating_score> <path_with_spaces>"
         # Split only on first space to make sure path with spaces work
-        parts = line.split(" ", 1)
+        parts = line.split(None, 1)
         if len(parts) == 2:
             score_str, path = parts
             return path, score_str


### PR DESCRIPTION
This is a bit of a nitpick. I noticed it randomly. I am the one who did this mistake anyways :)

Current split creates a tight dependency on the `zoxide` output, making the parsing less robust. 

This only splits output based on the first space, and output like `<score><multiple_spaces_or_tabs><path>` will not be split correctly, leading to unwanted leading spaces in the `path` string

```
>>> x="1    2  3"
>>> y="1    2"
>>> x.split(None, 1)
['1', '2  3']
>>> y.split(None, 1)
['1', '2']
>>> x.split(" ", 1)
['1', '   2  3']
>>> y.split(" ", 1)
['1', '   2']
>>>
```