### PR TITLE
feat(app): add scrolloff behaviour to filelist

### DIFF
--- a/src/rovr/config/config.toml
+++ b/src/rovr/config/config.toml
@@ -10,11 +10,14 @@ show_progress_percentage = true
 truncate_progress_file_path = false
 compact_mode = false
 show_line_numbers = true
+# yazi style is 5
+scrolloff = 5
 
 [interface.preview_text]
 error = "couldn't read this file! (\u00AC_\u00AC)" # ¬_¬
 binary = "the file doesn't use UTF-8, which isn't supported yet"
-start = """  ___ ___
+start = """
+  ___ ___
  |  _| . |
  |_| |___|
   _ _ ___

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -48,6 +48,12 @@
           "default": false,
           "description": "Add line numbers to the left gutter if you are viewing a text file."
         },
+        "scrolloff": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 5,
+          "description": "The number of files to keep above and below the cursor when moving through the file list."
+        },
         "clock": {
           "type": "object",
           "additionalProperties": false,


### PR DESCRIPTION
adds yazi like scroll-off behaviour because i can

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable "scrolloff" setting to keep a buffer of lines above/below the cursor during file-list navigation (default: 5).

* **Improvements**
  * Improved file-list scrolling to better position highlighted items within the viewport.

* **Bug Fixes**
  * Adjusted preview text formatting so ASCII-art previews begin on their own line for consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->