### PR TITLE
feat(app)!: remove cd on quit in favour of `--cwd-file`

### DIFF
--- a/docs/src/content/docs/features/cd-on-quit.mdx
+++ b/docs/src/content/docs/features/cd-on-quit.mdx
@@ -5,166 +5,120 @@ description: how to make rovr change your shell's directory on quit and export s
 
 import { Tabs, TabItem, Code, Aside } from "@astrojs/starlight/components";
 
-rovr can change the current directory to wherever you were when you quit, and export selected files to specified locations.
+rovr can change the current directory to wherever you were when you quit using the `--cwd-file` CLI option.
 
-### how it works
+### Using `--cwd-file`
 
-when `cd_on_quit` is enabled, rovr writes the path of its current directory to a file named `rovr_quit_cd_path` in your config directory before exiting.
+The `--cwd-file` option writes the current working directory to a specified file when rovr exits:
 
-a script or function in your shell config can read this file, `cd` into the saved directory, and delete the file.
+```bash
+# Create a temporary file and use it with rovr
+cwd_file=$(mktemp -t rovr_cwd.XXXXXX)
+rovr --cwd-file "$cwd_file"
+cd "$(cat "$cwd_file")"
+rm -f "$cwd_file"
+```
 
-### enabling `cd_on_quit`
+#### shell configuration
 
-set the `cd_on_quit` option to `true` in your `config.toml` file.
-
-<Code code={`[settings]\ncd_on_quit = true`} lang="toml" title="config.toml" />
-
-### shell configuration
-
-add a function to your shell config that wraps the `rovr` command.
+You can create wrapper functions in your shell config for convenience:
 
 <Tabs>
-  <TabItem label="Linux">
-    <Tabs>
-      <TabItem label="bash">
-        <Code
-          code={`rovr () {\n    command rovr "$@"\n    config_dir="\${XDG_CONFIG_HOME:-$HOME/.config}"\n    cd_path_file="$config_dir/rovr/rovr_quit_cd_path"\n    if [ -f "$cd_path_file" ]; then\n        cd "$(cat \\"$cd_path_file\\")"\n        rm -f "$cd_path_file"\n    fi\n}`}
-          lang="bash"
-          frame="code"
-          title=".bashrc / .zshrc"
-        />
-      </TabItem>
-      <TabItem label="fish">
-        <Code
-          code={`function rovr\n    command rovr $argv\n    set config_dir "$HOME/.config"\n    if set -q XDG_CONFIG_HOME\n        set config_dir "$XDG_CONFIG_HOME"\n    end\n    set cd_path_file "$config_dir/rovr/rovr_quit_cd_path"\n    if test -f "$cd_path_file"\n        cd (cat "$cd_path_file")\n        rm -f "$cd_path_file"\n    end\nend`}
-          lang="fish"
-          frame="code"
-          title="config.fish"
-        />
-      </TabItem>
-      <TabItem label="nushell">
-        <Code
-          code={`def --env --wrapped rovr [...args: string] {\n    ^rovr ...$args\n    let config_dir = ($env.XDG_CONFIG_HOME? | default ($env.HOME | path join ".config"))\n    let cd_path_file = ($config_dir | path join "rovr" "rovr_quit_cd_path")\n    if ($cd_path_file | path exists) {\n        cd ($cd_path_file | open | str trim)\n        rm $cd_path_file\n    }\n}`}
-          lang="nu"
-          frame="code"
-          title="config.nu"
-        />
-      </TabItem>
-    </Tabs>
+  <TabItem label="bash/zsh">
+    <Code
+      code={`rovr () {\n    local cwd_file=$(mktemp -t rovr_cwd.XXXXXX)\n    command rovr --cwd-file "$cwd_file" "$@"\n    if [ -f "$cwd_file" ]; then\n        cd "$(cat "$cwd_file")"\n        rm -f "$cwd_file"\n    fi\n}`}
+      lang="bash"
+      frame="code"
+      title=".bashrc / .zshrc"
+    />
   </TabItem>
