### PR TITLE
FEAT: compact_mode

### DIFF
--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -79,17 +79,6 @@ class Application(App, inherit_bindings=False):
     # higher index = higher priority
     CSS_PATH = ["style.tcss", path.join(VAR_TO_DIR["CONFIG"], "style.tcss")]
 
-    if config["interface"]["compact_mode"]:
-        CSS = """
-            #menu { display: none; }
-            #below_menu { border: none; }
-            $pinned_sidebar_width: 16;
-            $file_list_width: 1fr;
-            $preview_sidebar_width: 25vw;
-            $footer_unfocus_height: 7;
-            $footer_focus_height: 7;
-        """
-
     # reactivity
     HORIZONTAL_BREAKPOINTS = (
         [(0, "-filelistonly"), (35, "-nopreview"), (70, "-all-horizontal")]
@@ -174,6 +163,12 @@ class Application(App, inherit_bindings=False):
             yield FileListRightClickOptionList(filelist, classes="hidden")
 
     def on_mount(self) -> None:
+        # compact mode
+        if config["interface"]["compact_mode"]:
+            self.add_class('compact')
+        else:
+            self.remove_class('compact')
+
         # border titles
         self.query_one("#menu").border_title = "Options"
         self.query_one("#menu").can_focus = False

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -78,6 +78,18 @@ class Application(App, inherit_bindings=False):
     ]
     # higher index = higher priority
     CSS_PATH = ["style.tcss", path.join(VAR_TO_DIR["CONFIG"], "style.tcss")]
+
+    if config['interface']['compact_mode']:
+        CSS = '''
+            #menu { display: none; }
+            #below_menu { border: none; }
+            $pinned_sidebar_width: 16;
+            $file_list_width: 1fr;
+            $preview_sidebar_width: 25vw;
+            $footer_unfocus_height: 7;
+            $footer_focus_height: 7;
+        '''
+
     # reactivity
     HORIZONTAL_BREAKPOINTS = (
         [(0, "-filelistonly"), (35, "-nopreview"), (70, "-all-horizontal")]

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -165,9 +165,9 @@ class Application(App, inherit_bindings=False):
     def on_mount(self) -> None:
         # compact mode
         if config["interface"]["compact_mode"]:
-            self.add_class('compact')
+            self.add_class("compact")
         else:
-            self.remove_class('compact')
+            self.remove_class("compact")
 
         # border titles
         self.query_one("#menu").border_title = "Options"

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -79,8 +79,8 @@ class Application(App, inherit_bindings=False):
     # higher index = higher priority
     CSS_PATH = ["style.tcss", path.join(VAR_TO_DIR["CONFIG"], "style.tcss")]
 
-    if config['interface']['compact_mode']:
-        CSS = '''
+    if config["interface"]["compact_mode"]:
+        CSS = """
             #menu { display: none; }
             #below_menu { border: none; }
             $pinned_sidebar_width: 16;
@@ -88,7 +88,7 @@ class Application(App, inherit_bindings=False):
             $preview_sidebar_width: 25vw;
             $footer_unfocus_height: 7;
             $footer_focus_height: 7;
-        '''
+        """
 
     # reactivity
     HORIZONTAL_BREAKPOINTS = (

--- a/src/rovr/config/config.toml
+++ b/src/rovr/config/config.toml
@@ -14,6 +14,8 @@ preview_error = "Hmm, I think this file got corrupted (or maybe not?)"
 preview_binary = "This file is not UTF-8 encoded, so I decline to read it."
 preview_start = "print(\"Hello, world!\")"
 
+compact_mode = false
+
 [interface.clock]
 enabled = true
 align = "left"

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -56,7 +56,7 @@
         "compact_mode": {
           "type": "boolean",
           "default": false,
-          "description": "Enable compact mode."
+          "description": "Enable compact mode to hide the menu bar and adjust layout for a more streamlined interface."
         },
         "clock": {
           "type": "object",

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -53,6 +53,11 @@
           "default": "print(\"Hello, world!\")",
           "description": "This is shown when the rovr starts up. You may see it for a split second, but it will never appear afterwards."
         },
+        "compact_mode": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable compact mode."
+        },
         "clock": {
           "type": "object",
           "additionalProperties": false,

--- a/src/rovr/style.tcss
+++ b/src/rovr/style.tcss
@@ -30,6 +30,20 @@ $scrollbar-corner-color: $primary-muted;
   }
 }
 
+/* Compact mode */
+.compact {
+  #menu { display: none; }
+  #below_menu { border: none; }
+  #pinned_sidebar_container { width: 16; }
+  #preview_sidebar { width: 25vw; }
+  #footer {
+    height: 7;
+    &:focus-within {
+      height: 7;
+    }
+  }
+}
+
 /* border styling for main widgets */
 #menu,
 #below_menu,


### PR DESCRIPTION
 - Added `compact_mode` field in config
 - Added `compact_mode` in config schema
 - Added check for `comapact_mode` in `app.py`:
```python
if config["interface"]["compact_mode"]:
        CSS = """
            #menu { display: none; }
            #below_menu { border: none; }
            $pinned_sidebar_width: 16;
            $file_list_width: 1fr;
            $preview_sidebar_width: 25vw;
            $footer_unfocus_height: 7;
            $footer_focus_height: 7;
        """
```

**fixes #105**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Compact Mode: a denser layout that hides the main menu, trims chrome, adjusts sidebar widths and footer height to maximize content space; applied at app startup when enabled.

* **Configuration**
  * Added compact_mode setting (default: disabled) to toggle Compact Mode.
  * Configuration schema updated to validate the new setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->