### PR TITLE
REFACTOR: Automate keybind descriptions using schema #84

### DIFF
--- a/src/rovr/classes/textual_options.py
+++ b/src/rovr/classes/textual_options.py
@@ -42,8 +42,8 @@ class FileListSelectionWidget(Selection):
         cache_key = (icon[0], icon[1])
         if cache_key not in FileListSelectionWidget._icon_content_cache:
             # Parse the icon markup once and cache it as Content
-            FileListSelectionWidget._icon_content_cache[cache_key] = Content.from_markup(
-                f" [{icon[1]}]{icon[0]}[/{icon[1]}] "
+            FileListSelectionWidget._icon_content_cache[cache_key] = (
+                Content.from_markup(f" [{icon[1]}]{icon[0]}[/{icon[1]}] ")
             )
 
         # Create prompt by combining cached icon content with label

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -365,343 +365,392 @@
           "items": {
             "type": "string"
           },
-          "description": "Toggle the current folder in the Pinned Folder Sidebar."
+          "description": "Toggle the current folder in the Pinned Folder Sidebar.",
+          "display_name": "Pin folder"
         },
         "toggle_pinned_sidebar": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Toggle viewing the pinned sidebar."
+          "description": "Toggle viewing the pinned sidebar.",
+          "display_name": "Toggle sidebar"
         },
         "toggle_preview_sidebar": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Toggle viewing the preview sidebar."
+          "description": "Toggle viewing the preview sidebar.",
+          "display_name": "Toggle preview"
         },
         "toggle_footer": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Toggle viewing the footer."
+          "description": "Toggle viewing the footer.",
+          "display_name": "Toggle footer"
         },
         "focus_toggle_pinned_sidebar": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Toggle focus between pinned folder sidebar and file list."
+          "description": "Toggle focus between pinned folder sidebar and file list.",
+          "display_name": "Focus sidebar"
         },
         "focus_file_list": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Focus the file list."
+          "description": "Focus the file list.",
+          "display_name": "Focus file list"
         },
         "focus_toggle_preview_sidebar": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Focus toggle between preview sidebar and file list."
+          "description": "Focus toggle between preview sidebar and file list.",
+          "display_name": "Focus preview"
         },
         "focus_toggle_path_switcher": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Focus toggle between path switcher and file list."
+          "description": "Focus toggle between path switcher and file list.",
+          "display_name": "Focus path"
         },
         "focus_toggle_processes": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Focus toggle the processes container."
+          "description": "Focus toggle the processes container.",
+          "display_name": "Focus processes"
         },
         "focus_toggle_clipboard": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Focus toggle the clipboard container."
+          "description": "Focus toggle the clipboard container.",
+          "display_name": "Focus clipboard"
         },
         "focus_toggle_metadata": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Focus toggle the metadata container."
+          "description": "Focus toggle the metadata container.",
+          "display_name": "Focus metadata"
         },
         "focus_search": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Focus the search bar."
+          "description": "Focus the search bar.",
+          "display_name": "Search"
         },
         "copy": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Copy the selected files in the file list to the clipboard."
+          "description": "Copy the selected files in the file list to the clipboard.",
+          "display_name": "Copy"
         },
         "paste": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Paste the selected files in the clipboard into the current directory."
+          "description": "Paste the selected files in the clipboard into the current directory.",
+          "display_name": "Paste"
         },
         "cut": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Cut the selected files in the file list to the clipboard."
+          "description": "Cut the selected files in the file list to the clipboard.",
+          "display_name": "Cut"
         },
         "delete": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Delete the selected files in the file list."
+          "description": "Delete the selected files in the file list.",
+          "display_name": "Delete"
         },
         "rename": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Rename the selected file in the file list to something else."
+          "description": "Rename the selected file in the file list to something else.",
+          "display_name": "Rename"
         },
         "new": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Create a new item in the current directory."
+          "description": "Create a new item in the current directory.",
+          "display_name": "New"
         },
         "toggle_all": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Enter into select mode and select/unselect everything."
+          "description": "Enter into select mode and select/unselect everything.",
+          "display_name": "Select all"
         },
         "zip": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Create a zip archive from selected files."