-  <TabItem label="macOS">
-    <Tabs>
-      <TabItem label="bash">
-        <Code
-          code={`rovr () {\n    command rovr "$@"\n    cd_path_file="$HOME/Library/Application Support/rovr/rovr_quit_cd_path"\n    if [ -f "$cd_path_file" ]; then\n        cd "$(cat \\"$cd_path_file\\")"\n        rm -f "$cd_path_file"\n    fi\n}`}
-          lang="bash"
-          frame="code"
-          title=".bashrc / .zshrc"
-        />
-      </TabItem>
-      <TabItem label="fish">
-        <Code
-          code={`function rovr\n    command rovr $argv\n    set cd_path_file "$HOME/Library/Application Support/rovr/rovr_quit_cd_path"\n    if test -f "$cd_path_file"\n        cd (cat "$cd_path_file")\n        rm--env  -f "$cd_path_file"\n    end\nend`}
-          lang="fish"
-          frame="code"
-          title="config.fish"
-        />
-      </TabItem>
-      <TabItem label="nushell">
-        <Code
-          code={`def rovr [...args: string] {\n    ^rovr ...$args\n    let cd_path_file = ($env.HOME | path join "Library" "Application Support" "rovr" "rovr_quit_cd_path")\n    if ($cd_path_file | path exists) {\n        cd ($cd_path_file | open | str trim)\n        rm $cd_path_file\n    }\n}`}
-          lang="nu"
-          frame="code"
-          title="config.nu"
-        />
-      </TabItem>
-    </Tabs>
+  <TabItem label="fish">
+    <Code
+      code={`function rovr\n    set cwd_file (mktemp -t rovr_cwd.XXXXXX)\n    command rovr --cwd-file "$cwd_file" $argv\n    if test -f "$cwd_file"\n        cd (cat "$cwd_file")\n        rm -f "$cwd_file"\n    end\nend`}
+      lang="fish"
+      frame="code"
+      title="config.fish"
+    />
   </TabItem>
-  <TabItem label="Windows">
-    <Tabs>
-      <TabItem label="powershell">
-        <Code
-          code={`function rovr {\n    param ( [string[]]$Params )\n    & rovr.exe $Params\n    $cd_path_file = "$env:LOCALAPPDATA\\rovr\\rovr_quit_cd_path"\n    if (Test-Path $cd_path_file) {\n        Set-Location -Path (Get-Content $cd_path_file)\n        Remove-Item $cd_path_file\n    }\n}`}
-          lang="powershell"
-          frame="code"
-          title="$PROFILE"
-        />
-        Powershell may prevent you from running such functions, so you may have
-        to run
-        <Code
-          code={`Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine`}
-          lang="powershell"
-        />
-        for it to work. For more information on `Set-ExecutionPolicy`, refer to
-        its
-        [docs](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy)
-      </TabItem>
-      <TabItem label="nushell">
-        <Code
-          code={`def rovr [...args: string] {\n    ^rovr.exe ...$args\n    let cd_path_file = ($env.LOCALAPPDATA | path join "rovr" "rovr_quit_cd_path")\n    if ($cd_path_file | path exists) {\n        cd ($cd_path_file | open | str trim)\n        rm $cd_path_file\n    }\n}`}
-          lang="nu"
-          frame="code"
-          title="config.nu"
-        />
-      </TabItem>
-    </Tabs>
+  <TabItem label="nushell">
+    <Code
+      code={`def --env --wrapped rovr [...args: string] {\n    let cwd_file = (mktemp -t rovr_cwd.XXXXXX)\n    ^rovr --cwd-file $cwd_file ...$args\n    if ($cwd_file | path exists) {\n        cd ($cwd_file | open | str trim)\n        rm $cwd_file\n    }\n}`}
+      lang="nu"
+      frame="code"
+      title="config.nu"
+    />
+  </TabItem>
+  <TabItem label="powershell">
+    <Code
+      code={`function rovr {\n    $cwd_file = [System.IO.Path]::GetTempFileName()\n    & rovr.exe --cwd-file $cwd_file $args\n    if (Test-Path $cwd_file) {\n        Set-Location -Path (Get-Content $cwd_file)\n        Remove-Item $cwd_file\n    }\n}`}
+      lang="powershell"
+      frame="code"
+      title="$PROFILE"
+    />
+    Powershell may prevent you from running such functions, so you may have to
+    run
+    <Code
+      code={`Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine`}
+      lang="powershell"
+    />
+    for it to work. For more information on `Set-ExecutionPolicy`, refer to its
+    [docs](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy)
   </TabItem>
 </Tabs>
 
 <Aside type="note">
