### PR TITLE
feat: replace clippy with ctypes-based NSPasteboard for macOS clipboard


### DIFF
--- a/src/rovr/functions/system_clipboard.py
+++ b/src/rovr/functions/system_clipboard.py
@@ -209,6 +209,8 @@ def _copy_macos_ctypes(paths: list[str]) -> None:
         msg0(pasteboard, sel("clearContents"))
 
         array = msg_i(NSMutableArray, sel("arrayWithCapacity:"), len(paths))
+        if not array:
+            raise ClipboardError("Failed to create NSMutableArray for clipboard")
         failed_paths: list[str] = []
         for path in paths:
             resolved = str(Path(path).resolve())


### PR DESCRIPTION
no longer depends on clippy yipee

@lazysegtree take that haha (also can check for me, i checked on my dad's 2019 mac and its working)

amazing oneshot done by opus 4.6, i would never do this myself

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues
- [x] i have tested both the dev version (in venv) and the built version (uv build then install) of rovr
- [x] cache, logs and others were not accidentally added to git's tracking history
- [x] my commits follow the conventional commits format as much as possible
- [ ] the documentation has been updated wherever necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard reliability and error reporting across platforms when copying files; empty/no-op inputs now consistently succeed.
  * Better handling of Linux clipboard utilities, including clearer timeout and output behavior.

* **Refactor**
  * macOS clipboard pathway reworked to use a native integration for more stable pasteboard writes and clearer failure handling; no public API changes.
* **Other**
  * Windows behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->