### PR TITLE
feat: add show_drives option to remove drives from sidebar

### DIFF
--- a/docs/src/content/docs/dev/reference/schema.mdx
+++ b/docs/src/content/docs/dev/reference/schema.mdx
@@ -13,31 +13,32 @@ description: config schema humanified
   - [1.7. Property `Rovr Config > interface > show_line_numbers`](#interface_show_line_numbers)
   - [1.8. Property `Rovr Config > interface > scrolloff`](#interface_scrolloff)
   - [1.9. Property `Rovr Config > interface > show_hidden_files`](#interface_show_hidden_files)
-  - [1.10. Property `Rovr Config > interface > image_viewer`](#interface_image_viewer)
-    - [1.10.1. Property `Rovr Config > interface > image_viewer > protocol`](#interface_image_viewer_protocol)
-    - [1.10.2. Property `Rovr Config > interface > image_viewer > max_size`](#interface_image_viewer_max_size)
-      - [1.10.2.1. Rovr Config > interface > image_viewer > max_size > max_size items](#interface_image_viewer_max_size_items)
-    - [1.10.3. Property `Rovr Config > interface > image_viewer > resampling`](#interface_image_viewer_resampling)
-  - [1.11. Property `Rovr Config > interface > font_preview`](#interface_font_preview)
-    - [1.11.1. Property `Rovr Config > interface > font_preview > max_size`](#interface_font_preview_max_size)
-      - [1.11.1.1. Rovr Config > interface > font_preview > max_size > max_size items](#interface_font_preview_max_size_items)
-    - [1.11.2. Property `Rovr Config > interface > font_preview > font_size`](#interface_font_preview_font_size)
-  - [1.12. Property `Rovr Config > interface > allow_tab_nav`](#interface_allow_tab_nav)
-  - [1.13. Property `Rovr Config > interface > append_new_tabs`](#interface_append_new_tabs)
-  - [1.14. Property `Rovr Config > interface > double_click_delay`](#interface_double_click_delay)
-  - [1.15. Property `Rovr Config > interface > drive_watcher_frequency`](#interface_drive_watcher_frequency)
-  - [1.16. Property `Rovr Config > interface > clock`](#interface_clock)
-    - [1.16.1. Property `Rovr Config > interface > clock > enabled`](#interface_clock_enabled)
-    - [1.16.2. Property `Rovr Config > interface > clock > align`](#interface_clock_align)
-  - [1.17. Property `Rovr Config > interface > preview_text`](#interface_preview_text)
-    - [1.17.1. Property `Rovr Config > interface > preview_text > error`](#interface_preview_text_error)
-    - [1.17.2. Property `Rovr Config > interface > preview_text > start`](#interface_preview_text_start)
-    - [1.17.3. Property `Rovr Config > interface > preview_text > font_text`](#interface_preview_text_font_text)
-  - [1.18. Property `Rovr Config > interface > compact_mode`](#interface_compact_mode)
-    - [1.18.1. Property `Rovr Config > interface > compact_mode > buttons`](#interface_compact_mode_buttons)
-    - [1.18.2. Property `Rovr Config > interface > compact_mode > panels`](#interface_compact_mode_panels)
-  - [1.19. Property `Rovr Config > interface > mime_rules`](#interface_mime_rules)
-    - [1.19.1. Property `Rovr Config > interface > mime_rules > additionalProperties`](#interface_mime_rules_additionalProperties)
+  - [1.10. Property `Rovr Config > interface > show_drives`](#interface_show_drives)
+  - [1.11. Property `Rovr Config > interface > image_viewer`](#interface_image_viewer)
+    - [1.11.1. Property `Rovr Config > interface > image_viewer > protocol`](#interface_image_viewer_protocol)
+    - [1.11.2. Property `Rovr Config > interface > image_viewer > max_size`](#interface_image_viewer_max_size)
+      - [1.11.2.1. Rovr Config > interface > image_viewer > max_size > max_size items](#interface_image_viewer_max_size_items)
+    - [1.11.3. Property `Rovr Config > interface > image_viewer > resampling`](#interface_image_viewer_resampling)
+  - [1.12. Property `Rovr Config > interface > font_preview`](#interface_font_preview)
+    - [1.12.1. Property `Rovr Config > interface > font_preview > max_size`](#interface_font_preview_max_size)
+      - [1.12.1.1. Rovr Config > interface > font_preview > max_size > max_size items](#interface_font_preview_max_size_items)
+    - [1.12.2. Property `Rovr Config > interface > font_preview > font_size`](#interface_font_preview_font_size)
+  - [1.13. Property `Rovr Config > interface > allow_tab_nav`](#interface_allow_tab_nav)
+  - [1.14. Property `Rovr Config > interface > append_new_tabs`](#interface_append_new_tabs)
+  - [1.15. Property `Rovr Config > interface > double_click_delay`](#interface_double_click_delay)
+  - [1.16. Property `Rovr Config > interface > drive_watcher_frequency`](#interface_drive_watcher_frequency)
+  - [1.17. Property `Rovr Config > interface > clock`](#interface_clock)
+    - [1.17.1. Property `Rovr Config > interface > clock > enabled`](#interface_clock_enabled)
+    - [1.17.2. Property `Rovr Config > interface > clock > align`](#interface_clock_align)
+  - [1.18. Property `Rovr Config > interface > preview_text`](#interface_preview_text)
+    - [1.18.1. Property `Rovr Config > interface > preview_text > error`](#interface_preview_text_error)
+    - [1.18.2. Property `Rovr Config > interface > preview_text > start`](#interface_preview_text_start)
+    - [1.18.3. Property `Rovr Config > interface > preview_text > font_text`](#interface_preview_text_font_text)
+  - [1.19. Property `Rovr Config > interface > compact_mode`](#interface_compact_mode)
+    - [1.19.1. Property `Rovr Config > interface > compact_mode > buttons`](#interface_compact_mode_buttons)
+    - [1.19.2. Property `Rovr Config > interface > compact_mode > panels`](#interface_compact_mode_panels)
+  - [1.20. Property `Rovr Config > interface > mime_rules`](#interface_mime_rules)
+    - [1.20.1. Property `Rovr Config > interface > mime_rules > additionalProperties`](#interface_mime_rules_additionalProperties)
 - [2. Property `Rovr Config > settings`](#settings)
   - [2.1. Property `Rovr Config > settings > use_recycle_bin`](#settings_use_recycle_bin)
   - [2.2. Property `Rovr Config > settings > copy_includes_metadata`](#settings_copy_includes_metadata)
@@ -357,6 +358,7 @@ description: config schema humanified
 | [show_line_numbers](#interface_show_line_numbers)                     | boolean | Add line numbers to the left gutter if you are viewing a text file.                                                                                                                                                     |
 | [scrolloff](#interface_scrolloff)                                     | integer | The number of files to keep above and below the cursor when moving through the file list.                                                                                                                               |
 | [show_hidden_files](#interface_show_hidden_files)                     | boolean | Show hidden files and folders (those starting with a dot on Unix, or explicitly hidden on Windows/MacOS).                                                                                                               |
+| [show_drives](#interface_show_drives)                                 | boolean | Show drives and mounted directories.                                                                                                                                                                                    |
 | [image_viewer](#interface_image_viewer)                               | object  | Settings related to the image viewer used in the preview sidebar                                                                                                                                                        |
 | [font_preview](#interface_font_preview)                               | object  | Settings related to the font preview used in the preview sidebar                                                                                                                                                        |
 | [allow_tab_nav](#interface_allow_tab_nav)                             | boolean | Allow navigating the main app screen with \`tab\` and \`shift+tab\`                                                                                                                                                     |
@@ -464,7 +466,17 @@ Not properly hot-reloaded.
 
 **Description:** Show hidden files and folders (those starting with a dot on Unix, or explicitly hidden on Windows/MacOS).
 
-### <a name="interface_image_viewer"></a>1.10. Property `Rovr Config > interface > image_viewer`
+### <a name="interface_show_drives"></a>1.10. Property `Rovr Config > interface > show_drives`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+| **Default**  | `true`    |
+
+**Description:** Show drives and mounted directories.
+
+### <a name="interface_image_viewer"></a>1.11. Property `Rovr Config > interface > image_viewer`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -480,7 +492,7 @@ Not properly hot-reloaded.
 | [max_size](#interface_image_viewer_max_size)     | array of integer | The maximum size for the image viewer. If the image exceeds this size, it will be scaled down to fit within these dimensions while maintaining its aspect ratio. |
 | [resampling](#interface_image_viewer_resampling) | enum (of string) | The resampling method to use when resizing images. This is only applicable when the image exceeds the maximum size specified in \`max_size\`.                    |
 
-#### <a name="interface_image_viewer_protocol"></a>1.10.1. Property `Rovr Config > interface > image_viewer > protocol`
+#### <a name="interface_image_viewer_protocol"></a>1.11.1. Property `Rovr Config > interface > image_viewer > protocol`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -498,7 +510,7 @@ Must be one of:
 - "Halfcell"
 - "Unicode"
 
-#### <a name="interface_image_viewer_max_size"></a>1.10.2. Property `Rovr Config > interface > image_viewer > max_size`
+#### <a name="interface_image_viewer_max_size"></a>1.11.2. Property `Rovr Config > interface > image_viewer > max_size`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -520,7 +532,7 @@ Must be one of:
 | -------------------------------------------------------- | ----------- |
 | [max_size items](#interface_image_viewer_max_size_items) |             |
 
-##### <a name="interface_image_viewer_max_size_items"></a>1.10.2.1. Rovr Config > interface > image_viewer > max_size > max_size items
+##### <a name="interface_image_viewer_max_size_items"></a>1.11.2.1. Rovr Config > interface > image_viewer > max_size > max_size items
 
 |              |           |
 | ------------ | --------- |
@@ -531,7 +543,7 @@ Must be one of:
 | ------------ | ------ |
 | **Minimum**  | &ge; 1 |
 
-#### <a name="interface_image_viewer_resampling"></a>1.10.3. Property `Rovr Config > interface > image_viewer > resampling`
+#### <a name="interface_image_viewer_resampling"></a>1.11.3. Property `Rovr Config > interface > image_viewer > resampling`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -550,7 +562,7 @@ Must be one of:
 - "box"
 - "hamming"
 
-### <a name="interface_font_preview"></a>1.11. Property `Rovr Config > interface > font_preview`
+### <a name="interface_font_preview"></a>1.12. Property `Rovr Config > interface > font_preview`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -565,7 +577,7 @@ Must be one of:
 | [max_size](#interface_font_preview_max_size)   | array of integer | The maximum size for the font preview. If the rendered font preview exceeds this size, it will be scaled down to fit within these dimensions while maintaining its aspect ratio. |
 | [font_size](#interface_font_preview_font_size) | integer          | The font size to use when rendering font previews. This is only applicable when the font preview exceeds the maximum size specified in \`max_size\`.                             |
 
-#### <a name="interface_font_preview_max_size"></a>1.11.1. Property `Rovr Config > interface > font_preview > max_size`
+#### <a name="interface_font_preview_max_size"></a>1.12.1. Property `Rovr Config > interface > font_preview > max_size`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -587,7 +599,7 @@ Must be one of:
 | -------------------------------------------------------- | ----------- |
 | [max_size items](#interface_font_preview_max_size_items) |             |
 
-##### <a name="interface_font_preview_max_size_items"></a>1.11.1.1. Rovr Config > interface > font_preview > max_size > max_size items
+##### <a name="interface_font_preview_max_size_items"></a>1.12.1.1. Rovr Config > interface > font_preview > max_size > max_size items
 
 |              |           |
 | ------------ | --------- |
@@ -598,7 +610,7 @@ Must be one of:
 | ------------ | ------ |
 | **Minimum**  | &ge; 1 |
 
-#### <a name="interface_font_preview_font_size"></a>1.11.2. Property `Rovr Config > interface > font_preview > font_size`
+#### <a name="interface_font_preview_font_size"></a>1.12.2. Property `Rovr Config > interface > font_preview > font_size`
 
 |              |           |
 | ------------ | --------- |
@@ -608,7 +620,7 @@ Must be one of:
 
 **Description:** The font size to use when rendering font previews. This is only applicable when the font preview exceeds the maximum size specified in `max_size`.
 
-### <a name="interface_allow_tab_nav"></a>1.12. Property `Rovr Config > interface > allow_tab_nav`
+### <a name="interface_allow_tab_nav"></a>1.13. Property `Rovr Config > interface > allow_tab_nav`
 
 |              |           |
 | ------------ | --------- |
@@ -618,7 +630,7 @@ Must be one of:
 
 **Description:** Allow navigating the main app screen with `tab` and `shift+tab`
 
-### <a name="interface_append_new_tabs"></a>1.13. Property `Rovr Config > interface > append_new_tabs`
+### <a name="interface_append_new_tabs"></a>1.14. Property `Rovr Config > interface > append_new_tabs`
 
 |              |           |
 | ------------ | --------- |
@@ -630,7 +642,7 @@ Must be one of:
 `true` =&gt; Append to the end of the tab list.
 `false` =&gt; Insert after the active tab.
 
-### <a name="interface_double_click_delay"></a>1.14. Property `Rovr Config > interface > double_click_delay`
+### <a name="interface_double_click_delay"></a>1.15. Property `Rovr Config > interface > double_click_delay`
 
 |              |          |
 | ------------ | -------- |
@@ -640,7 +652,7 @@ Must be one of:
 
 **Description:** The delay between two consecutive clicks to enter into a directory, or open a file.
 
-### <a name="interface_drive_watcher_frequency"></a>1.15. Property `Rovr Config > interface > drive_watcher_frequency`
+### <a name="interface_drive_watcher_frequency"></a>1.16. Property `Rovr Config > interface > drive_watcher_frequency`
 
 |              |          |
 | ------------ | -------- |
@@ -650,7 +662,7 @@ Must be one of:
 
 **Description:** How often (in seconds) to check for changes in mounted drives in the sidebar.
 
-### <a name="interface_clock"></a>1.16. Property `Rovr Config > interface > clock`
+### <a name="interface_clock"></a>1.17. Property `Rovr Config > interface > clock`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -663,7 +675,7 @@ Must be one of:
 | [enabled](#interface_clock_enabled) | boolean          | Show a clock in the tabs bar.                                    |
 | [align](#interface_clock_align)     | enum (of string) | Align the clock to either the 'right' or 'left' of the tabs bar. |
 
-#### <a name="interface_clock_enabled"></a>1.16.1. Property `Rovr Config > interface > clock > enabled`
+#### <a name="interface_clock_enabled"></a>1.17.1. Property `Rovr Config > interface > clock > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -673,7 +685,7 @@ Must be one of:
 
 **Description:** Show a clock in the tabs bar.
 
-#### <a name="interface_clock_align"></a>1.16.2. Property `Rovr Config > interface > clock > align`
+#### <a name="interface_clock_align"></a>1.17.2. Property `Rovr Config > interface > clock > align`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -688,7 +700,7 @@ Must be one of:
 - "left"
 - "right"
 
-### <a name="interface_preview_text"></a>1.17. Property `Rovr Config > interface > preview_text`
+### <a name="interface_preview_text"></a>1.18. Property `Rovr Config > interface > preview_text`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -702,7 +714,7 @@ Must be one of:
 | [start](#interface_preview_text_start)         | string | This is shown when the rovr starts up. You may see it for a split second, but it will never appear afterwards. You cannot view this properly in this docs. |
 | [font_text](#interface_preview_text_font_text) | string | When a font file is previewed, this text will be rendered in the font if possible.                                                                         |
 
-#### <a name="interface_preview_text_error"></a>1.17.1. Property `Rovr Config > interface > preview_text > error`
+#### <a name="interface_preview_text_error"></a>1.18.1. Property `Rovr Config > interface > preview_text > error`
 
 |              |                                     |
 | ------------ | ----------------------------------- |
@@ -712,7 +724,7 @@ Must be one of:
 
 **Description:** If for any reason the file preview refused to show, this appears.
 
-#### <a name="interface_preview_text_start"></a>1.17.2. Property `Rovr Config > interface > preview_text > start`
+#### <a name="interface_preview_text_start"></a>1.18.2. Property `Rovr Config > interface > preview_text > start`
 
 |              |                                                                                                                                      |
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
@@ -722,7 +734,7 @@ Must be one of:
 
 **Description:** This is shown when the rovr starts up. You may see it for a split second, but it will never appear afterwards. You cannot view this properly in this docs.
 
-#### <a name="interface_preview_text_font_text"></a>1.17.3. Property `Rovr Config > interface > preview_text > font_text`
+#### <a name="interface_preview_text_font_text"></a>1.18.3. Property `Rovr Config > interface > preview_text > font_text`
 
 |              |                                                                                                                            |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------- |
@@ -732,7 +744,7 @@ Must be one of:
 
 **Description:** When a font file is previewed, this text will be rendered in the font if possible.
 
-### <a name="interface_compact_mode"></a>1.18. Property `Rovr Config > interface > compact_mode`
+### <a name="interface_compact_mode"></a>1.19. Property `Rovr Config > interface > compact_mode`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -745,7 +757,7 @@ Must be one of:
 | [buttons](#interface_compact_mode_buttons) | boolean | Whether to compact the buttons and path input to one line instead of three.  |
 | [panels](#interface_compact_mode_panels)   | boolean | Whether to make the panels smaller to add more room for the file list itself |
 
-#### <a name="interface_compact_mode_buttons"></a>1.18.1. Property `Rovr Config > interface > compact_mode > buttons`
+#### <a name="interface_compact_mode_buttons"></a>1.19.1. Property `Rovr Config > interface > compact_mode > buttons`
 
 |              |           |
 | ------------ | --------- |
@@ -755,7 +767,7 @@ Must be one of:
 
 **Description:** Whether to compact the buttons and path input to one line instead of three.
 
-#### <a name="interface_compact_mode_panels"></a>1.18.2. Property `Rovr Config > interface > compact_mode > panels`
+#### <a name="interface_compact_mode_panels"></a>1.19.2. Property `Rovr Config > interface > compact_mode > panels`
 
 |              |           |
 | ------------ | --------- |
@@ -765,7 +777,7 @@ Must be one of:
 
 **Description:** Whether to make the panels smaller to add more room for the file list itself
 
-### <a name="interface_mime_rules"></a>1.19. Property `Rovr Config > interface > mime_rules`
+### <a name="interface_mime_rules"></a>1.20. Property `Rovr Config > interface > mime_rules`
 
 |                           |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -781,7 +793,7 @@ Must be one of:
 | ---------------------------------------------- | ---------------- | ----------------- |
 | [](#interface_mime_rules_additionalProperties) | enum (of string) |                   |
 
-#### <a name="interface_mime_rules_additionalProperties"></a>1.19.1. Property `Rovr Config > interface > mime_rules > additionalProperties`
+#### <a name="interface_mime_rules_additionalProperties"></a>1.20.1. Property `Rovr Config > interface > mime_rules > additionalProperties`
 
 |              |                    |
 | ------------ | ------------------ |

--- a/src/rovr/classes/config.py
+++ b/src/rovr/classes/config.py
@@ -126,6 +126,10 @@ _ROVR_CONFIG_INTERFACE_SCROLLOFF_DEFAULT = 3
 r""" Default value of the field path 'Rovr Config interface scrolloff' """
 
 
+_ROVR_CONFIG_INTERFACE_SHOW_DRIVES_DEFAULT = True
+r""" Default value of the field path 'Rovr Config interface show_drives' """
+
+
 _ROVR_CONFIG_INTERFACE_SHOW_HIDDEN_FILES_DEFAULT = False
 r""" Default value of the field path 'Rovr Config interface show_hidden_files' """
 
@@ -586,6 +590,13 @@ class _RovrConfigInterface(TypedDict, total=False):
     Show hidden files and folders (those starting with a dot on Unix, or explicitly hidden on Windows/MacOS).
 
     default: False
+    """
+
+    show_drives: bool
+    r"""
+    Show drives and mounted directories.
+
+    default: True
     """
 
     image_viewer: "_RovrConfigInterfaceImageViewer"

--- a/src/rovr/config/config.toml
+++ b/src/rovr/config/config.toml
@@ -10,6 +10,7 @@ show_progress_percentage = true
 truncate_progress_file_path = false
 show_line_numbers = true
 show_hidden_files = false
+show_drives = true
 allow_tab_nav = true
 append_new_tabs = true
 double_click_delay = 0.25

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -63,6 +63,11 @@
           "default": false,
           "description": "Show hidden files and folders (those starting with a dot on Unix, or explicitly hidden on Windows/MacOS)."
         },
+        "show_drives": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show drives and mounted directories."
+        },
         "image_viewer": {
           "type": "object",
           "description": "Settings related to the image viewer used in the preview sidebar",

--- a/src/rovr/core/pinned_sidebar.py
+++ b/src/rovr/core/pinned_sidebar.py
@@ -114,15 +114,19 @@ class PinnedSidebar(OptionList, inherit_bindings=False):
                     )
                 )
                 id_list.append(new_id)
-        self.list_of_options.append(
-            Option(" Drives", id="drives-header", disabled=True)
-        )
-        self.app.call_from_thread(self.set_options, self.list_of_options)
-        if prev_highlighted < len(self.list_of_options):
-            self.highlighted = prev_highlighted
-            self.refresh_drives(id_list, None)
-            return
-        self.refresh_drives(id_list, prev_highlighted)
+
+        if config["interface"]["show_drives"]:
+            self.list_of_options.append(
+                Option(" Drives", id="drives-header", disabled=True)
+            )
+            self.app.call_from_thread(self.set_options, self.list_of_options)
+            if prev_highlighted < len(self.list_of_options):
+                self.highlighted = prev_highlighted
+                self.refresh_drives(id_list, None)
+                return
+            self.refresh_drives(id_list, prev_highlighted)
+        else:
+            self.app.call_from_thread(self.set_options, self.list_of_options)
 
     @work(thread=True)
     def refresh_drives(


### PR DESCRIPTION
<!--describe your pull request-->
Should solve #257 

<!--also include videos, screenshots or gifs if applicable if it is a new feature-->

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible
- [x] the documentation has been updated wherever necessary (run `poe gen-schema` and `poe gen-keys` if applicable)

## Summary by Sourcery

Add a configurable option to control whether drives are shown in the sidebar and update configuration and documentation accordingly.

New Features:
- Introduce the `interface.show_drives` configuration option (defaulting to true) to toggle visibility of drives and mounted directories in the sidebar.

Enhancements:
- Wire the pinned sidebar to respect the `show_drives` setting so the drives section is omitted when disabled.

Documentation:
- Document the new `interface.show_drives` option in the config schema reference, including it in the interface properties table.