-  rovr uses platform-specific config directories: `~/.config/rovr` on Linux,
-  `~/Library/Application Support/rovr` on macOS, and `%LOCALAPPDATA%\rovr` on
-  Windows. the examples above should work for most setups, but you may need to
-  adjust paths based on your specific installation.
+  The shell functions above use temporary files for better security while avoiding conflicts.
 </Aside>
 
-## CLI options
+### Additional CLI options
 
-rovr also supports Yazi-style CLI options for direct integration with scripts and other tools:
+rovr also supports other Yazi-style CLI options for direct integration with scripts and tools:
 
-### `--cwd-file`
-
-Write the current working directory to a specified file when rovr exits:
-
-```sh
-rovr --cwd-file /tmp/rovr_cwd
-```
-
-After quitting rovr, you can read the final directory from the file:
-
-```bash
-# Example usage in bash
-rovr --cwd-file /tmp/rovr_cwd
-cd "$(cat /tmp/rovr_cwd)"
-```
-
-### `--chooser-file`
+#### `--chooser-file`
 
 Write selected files to a specified file when rovr exits:
 
-```sh
-rovr --chooser-file /tmp/rovr_selected
-```
-
-This writes the paths of any files you have selected (using visual mode or other selection methods) to the specified file, one per line.
-
 ```bash
-# Example: process selected files
-rovr --chooser-file /tmp/rovr_selected
+# Using a temporary file
+chooser_file=$(mktemp -t rovr_selected.XXXXXX)
+rovr --chooser-file "$chooser_file"
 while IFS= read -r file; do
     echo "Selected: $file"
-done < /tmp/rovr_selected
+done < "$chooser_file"
+rm -f "$chooser_file"
 ```
 
-### Combined usage
+#### Combined usage
 
 You can use both options together:
 
