### PR TITLE
refactor: move list bindings to constants

### DIFF
--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -5,7 +5,7 @@ from typing import ClassVar
 from rich.segment import Segment
 from rich.style import Style
 from textual import events, on, work
-from textual.binding import Binding, BindingType
+from textual.binding import BindingType
 from textual.css.query import NoMatches
 from textual.strip import Strip
 from textual.widgets import Button, Input, OptionList, SelectionList
@@ -17,7 +17,7 @@ from rovr.functions import icons as icon_utils
 from rovr.functions import path as path_utils
 from rovr.functions import pins as pin_utils
 from rovr.functions import utils
-from rovr.variables.constants import buttons_that_depend_on_path, config
+from rovr.variables.constants import buttons_that_depend_on_path, config, vindings
 from rovr.variables.maps import ARCHIVE_EXTENSIONS
 
 
@@ -26,36 +26,7 @@ class FileList(SelectionList, inherit_bindings=False):
     OptionList but can multi-select files and folders.
     """
 
-    BINDINGS: ClassVar[list[BindingType]] = (
-        [
-            Binding(bind, "cursor_down", "Down", show=False)
-            for bind in config["keybinds"]["down"]
-        ]
-        + [
-            Binding(bind, "last", "Last", show=False)
-            for bind in config["keybinds"]["end"]
-        ]
-        + [
-            Binding(bind, "select", "Select", show=False)
-            for bind in config["keybinds"]["down_tree"]
-        ]
-        + [
-            Binding(bind, "first", "First", show=False)
-            for bind in config["keybinds"]["home"]
-        ]
-        + [
-            Binding(bind, "page_down", "Page Down", show=False)
-            for bind in config["keybinds"]["page_down"]
-        ]
-        + [
-            Binding(bind, "page_up", "Page Up", show=False)
-            for bind in config["keybinds"]["page_up"]
-        ]
-        + [
-            Binding(bind, "cursor_up", "Up", show=False)
-            for bind in config["keybinds"]["up"]
-        ]
-    )
+    BINDINGS: ClassVar[list[BindingType]] = vindings
 
     def __init__(
         self,

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -26,7 +26,7 @@ class FileList(SelectionList, inherit_bindings=False):
     OptionList but can multi-select files and folders.
     """
 
-    BINDINGS: ClassVar[list[BindingType]] = vindings
+    BINDINGS: ClassVar[list[BindingType]] = list(vindings)
 
     def __init__(
         self,

--- a/src/rovr/core/pinned_sidebar.py
+++ b/src/rovr/core/pinned_sidebar.py
@@ -3,7 +3,7 @@ from os import path
 from typing import ClassVar
 
 from textual import events, on, work
-from textual.binding import Binding, BindingType
+from textual.binding import BindingType
 from textual.widgets import Input, OptionList
 from textual.widgets.option_list import Option
 
@@ -11,42 +11,13 @@ from rovr.classes import FolderNotFileError, PinnedSidebarOption
 from rovr.functions import icons as icon_utils
 from rovr.functions import path as path_utils
 from rovr.functions import pins as pin_utils
-from rovr.variables.constants import config
+from rovr.variables.constants import config, vindings
 
 
 class PinnedSidebar(OptionList, inherit_bindings=False):
     DRIVE_WATCHER_FREQUENCY: float = config["settings"]["drive_watcher_frequency"]
     # Just so that I can disable space
-    BINDINGS: ClassVar[list[BindingType]] = (
-        [
-            Binding(bind, "cursor_down", "Down", show=False)
-            for bind in config["keybinds"]["down"]
-        ]
-        + [
-            Binding(bind, "last", "Last", show=False)
-            for bind in config["keybinds"]["end"]
-        ]
-        + [
-            Binding(bind, "select", "Select", show=False)
-            for bind in config["keybinds"]["down_tree"]
-        ]
-        + [
-            Binding(bind, "first", "First", show=False)
-            for bind in config["keybinds"]["home"]
-        ]
-        + [
-            Binding(bind, "page_down", "Page Down", show=False)
-            for bind in config["keybinds"]["page_down"]
-        ]
-        + [
-            Binding(bind, "page_up", "Page Up", show=False)
-            for bind in config["keybinds"]["page_up"]
-        ]
-        + [
-            Binding(bind, "cursor_up", "Up", show=False)
-            for bind in config["keybinds"]["up"]
-        ]
-    )
+    BINDINGS: ClassVar[list[BindingType]] = vindings
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)

