### PR TITLE
fix: Add package-lock.json in gitignore

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,6 +3,9 @@ dist/
 # generated types
 .astro/
 
+# lockfiles
+package-lock.json
+
 # dependencies
 node_modules/
 


### PR DESCRIPTION
I use `git add .` and end up pushing the package-lock json many times.