+          "description": "Create a zip archive from selected files.",
+          "display_name": "Zip"
         },
         "unzip": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Extract a selected zip archive."
+          "description": "Extract a selected zip archive.",
+          "display_name": "Unzip"
         },
         "copy_path": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Copy the path of the item to the system clipboard."
+          "description": "Copy the path of the item to the system clipboard.",
+          "display_name": "Copy path"
         },
         "up": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Go up the file list options."
+          "description": "Go up the file list options.",
+          "display_name": "Up"
         },
         "down": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Go down the file list options."
+          "description": "Go down the file list options.",
+          "display_name": "Down"
         },
         "up_tree": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Go up the file tree."
+          "description": "Go up the file tree.",
+          "display_name": "Go up directory"
         },
         "down_tree": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Go down the file tree, or open the currently selected item."
+          "description": "Go down the file tree, or open the currently selected item.",
+          "display_name": "Enter/Select"
         },
         "page_up": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Page Up in the file list options."
+          "description": "Page Up in the file list options.",
+          "display_name": "Page Up"
         },
         "page_down": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Page Down in the file list options."
+          "description": "Page Down in the file list options.",
+          "display_name": "Page Down"
         },
         "home": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Go to the first option in the file list options."
+          "description": "Go to the first option in the file list options.",
+          "display_name": "First"
         },
         "end": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Go to the last option in the file list options."
+          "description": "Go to the last option in the file list options.",
+          "display_name": "Last"
         },
         "hist_previous": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Go back in history."
+          "description": "Go back in history.",
+          "display_name": "History back"
         },
         "hist_next": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Go forward in history."
+          "description": "Go forward in history.",
+          "display_name": "History forward"
         },
         "toggle_visual": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Enter or exit select/visual mode."
+          "description": "Enter or exit select/visual mode.",
+          "display_name": "Visual mode"
         },
         "toggle_hidden_files": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Toggle the visibility of hidden files (dot-prefixed on Unix, or flagged hidden on Windows/macOS)."
+          "description": "Toggle the visibility of hidden files (dot-prefixed on Unix, or flagged hidden on Windows/macOS).",
+          "display_name": "Toggle hidden files"
         },
         "select_up": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "While in visual mode, extend the selection up."
+          "description": "While in visual mode, extend the selection up.",
+          "display_name": "Select up"
         },
         "select_down": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "While in visual mode, extend the selection down."
+          "description": "While in visual mode, extend the selection down.",
+          "display_name": "Select down"
         },
         "select_page_up": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "While in visual mode, extend the selection to the previous page."
+          "description": "While in visual mode, extend the selection to the previous page.",
+          "display_name": "Select page up"
         },
         "select_page_down": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "While in visual mode, extend the selection to the next page."
+          "description": "While in visual mode, extend the selection to the next page.",
+          "display_name": "Select page down"
         },
         "select_home": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "While in visual mode, extend the selection to the first option."
+          "description": "While in visual mode, extend the selection to the first option.",
+          "display_name": "Select to top"
         },
         "select_end": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "While in visual mode, extend the selection to the last option."
+          "description": "While in visual mode, extend the selection to the last option.",
+          "display_name": "Select to end"
         },
         "tab_next": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Go to the next tab, if it is available."
+          "description": "Go to the next tab, if it is available.",
+          "display_name": "Next tab"
         },
         "tab_previous": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Go to the previous tab, if it is available."
+          "description": "Go to the previous tab, if it is available.",
+          "display_name": "Previous tab"
         },
         "tab_new": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Create a new tab."
+          "description": "Create a new tab.",
+          "display_name": "New tab"
         },
         "tab_close": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Close the current tab."
+          "description": "Close the current tab.",
+          "display_name": "Close tab"
         },
         "preview_scroll_left": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "While using `settings.preview_full = true`, and the preview container is focused, scroll left when this keybind is pressed."
+          "description": "While using `settings.preview_full = true`, and the preview container is focused, scroll left when this keybind is pressed.",
+          "display_name": "Scroll left"
         },
         "preview_scroll_right": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "While using `settings.preview_full = true`, and the preview container is focused, scroll right when this keybind is pressed."