--- a/src/rovr/core/pinned_sidebar.py
+++ b/src/rovr/core/pinned_sidebar.py
@@ -17,7 +17,7 @@ from rovr.variables.constants import config, vindings
 class PinnedSidebar(OptionList, inherit_bindings=False):
     DRIVE_WATCHER_FREQUENCY: float = config["settings"]["drive_watcher_frequency"]
     # Just so that I can disable space
-    BINDINGS: ClassVar[list[BindingType]] = vindings
+    BINDINGS: ClassVar[list[BindingType]] = list(vindings)
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)

--- a/src/rovr/footer/clipboard_container.py
+++ b/src/rovr/footer/clipboard_container.py
@@ -3,7 +3,7 @@ from typing import ClassVar
 from rich.segment import Segment
 from rich.style import Style
 from textual import events, work
-from textual.binding import Binding, BindingType
+from textual.binding import BindingType
 from textual.content import Content
 from textual.strip import Strip
 from textual.widgets import Button, SelectionList
@@ -12,42 +12,13 @@ from textual.widgets.option_list import OptionDoesNotExist
 from rovr.classes import ClipboardSelection
 from rovr.functions import icons as icon_utils
 from rovr.functions import path as path_utils
-from rovr.variables.constants import config
+from rovr.variables.constants import config, vindings
 
 
 class Clipboard(SelectionList, inherit_bindings=False):
     """A selection list that displays the clipboard contents."""
 
-    BINDINGS: ClassVar[list[BindingType]] = (
-        [
-            Binding(bind, "cursor_down", "Down", show=False)
-            for bind in config["keybinds"]["down"]
-        ]
-        + [
-            Binding(bind, "last", "Last", show=False)
-            for bind in config["keybinds"]["end"]
-        ]
-        + [
-            Binding(bind, "select", "Select", show=False)
-            for bind in config["keybinds"]["down_tree"]
-        ]
-        + [
-            Binding(bind, "first", "First", show=False)
-            for bind in config["keybinds"]["home"]
-        ]
-        + [
-            Binding(bind, "page_down", "Page Down", show=False)
-            for bind in config["keybinds"]["page_down"]
-        ]
-        + [
-            Binding(bind, "page_up", "Page Up", show=False)
-            for bind in config["keybinds"]["page_up"]
-        ]
-        + [
-            Binding(bind, "cursor_up", "Up", show=False)
-            for bind in config["keybinds"]["up"]
-        ]
-    )
+    BINDINGS: ClassVar[list[BindingType]] = vindings
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)

--- a/src/rovr/footer/clipboard_container.py
+++ b/src/rovr/footer/clipboard_container.py
@@ -18,7 +18,7 @@ from rovr.variables.constants import config, vindings
 class Clipboard(SelectionList, inherit_bindings=False):
     """A selection list that displays the clipboard contents."""
 
-    BINDINGS: ClassVar[list[BindingType]] = vindings
+    BINDINGS: ClassVar[list[BindingType]] = list(vindings)
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)

--- a/src/rovr/screens/keybinds.py
+++ b/src/rovr/screens/keybinds.py
@@ -2,7 +2,7 @@ from typing import ClassVar, cast
 
 from textual import events
 from textual.app import ComposeResult
-from textual.binding import Binding, BindingType
+from textual.binding import BindingType
 from textual.containers import VerticalGroup
 from textual.screen import ModalScreen
 from textual.widgets import OptionList
