### PR TITLE
feat: confine related mount places for drives on linux

### DIFF
--- a/src/rovr/functions/drive_workers.py
+++ b/src/rovr/functions/drive_workers.py
@@ -72,8 +72,8 @@ def _should_include_linux_mount_point(partition: "psutil._common.sdiskpart") -> 
         "/media/",
         "/mnt/",
     )) and not partition.mountpoint.startswith((
-        "/mnt/wslg/",
-        "/mnt/wsl/",
+        "/mnt/wslg",
+        "/mnt/wsl",
     ))
 
 

--- a/src/rovr/functions/drive_workers.py
+++ b/src/rovr/functions/drive_workers.py
@@ -68,9 +68,9 @@ def _should_include_linux_mount_point(partition: "psutil._common.sdiskpart") -> 
     # - /mnt/wslg: WSL GUI support directory
     # - /mnt/wsl: WSL system integration directory
     return partition.mountpoint.startswith((
-        "/run/media",
-        "/media",
-        "/mnt",
+        "/run/media/",
+        "/media/",
+        "/mnt/",
     )) and not partition.mountpoint.startswith((
         "/mnt/wslg/",
         "/mnt/wsl/",

--- a/src/rovr/functions/drive_workers.py
+++ b/src/rovr/functions/drive_workers.py
@@ -61,56 +61,19 @@ def _should_include_linux_mount_point(partition: "psutil._common.sdiskpart") -> 
     Returns:
         bool: True if the mount point should be included, False otherwise.
     """
-    # Skip virtual/system filesystem types:
-    # - autofs: Automounter filesystem for automatic mounting/unmounting
-    # - devfs: Device filesystem providing access to device files
-    # - devtmpfs: Device temporary filesystem (like devfs but in tmpfs)
-    # - tmpfs: Temporary filesystem stored in memory
-    # - proc: Process information filesystem
-    # - sysfs: System information filesystem
-    # - cgroup2: Control group filesystem for resource management
-    # - debugfs, tracefs, fusectl, configfs: Kernel debugging/configuration filesystems
-    # - securityfs, pstore, bpf: Security and kernel subsystem filesystems
-    # - hugetlbfs, mqueue: Specialized system filesystems
-    # - devpts: Pseudo-terminal filesystem
-    # - binfmt_misc: Binary format support filesystem
-    if partition.fstype in (
-        "autofs",
-        "devfs",
-        "devtmpfs",
-        "tmpfs",
-        "proc",
-        "sysfs",
-        "cgroup2",
-        "debugfs",
-        "tracefs",
-        "fusectl",
-        "configfs",
-        "securityfs",
-        "pstore",
-        "bpf",
-        "hugetlbfs",
-        "mqueue",
-        "devpts",
-        "binfmt_misc",
-    ):
-        return False
-
-    # Skip system paths that users typically don't access:
-    # - /dev, /proc, /sys: System directories
-    # - /run: Runtime data directory
-    # - /boot: Boot partition (typically not accessed by users)
+    # Skip all uncommon places but include:
+    # - /run/media, /media: removable media
+    # - /mnt: common mounts
+    # Some things that should be excluded:
     # - /mnt/wslg: WSL GUI support directory
     # - /mnt/wsl: WSL system integration directory
-    # Include everything else (root filesystem, /home, /media, Windows drives in WSL like /mnt/c, etc.)
-    return not partition.mountpoint.startswith((
-        "/dev",
-        "/proc",
-        "/sys",
-        "/run",
-        "/boot",
-        "/mnt/wslg",
-        "/mnt/wsl",
+    return partition.mountpoint.startswith((
+        "/run/media",
+        "/media",
+        "/mnt",
+    )) and not partition.mountpoint.startswith((
+        "/mnt/wslg/",
+        "/mnt/wsl/",
     ))
 
 


### PR DESCRIPTION
<!--describe your pull request-->
Should be an alternative solution for #257, that excludes everything except common paths for removable media in `/media` and `/run/media`, as well as common mounting points in `/mnt`.
<!--also include videos, screenshots or gifs if applicable if it is a new feature-->

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible
- [x] the documentation has been updated wherever necessary (run `poe gen-schema` and `poe gen-keys` if applicable)

## Summary by Sourcery

New Features:
- Limit considered Linux mount points to /media, /run/media, and /mnt while excluding WSL-specific mounts.