-```sh
-rovr --cwd-file /tmp/rovr_cwd --chooser-file /tmp/rovr_selected
+```bash
+# Using temporary files for both options
+cwd_file=$(mktemp -t rovr_cwd.XXXXXX)
+chooser_file=$(mktemp -t rovr_selected.XXXXXX)
+rovr --cwd-file "$cwd_file" --chooser-file "$chooser_file"
+
+# Process results
+cd "$(cat "$cwd_file")"
+while IFS= read -r file; do
+    echo "Selected: $file"
+done < "$chooser_file"
+
+# Clean up
+rm -f "$cwd_file" "$chooser_file"
 ```
 
-<Aside type="tip">
-  these CLI options take priority over the `cd_on_quit` configuration setting,
-  ensuring backward compatibility while providing flexible integration options.
-</Aside>
+### integrations
+as much as it might be tempting, this will not work. i use helix <sub>btw</sub> and just like superfile, it just cannot launch the app. i'm not sure why, but it might be a conflict between terminal buffer areas.
+so something like yazi's
+```toml
+[keys.normal]
+C-y = [
+  ':sh rm -f /tmp/unique-file',
+  ':insert-output rovr %{buffer_name} --chooser-file=/tmp/unique-file',
+  ':insert-output echo "\x1b[?1049h\x1b[?2004h" > /dev/tty',
+  ':open %sh{cat /tmp/unique-file}',
+  ':redraw',
+]
+```
+will not work

--- a/src/rovr/__main__.py
+++ b/src/rovr/__main__.py
@@ -119,11 +119,6 @@ try:
             table.add_row("[cyan]custom config[/]", f"{config_path}/config.toml")
             table.add_row("[yellow]pinned folders[/]", f"{config_path}/pins.json")
             table.add_row("[hot_pink]custom styles[/]", f"{config_path}/style.tcss")
-            if config["settings"]["cd_on_quit"]:
-                table.add_row(
-                    "[green]path saved on quit[/]",
-                    f"{config_path}/rovr_cd_on_quit",
-                )
             pprint(table)
             return
         elif show_version:

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -424,7 +424,7 @@ class Application(App, inherit_bindings=False):
             )
         ):
             return
-        # 1) Write cwd to explicit --cwd-file if provided
+        # Write cwd to explicit --cwd-file if provided
         message = ""
         if self._cwd_file:
             try:
@@ -434,18 +434,7 @@ class Application(App, inherit_bindings=False):
                 message += (
                     f"Failed to write cwd file `{path.basename(self._cwd_file)}`!\n"
                 )
-        # 2) Otherwise, honor legacy cd_on_quit behavior
-        elif config["settings"]["cd_on_quit"]:
-            try:
-                with open(
-                    path.join(VAR_TO_DIR["CONFIG"], "rovr_quit_cd_path"),
-                    "w",
-                    encoding="utf-8",
-                ) as file:
-                    file.write(getcwd())
-            except OSError:
-                message += "Failed to write `rovr_quit_cd_path`!\n"
-        # 3) Write selected/active item(s) to --chooser-file, if provided
+        # Write selected/active item(s) to --chooser-file, if provided
         if self._chooser_file:
             try:
                 file_list = self.query_one("#file_list")

--- a/src/rovr/config/config.toml
+++ b/src/rovr/config/config.toml
@@ -36,7 +36,6 @@ copy_includes_metadata = true
 use_recycle_bin = true
 allow_tab_nav = true
 append_new_tabs = true
-cd_on_quit = false
 double_click_delay = 0.25
 drive_watcher_frequency = 3.0
 

--- a/src/rovr/config/migration.json
+++ b/src/rovr/config/migration.json
@@ -24,5 +24,14 @@
       "- when previewing files, with or without [bright_cyan]bat[/], the height will always be enough to fill the container."
     ],
     "extra": "Removed in v0.5.0"
+  },
+  {
+    "keys": ["settings.cd_on_quit"],
+    "message": [
+      "[bright_blue]settings.cd_on_quit[/] has been removed in favour of using [bright_blue]--cwd-file[/]",
+      "Remove it from your [cyan]config.toml[/] and update your shell configuration with the functions from the [u][link=https://nspc911.github.io/rovr/features/cd-on-quit/#shell-configuration]docs[/][/]",
+      "Cannot click on the link? https://nspc911.github.io/rovr/features/cd-on-quit/#shell-configuration"
+    ],
+    "extra": "Removed in v0.5.0"
   }
 ]

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -133,11 +133,6 @@
           "default": true,
           "description": "Choose whether or not to append new tabs instead of inserting them.\n`true` => Append to the end of the tab list.\n`false` => Insert after the active tab."
         },
-        "cd_on_quit": {
-          "type": "boolean",
-          "default": false,
-          "description": "When quitting rovr, write the current directory to a file, so that you can cd into it."
-        },
         "double_click_delay": {
           "type": "number",
           "default": 0.25,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced the legacy `cd_on_quit` configuration setting with explicit `--cwd-file` and `--chooser-file` command-line options for directory restoration and selection output.

* **Documentation**
  * Updated guidance to emphasize temporary-file-based workflows with unified, cross-platform integration examples.

* **Chores**
  * Added migration notification for removed configuration setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->