### PR TITLE
fix: batch delete in select mode Fixes #102

### DIFF
--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -535,10 +535,8 @@ class FileList(SelectionList, inherit_bindings=False):
             ]
         else:
             return [
-                str(
-                    path_utils.normalise(path.join(cwd, path_utils.decompress(option)))
-                    for option in self.selected
-                )
+                str(path_utils.normalise(path.join(cwd, path_utils.decompress(option))))
+                for option in self.selected
             ]
 
     async def on_key(self, event: events.Key) -> None:


### PR DESCRIPTION
Summary :
This PR fixes a bug where batch deleting files in select mode did not work and showed the message "Successfully deleted nothing!"
Now, when multiple files are selected in select mode, they are deleted as expected.

Details
Root Cause:
The get_selected_objects method in FileList was returning a list containing a generator object instead of a list of file paths when in select mode.
Fix:
Updated get_selected_objects to return a proper list of file paths for batch operations.

Steps to Reproduce (Before Fix)
Enable select mode.
Select multiple files.
Attempt to delete them.
Observe that nothing is deleted and the message "Successfully deleted nothing!" appears.

Steps to Test (After Fix)
Enable select mode.
Select multiple files.
Delete them using the delete button.
The selected files should be deleted as expected.

Related Issue
Closes https://github.com/NSPC911/rovr/issues/102

Checklist
[x] Bug fixed for batch delete in select mode
[x] Single file delete still works
[x] Code is linted and tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted internal selection handling for improved readability and consistency.
  * No changes to functionality, performance, or user interface.

* **Refactor**
  * Simplified internal list construction in the multi-select path to be more concise.
  * Maintains existing behavior and compatibility; no impact on user workflows or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->