### PR TITLE
feat: add --cwd-file and --chooser-file options to write working directory and selected files on exit

### DIFF
--- a/src/rovr/__main__.py
+++ b/src/rovr/__main__.py
@@ -39,12 +39,30 @@ try:
         is_flag=True,
         help="Show the current version of rovr.",
     )
+    @click.option(
+        "--cwd-file",
+        "cwd_file",
+        multiple=False,
+        type=str,
+        default="",
+        help="Write the final working directory to this file on exit.",
+    )
+    @click.option(
+        "--chooser-file",
+        "chooser_file",
+        multiple=False,
+        type=str,
+        default="",
+        help="Write chosen file(s) (newline-separated) to this file on exit.",
+    )
     @click.argument("path", type=str, required=False, default="")
     def main(
         with_features: list[str],
         without_features: list[str],
         config_path: bool,
         show_version: bool,
+        cwd_file: str,
+        chooser_file: str,
         path: str,
     ) -> None:
         """A post-modern terminal file explorer"""
@@ -69,7 +87,12 @@ try:
         # TODO: Need to move this 'path' in the config dict, or a new runtime_config dict
         # Eventually there will be many options coming via arguments, but we cant keep sending all of
         # them via this Application's __init__ function here
-        Application(watch_css=True, startup_path=path).run()
+        Application(
+            watch_css=True,
+            startup_path=path,
+            cwd_file=cwd_file if cwd_file else None,
+            chooser_file=chooser_file if chooser_file else None,
+        ).run()
 
 except KeyboardInterrupt:
     pass

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -318,15 +318,19 @@ class FileList(SelectionList, inherit_bindings=False):
             self.app.tabWidget.active_tab.selectedItems = []
             self.app.query_one("#file_list").focus()
         elif not self.select_mode_enabled:
-            # Check if it's a folder or a file
-            if path.isdir(path.join(cwd, file_name)):
-                # If it's a folder, navigate into it
-                self.app.cd(path.join(cwd, file_name))
+            # check if chooser file is enabled
+            if self.app._chooser_file:
+                self.app.action_quit()
             else:
-                path_utils.open_file(path.join(cwd, file_name))
-            if self.highlighted is None:
-                self.highlighted = 0
-            self.app.tabWidget.active_tab.selectedItems = []
+                # Check if it's a folder or a file
+                if path.isdir(path.join(cwd, file_name)):
+                    # If it's a folder, navigate into it
+                    self.app.cd(path.join(cwd, file_name))
+                else:
+                    path_utils.open_file(path.join(cwd, file_name))
+                if self.highlighted is None:
+                    self.highlighted = 0
+                self.app.tabWidget.active_tab.selectedItems = []
         else:
             self.app.tabWidget.active_tab.session.selectedItems = self.selected.copy()
 

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -318,19 +318,17 @@ class FileList(SelectionList, inherit_bindings=False):
             self.app.tabWidget.active_tab.selectedItems = []
             self.app.query_one("#file_list").focus()
         elif not self.select_mode_enabled:
-            # check if chooser file is enabled
-            if self.app._chooser_file:
-                self.app.action_quit()
+            full_path = path.join(cwd, file_name)
+            if path.isdir(full_path):
+                self.app.cd(full_path)
             else:
-                # Check if it's a folder or a file
-                if path.isdir(path.join(cwd, file_name)):
-                    # If it's a folder, navigate into it
-                    self.app.cd(path.join(cwd, file_name))
+                if self.app._chooser_file:
+                    self.app.action_quit()
                 else:
-                    path_utils.open_file(path.join(cwd, file_name))
-                if self.highlighted is None:
-                    self.highlighted = 0
-                self.app.tabWidget.active_tab.selectedItems = []
+                    path_utils.open_file(full_path)
+            if self.highlighted is None:
+                self.highlighted = 0
+            self.app.tabWidget.active_tab.selectedItems = []
         else:
             self.app.tabWidget.active_tab.session.selectedItems = self.selected.copy()
 


### PR DESCRIPTION
This adds Yazi-style --cwd-file and --chooser-file CLI options. On quit, rovr can now write the final working directory and selected file(s) to specified files. These options take priority over cd_on_quit, ensuring backward compatibility. Implementation updates CLI parsing and quit logic, enabling seamless external script integration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two CLI options: --cwd-file (write final working directory on exit) and --chooser-file (write chosen file(s), newline-separated, on exit).
  * When --chooser-file is set, selecting a file exits and produces chooser output.
  * Selecting a directory navigates into it; selecting a file opens it when chooser not set.
  * On quit, these files are written if provided; write failures are safely ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->