### PR TITLE
fix(icons): folder icons no longer look similar to files

### DIFF
--- a/src/rovr/functions/icons.py
+++ b/src/rovr/functions/icons.py
@@ -95,9 +95,19 @@ def get_icon_for_folder(location: str) -> list:
                 is_match = True
 
             if is_match:
-                # Custom icons always preserve their configured colors
-                # since users explicitly chose them
-                return [custom_icon["icon"], custom_icon["color"]]
+                # For custom icons, we can't reliably determine if they have folder-like silhouettes
+                # since they're user-defined. We'll use a simple heuristic: if the folder name
+                # corresponds to a built-in folder type that has a folder silhouette, preserve the custom color.
+                # Otherwise, use the default folder color for better distinction.
+                if folder_name in FOLDER_MAP:
+                    icon_key = FOLDER_MAP[folder_name]
+                    if icon_key in FOLDER_ICONS_WITH_FOLDER_SILHOUETTE:
+                        # Keep original custom color
+                        return [custom_icon["icon"], custom_icon["color"]]
+
+                # Use default folder color for better distinction
+                default_color = ICONS["folder"]["default"][1]
+                return [custom_icon["icon"], default_color]
 
     # Check for special folder types
     if folder_name in FOLDER_MAP:
@@ -128,9 +138,9 @@ def get_icon(outer_key: str, inner_key: str) -> list:
         list[str,str]: The icon and color for the icon
     """
     if not config["interface"]["nerd_font"]:
-        return ASCII_ICONS.get(outer_key, {"empty": None}).get(inner_key, " ")
+        return ASCII_ICONS.get(outer_key, {}).get(inner_key, [" ", "white"])
     else:
-        return ICONS[outer_key][inner_key]
+        return ICONS.get(outer_key, {}).get(inner_key, [" ", "white"])
 
 
 @lru_cache(maxsize=128)

--- a/src/rovr/variables/maps.py
+++ b/src/rovr/variables/maps.py
@@ -16,7 +16,7 @@ VAR_TO_DIR = {
 }
 
 # Folder icons that contain folder-like silhouettes
-# These will keep their themed colors when folder color preservation is applied
+# These will keep their themed colors while others use the default folder color
 FOLDER_ICONS_WITH_FOLDER_SILHOUETTE = {
     "default",
     "open",


### PR DESCRIPTION
because both use equally colorful icons, making it hard to distinguish between them at a glance

In code changes i have added a configurable feature that preserves the default folder color for folder icons that dont contain actual folder silhouettes in there design

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Smarter folder icon coloring: preserves themed or custom colors for recognized folder-like silhouettes, while defaulting to the standard folder color for other icons to improve visual consistency.
- **Bug Fixes**
  - Safer icon fallbacks: improved default icon and color used when icon lookups fail (covers both nerd-font enabled and disabled cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->