@@ -10,40 +10,11 @@ from textual.widgets import OptionList
 from rovr.classes.textual_options import KeybindOption
 from rovr.functions import icons
 from rovr.search_container import SearchInput
-from rovr.variables.constants import config
+from rovr.variables.constants import config, vindings
 
 
 class KeybindList(OptionList, inherit_bindings=False):
-    BINDINGS: ClassVar[list[BindingType]] = (
-        [
-            Binding(bind, "cursor_down", "Down", show=False)
-            for bind in config["keybinds"]["down"]
-        ]
-        + [
-            Binding(bind, "last", "Last", show=False)
-            for bind in config["keybinds"]["end"]
-        ]
-        + [
-            Binding(bind, "select", "Select", show=False)
-            for bind in config["keybinds"]["down_tree"]
-        ]
-        + [
-            Binding(bind, "first", "First", show=False)
-            for bind in config["keybinds"]["home"]
-        ]
-        + [
-            Binding(bind, "page_down", "Page Down", show=False)
-            for bind in config["keybinds"]["page_down"]
-        ]
-        + [
-            Binding(bind, "page_up", "Page Up", show=False)
-            for bind in config["keybinds"]["page_up"]
-        ]
-        + [
-            Binding(bind, "cursor_up", "Up", show=False)
-            for bind in config["keybinds"]["up"]
-        ]
-    )
+    BINDINGS: ClassVar[list[BindingType]] = vindings
 
     def __init__(self, **kwargs) -> None:
         keybind_data, primary_keybind_data = self.get_keybind_data()

--- a/src/rovr/screens/keybinds.py
+++ b/src/rovr/screens/keybinds.py
@@ -14,7 +14,7 @@ from rovr.variables.constants import config, vindings
 
 
 class KeybindList(OptionList, inherit_bindings=False):
-    BINDINGS: ClassVar[list[BindingType]] = vindings
+    BINDINGS: ClassVar[list[BindingType]] = list(vindings)
 
     def __init__(self, **kwargs) -> None:
         keybind_data, primary_keybind_data = self.get_keybind_data()

--- a/src/rovr/variables/constants.py
+++ b/src/rovr/variables/constants.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+from textual.binding import Binding, BindingType
+
 from rovr.functions.config import config_setup, load_config
 
 # Initialize the config once at import time
@@ -41,3 +43,32 @@ class MaxPossible:
     @property
     def width(self) -> int:
         return 26 if config["interface"]["use_reactive_layout"] else 70
+
+
+vindings: list[BindingType] = (
+    [
+        Binding(bind, "cursor_down", "Down", show=False)
+        for bind in config["keybinds"]["down"]
+    ]
+    + [Binding(bind, "last", "Last", show=False) for bind in config["keybinds"]["end"]]
+    + [
+        Binding(bind, "select", "Select", show=False)
+        for bind in config["keybinds"]["down_tree"]
+    ]
+    + [
+        Binding(bind, "first", "First", show=False)
+        for bind in config["keybinds"]["home"]
+    ]
+    + [
+        Binding(bind, "page_down", "Page Down", show=False)
+        for bind in config["keybinds"]["page_down"]
+    ]
+    + [
+        Binding(bind, "page_up", "Page Up", show=False)
+        for bind in config["keybinds"]["page_up"]
+    ]
+    + [
+        Binding(bind, "cursor_up", "Up", show=False)
+        for bind in config["keybinds"]["up"]
+    ]
+)


### PR DESCRIPTION
resolves #86


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Centralized keyboard shortcut definitions into a single, shared source used across lists, sidebars, clipboard, and keybinds view for consistent behavior and easier maintenance.
- Performance
  - Slight startup/runtime improvement by using precomputed shortcut definitions instead of constructing them dynamically.
- Reliability
  - Reduced risk of mismatched or missing shortcuts across screens through unified, preconfigured bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->