+          "description": "While using `settings.preview_full = true`, and the preview container is focused, scroll right when this keybind is pressed.",
+          "display_name": "Scroll right"
         },
         "preview_select_right": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "While using TextArea for previewing, use this keybind to extend selection to the right."
+          "description": "While using TextArea for previewing, use this keybind to extend selection to the right.",
+          "display_name": "Select right"
         },
         "preview_select_left": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "While using TextArea for previewing, use this keybind to extend selection to the left."
+          "description": "While using TextArea for previewing, use this keybind to extend selection to the left.",
+          "display_name": "Select left"
         },
         "show_keybinds": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Show the keybinds list with all available keybinds."
+          "description": "Show the keybinds list with all available keybinds.",
+          "display_name": "Show keybinds"
         }
       }
     },
@@ -724,7 +773,8 @@
               "items": {
                 "type": "string"
               },
-              "description": "The keybind to open the zoxide modal."
+              "description": "The keybind to open the zoxide modal.",
+              "display_name": "Launch zoxide selector"
             },
             "show_scores": {
               "type": "boolean",
@@ -774,7 +824,8 @@
               "items": {
                 "type": "string"
               },
-              "description": "The keybind to launch your editor."
+              "description": "The keybind to launch your editor.",
+              "display_name": "Open file with editor"
             }
           }
         }

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -682,9 +682,7 @@ class FileList(SelectionList, inherit_bindings=False):
                     if path.isdir(
                         path.join(
                             getcwd(),
-                            path_utils.decompress(
-                                self.highlighted_option.value
-                            ),
+                            path_utils.decompress(self.highlighted_option.value),
                         )
                     ):
                         with self.app.suspend():

--- a/src/rovr/functions/config.py
+++ b/src/rovr/functions/config.py
@@ -16,7 +16,7 @@ lzstring = LZString()
 pprint = Console().print
 
 
