### PR TITLE
Fix: context menu no longer cause a crash in empty directories

### DIFF
--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -983,7 +983,8 @@ class FileListRightClickOptionList(PopupOptionList):
             Option(
                 f" {icon_utils.get_icon('general', 'open')[0]} Unzip",
                 id="unzip",
-                disabled=not utils.is_archive(
+                disabled=not self.app.file_list.highlighted_option.value
+                or not utils.is_archive(
                     self.app.file_list.highlighted_option.dir_entry.path
                 ),
             ),


### PR DESCRIPTION
Should fix #244 

<!--also include videos, screenshots or gifs if applicable if it is a new feature-->

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible
- [x] the documentation has been updated wherever necessary (run `poe gen-schema` and `poe gen-keys` if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Unzip option in the right-click context menu to properly disable when no file is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->