### PR TITLE
fix: prevent freeze when opening a file + capture output to prevent tui overwrites

### DIFF
--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -325,7 +325,7 @@ class FileList(SelectionList, inherit_bindings=False):
                 if self.app._chooser_file:
                     self.app.action_quit()
                 else:
-                    path_utils.open_file(full_path)
+                    path_utils.open_file(self.app, full_path)
             if self.highlighted is None:
                 self.highlighted = 0
             self.app.tabWidget.active_tab.selectedItems = []

--- a/src/rovr/functions/path.py
+++ b/src/rovr/functions/path.py
@@ -81,6 +81,7 @@ async def open_file(app: App, filepath: str) -> None:
     """Cross-platform function to open files with their default application.
 
     Args:
+        app (App): The Textuall application instance
         filepath (str): Path to the file to open
     """
     system = os_type.lower()
@@ -93,9 +94,11 @@ async def open_file(app: App, filepath: str) -> None:
                 process = await asyncio.create_subprocess_exec("open", filepath, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
             case _:  # Linux and other Unix-like
                 process = await asyncio.create_subprocess_exec("xdg-open", filepath, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
-        stdout, stderr = await process.communicate()
+        _, stderr = await process.communicate()
         if stderr:
             app.notify(str(stderr.decode().strip()), title="Open File", severity="error")
+        elif process.returncode and process.returncode != 0:
+            app.notify(f"Process exited with return code {process.returncode}", title="Open File", severity="error")
     except Exception as e:
         app.notify(str(e), title="Open File", severity="error")
 

--- a/src/rovr/functions/path.py
+++ b/src/rovr/functions/path.py
@@ -1,12 +1,14 @@
+import asyncio
 import ctypes
 import os
 import stat
-import subprocess
 from os import path
 
 import psutil
 from lzstring import LZString
 from rich.console import Console
+from textual import work
+from textual.app import App
 
 from rovr.functions.icons import get_icon_for_file, get_icon_for_folder
 from rovr.variables.constants import os_type
@@ -74,7 +76,8 @@ def decompress(text: str) -> str:
     return lzstring.decompressFromEncodedURIComponent(text)
 
 
-def open_file(filepath: str) -> None:
+@work
+async def open_file(app: App, filepath: str) -> None:
     """Cross-platform function to open files with their default application.
 
     Args:
@@ -85,13 +88,16 @@ def open_file(filepath: str) -> None:
     try:
         match system:
             case "windows":
-                os.startfile(filepath)
+                process = await asyncio.create_subprocess_exec("cmd", "/c", "start", filepath, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
             case "darwin":  # macOS
-                subprocess.run(["open", filepath], check=True)
+                process = await asyncio.create_subprocess_exec("open", filepath, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
             case _:  # Linux and other Unix-like
-                subprocess.run(["xdg-open", filepath], check=True)
+                process = await asyncio.create_subprocess_exec("xdg-open", filepath, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+        stdout, stderr = await process.communicate()
+        if stderr:
+            app.notify(str(stderr.decode().strip()), title="Open File", severity="error")
     except Exception as e:
-        print(f"Error opening file: {e}")
+        app.notify(str(e), title="Open File", severity="error")
 
 
 def get_filtered_dir_names(cwd: str | bytes, show_hidden: bool = False) -> set[str]:

--- a/src/rovr/functions/path.py
+++ b/src/rovr/functions/path.py
@@ -88,7 +88,7 @@ async def open_file(app: App, filepath: str) -> None:
     try:
         match system:
             case "windows":
-                process = await asyncio.create_subprocess_exec("cmd", "/c", "start", filepath, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+                process = await asyncio.create_subprocess_exec("cmd", "/c", "start", "", filepath, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
             case "darwin":  # macOS
                 process = await asyncio.create_subprocess_exec("open", filepath, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
             case _:  # Linux and other Unix-like


### PR DESCRIPTION
switch to asyncio + worker so that it doesnt freeze until you close the app

also use `cmd /c start` so that it doesnt just like spam the output


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - File opening now runs in the background to keep the UI responsive.
  - File open actions are integrated with the application context so notifications and UI state reflect progress and errors.
  - Improved cross-platform launching for Windows, macOS, and Linux.

- **Bug Fixes**
  - Reduced freezes when opening files.
  - Console-only errors replaced with clear, in-app error notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->