-def load_config() -> dict:
+def load_config() -> tuple[dict, dict]:
     """
     Load both the template config and the user config
 
@@ -100,7 +100,7 @@ def load_config() -> dict:
     # image protocol because "AutoImage" doesn't work with Sixel
     if config["settings"]["image_protocol"] == "Auto":
         config["settings"]["image_protocol"] = ""
-    return config
+    return schema, config
 
 
 def config_setup() -> None:

--- a/src/rovr/screens/keybinds.py
+++ b/src/rovr/screens/keybinds.py
@@ -10,7 +10,7 @@ from textual.widgets import OptionList
 from rovr.classes.textual_options import KeybindOption
 from rovr.functions import icons
 from rovr.search_container import SearchInput
-from rovr.variables.constants import config, vindings
+from rovr.variables.constants import config, schema, vindings
 
 
 class KeybindList(OptionList, inherit_bindings=False):
@@ -29,97 +29,34 @@ class KeybindList(OptionList, inherit_bindings=False):
         super().__init__(*self.list_of_options, **kwargs)
 
     def get_keybind_data(self) -> tuple[list[tuple[str, str]], list[str]]:
-        # Hardcoded descriptions based on BINDINGS from various files
-        keybind_descriptions = {
-            # Navigation - from core/file_list.py, core/pinned_sidebar.py
-            "up": "Up",
-            "down": "Down",
-            "home": "First",
-            "end": "Last",
-            "page_up": "Page Up",
-            "page_down": "Page Down",
-            "up_tree": "Go up directory",
-            "down_tree": "Enter/Select",
-            "hist_previous": "History back",
-            "hist_next": "History forward",
-            # File operations - from core/preview_container.py
-            "copy": "Copy",
-            "cut": "Cut",
-            "paste": "Paste",
-            "delete": "Delete",
-            "rename": "Rename",
-            "new": "New",
-            "zip": "Zip",
-            "unzip": "Unzip",
-            "copy_path": "Copy path",
-            # Interface - app-level keybinds
-            "focus_file_list": "Focus file list",
-            "focus_toggle_pinned_sidebar": "Focus sidebar",
-            "focus_toggle_preview_sidebar": "Focus preview",
-            "focus_toggle_path_switcher": "Focus path",
-            "focus_search": "Search",
-            "focus_toggle_processes": "Focus processes",
-            "focus_toggle_clipboard": "Focus clipboard",
-            "focus_toggle_metadata": "Focus metadata",
-            "toggle_pinned_sidebar": "Toggle sidebar",
-            "toggle_preview_sidebar": "Toggle preview",
-            "toggle_footer": "Toggle footer",
-            "toggle_pin": "Pin folder",
-            "show_keybinds": "Show keybinds",
-            # FileList - from core/file_list.py
-            "toggle_visual": "Visual mode",
-            "toggle_all": "Select all",
-            "select_up": "Select up",
-            "select_down": "Select down",
-            "select_page_up": "Select page up",
-            "select_page_down": "Select page down",
-            "select_home": "Select to top",
-            "select_end": "Select to end",
-            "toggle_hidden_files": "Toggle hidden files",
-            # Tabs - app-level keybinds
-            "tab_new": "New tab",
-            "tab_close": "Close tab",
-            "tab_next": "Next tab",
-            "tab_previous": "Previous tab",
-            # Preview - from core/preview_container.py
-            "preview_scroll_left": "Scroll left",
-            "preview_scroll_right": "Scroll right",
-            "preview_select_left": "Select left",
-            "preview_select_right": "Select right",
-            # Plugins
-            "zoxide": "Launch zoxide selector",
-            "editor": "Open file with editor",
-        }
-
         # Generate keybind data programmatically
         keybind_data = []
         primary_keys = []
+        keybinds_schema = schema["properties"]["keybinds"]["properties"]
         for action, keys in config["keybinds"].items():
-            if action in keybind_descriptions:
+            if action in keybinds_schema:
+                display_name = keybinds_schema[action].get("display_name", action)
                 if not keys:
                     formatted_keys = "<disabled>"
                     primary_keys.append("")
                 else:
                     formatted_keys = ", ".join(f"<{key}>" for key in keys)
                     primary_keys.append(keys[0])
-                description = keybind_descriptions[action]
-                keybind_data.append((formatted_keys, description))
+                keybind_data.append((formatted_keys, display_name))
 
         # for plugins
+        plugins_schema = schema["properties"]["plugins"]["properties"]
         for key, value in config["plugins"].items():
-            if (
-                "enabled" in value
-                and "keybinds" in value
-                and key in keybind_descriptions
-            ):
+            if "enabled" in value and "keybinds" in value and key in plugins_schema:
                 if not value["keybinds"] or not value["enabled"]:
                     formatted_keys = "<disabled>"
                     primary_keys.append("")
                 else:
                     formatted_keys = ", ".join(f"<{key}>" for key in value["keybinds"])
                     primary_keys.append(value["keybinds"][0])
-                description = keybind_descriptions[key]
-                keybind_data.append((formatted_keys, description))
+                plugins_properties = plugins_schema[key]["properties"]
+                display_name = plugins_properties["keybinds"].get("display_name", key)
+                keybind_data.append((formatted_keys, display_name))
 
         return keybind_data, primary_keys
 

--- a/src/rovr/variables/constants.py
+++ b/src/rovr/variables/constants.py
@@ -7,8 +7,8 @@ from rovr.functions.config import config_setup, load_config
 
 # Initialize the config once at import time
 if "config" not in globals():
-    global config
-    config = load_config()
+    global config, schema
+    schema, config = load_config()
     config_setup()
 
 


### PR DESCRIPTION
Summary:
Added display_name field to config/schema.json to automate keybind descriptions in the shortcuts display. Previously, get_keybind_data() used hardcoded mappings with keybind_descriptions dictionary. 

Now it fetches display_names directly from the schema via load_config(). This ensures that there is a single source of truth and keybinds appear automatically in the shortcuts list

Fixes #84 

Checklist:
- [x] I have run ruff format to format the code and ty check to ensure proper typing.
- [x] I have tested both the dev version and the built version of rovr.
- [x] Cache, logs and others are not accidentally added to git's tracking history.
- [x] My commits follow the conventional commits format.
