### PR TITLE
fix(zoxide): resolve scenario of no zoxide

### DIFF
--- a/src/rovr/screens/zd_to_directory.py
+++ b/src/rovr/screens/zd_to_directory.py
@@ -1,5 +1,5 @@
 import contextlib
-from subprocess import run
+from subprocess import CalledProcessError, run
 from time import monotonic
 
 from textual import events, work
@@ -126,7 +126,7 @@ class ZDToDirectory(ModalScreen):
                 capture_output=True,
                 text=True,
             )
-        except OSError:
+        except (FileNotFoundError, CalledProcessError, OSError):
             # zoxide not installed
             if self.any_in_queue():
                 return
@@ -214,7 +214,7 @@ class ZDToDirectory(ModalScreen):
         selected_value = event.option.id
         assert selected_value is not None
         # ignore if zoxide got uninstalled, why are you doing this
-        with contextlib.suppress(OSError):
+        with contextlib.suppress(FileNotFoundError, CalledProcessError, OSError):
             run(
                 ["zoxide", "add", path_utils.decompress(selected_value)],
                 capture_output=True,

--- a/src/rovr/screens/zd_to_directory.py
+++ b/src/rovr/screens/zd_to_directory.py
@@ -126,7 +126,7 @@ class ZDToDirectory(ModalScreen):
                 capture_output=True,
                 text=True,
             )
-        except FileNotFoundError:
+        except OSError:
             # zoxide not installed
             if self.any_in_queue():
                 return
@@ -137,7 +137,11 @@ class ZDToDirectory(ModalScreen):
                 self.app.call_from_thread(zoxide_options.clear_options)
                 self.app.call_from_thread(
                     zoxide_options.add_option,
-                    Option("  zoxide is not found on $PATH", disabled=True, id="na"),
+                    Option(
+                        "  zoxide is missing on $PATH or cannot be executed",
+                        disabled=True,
+                        id="na",
+                    ),
                 )
             self.any_in_queue()
             return
@@ -210,7 +214,7 @@ class ZDToDirectory(ModalScreen):
         selected_value = event.option.id
         assert selected_value is not None
         # ignore if zoxide got uninstalled, why are you doing this
-        with contextlib.suppress(FileNotFoundError):
+        with contextlib.suppress(OSError):
             run(
                 ["zoxide", "add", path_utils.decompress(selected_value)],
                 capture_output=True,

--- a/src/rovr/screens/zd_to_directory.py
+++ b/src/rovr/screens/zd_to_directory.py
@@ -1,3 +1,4 @@
+import contextlib
 from subprocess import run
 from time import monotonic
 
@@ -119,11 +120,27 @@ class ZDToDirectory(ModalScreen):
             zoxide_cmd.append("--score")
         zoxide_cmd += search_term.split()
 
-        zoxide_output = run(
-            zoxide_cmd,
-            capture_output=True,
-            text=True,
-        )
+        try:
+            zoxide_output = run(
+                zoxide_cmd,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            # zoxide not installed
+            if self.any_in_queue():
+                return
+            zoxide_options: ZoxideOptionList = self.query_one(
+                "#zoxide_options", ZoxideOptionList
+            )
+            if zoxide_options.get_option_at_index(0).id != "na":
+                self.app.call_from_thread(zoxide_options.clear_options)
+                self.app.call_from_thread(
+                    zoxide_options.add_option,
+                    Option("  zoxide is not found on $PATH", disabled=True, id="na"),
+                )
+            self.any_in_queue()
+            return
         # check 2 for queue, to ignore mounting as a whole
         if self.any_in_queue():
             return
@@ -142,7 +159,7 @@ class ZDToDirectory(ModalScreen):
                     if first_score_width == 0:
                         first_score_width = len(score)
                     # Fixed size to make it look good.
-                    display_text = f" {score:>{first_score_width}} | {path}"
+                    display_text = f" {score:>{first_score_width}} │ {path}"
                 else:
                     display_text = f" {path}"
 
@@ -192,11 +209,13 @@ class ZDToDirectory(ModalScreen):
         """Handle option selection."""
         selected_value = event.option.id
         assert selected_value is not None
-        run(
-            ["zoxide", "add", path_utils.decompress(selected_value)],
-            capture_output=True,
-            text=True,
-        )
+        # ignore if zoxide got uninstalled, why are you doing this
+        with contextlib.suppress(FileNotFoundError):
+            run(
+                ["zoxide", "add", path_utils.decompress(selected_value)],
+                capture_output=True,
+                text=True,
+            )
         if selected_value:
             self.dismiss(selected_value)
         else:


### PR DESCRIPTION
resolves #79


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * App no longer fails if the external zoxide tool is missing, times out, or fails to run; processing continues and a clear “zoxide not found on PATH” or timeout message is shown when applicable.
  * Silent handling prevents user interruptions when zoxide add cannot run while preserving normal dismissal and navigation behavior.

* **Style**
  * Improved readability of location scores by switching the separator to a vertical box-drawing character (│).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->