### PR TITLE
perf(filelist): monkey patch line renderer to render on demand

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,6 @@ repos:
     hooks:
       - id: ty
         name: ty check
-        entry: uvx ty==0.0.8 check . --ignore unresolved-import
+        entry: uvx ty==0.0.20 check . --ignore unresolved-import
         language: python
         types_or: [python, pyi, jupyter]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Performance
+- `filelist`: improve loading by lazy loading renderer and stuff #263
+
 ## [0.8.1] - 2026-04-10
 
 ### Added
@@ -386,7 +391,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sort_order`: fix icon setting and tooltips
 - `style`: fix image and option padding/styling
 
-[Unreleased]: https://github.com/NSPC911/rovr/compare/v0.8.0.dev3...HEAD
+[Unreleased]: https://github.com/NSPC911/rovr/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/NSPC911/rovr/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/NSPC911/rovr/compare/v0.8.0rc1...v0.8.0
+[0.8.0rc1]: https://github.com/NSPC911/rovr/compare/v0.8.0.dev3...v0.8.0rc1
 [0.8.0.dev3]: https://github.com/NSPC911/rovr/compare/v0.8.0.dev2...v0.8.0.dev3
 [0.8.0.dev2]: https://github.com/NSPC911/rovr/compare/v0.8.0.dev1...v0.8.0.dev2
 [0.8.0.dev1]: https://github.com/NSPC911/rovr/compare/v0.7.0...v0.8.0.dev1

--- a/src/rovr/classes/mixins.py
+++ b/src/rovr/classes/mixins.py
@@ -1,10 +1,51 @@
 from rich.segment import Segment
 from rich.style import Style
+from textual.geometry import Size
 from textual.strip import Strip
 from textual.widgets import OptionList
 from textual.widgets.option_list import OptionDoesNotExist
 
 from rovr.functions import icons as icon_utils
+
+
+class SingleLineOptionLayoutMixin:
+    """OptionList/SelectionList layout optimization for single-line rows."""
+
+    def _update_lines(self) -> None:
+        """Update line caches without forcing prompt visualization for all options."""
+        if not self.scrollable_content_region:
+            return
+
+        line_cache = self._line_cache
+        lines = line_cache.lines
+        next_index = lines[-1][0] + 1 if lines else 0
+
+        if next_index < len(self.options):
+            for index, option in enumerate(self.options[next_index:], next_index):
+                line_cache.index_to_line[index] = len(line_cache.lines)
+                line_count = 1 + int(option._divider)
+                line_cache.heights[index] = line_count
+                line_cache.lines.extend(
+                    (index, line_no) for line_no in range(line_count)
+                )
+
+        last_divider = self.options and self.options[-1]._divider
+        width = self.scrollable_content_region.width - self._get_left_gutter_width()
+        virtual_size = Size(width, len(lines) - (1 if last_divider else 0))
+        if virtual_size != self.virtual_size:
+            self.virtual_size = virtual_size
+            self._scroll_update(virtual_size)
+
+    def get_content_width(self, container: Size, viewport: Size) -> int:
+        del viewport
+        return container.width
+
+    def get_content_height(self, container: Size, viewport: Size, width: int) -> int:
+        del container, viewport, width
+        last_divider = self.options and self.options[-1]._divider
+        return sum(1 + int(option._divider) for option in self.options) - (
+            1 if last_divider else 0
+        )
 
 
 class CheckboxRenderingMixin:

--- a/src/rovr/classes/textual_options.py
+++ b/src/rovr/classes/textual_options.py
@@ -123,7 +123,7 @@ class LazySelection(LazyOption, Selection[SelectionType]):
     @property
     def value(self) -> SelectionType:
         """The value associated with the selection."""
-        return self._value  # ty: ignore[invalid-return-type]
+        return self._value
 
     @property
     def initial_state(self) -> bool:
@@ -304,7 +304,7 @@ class ModalSearcherOption(LazyOption):
         Initialise the option
 
         Args:
-            icon (list[str] | None): The icon list from a utils function.
+            icon (list[str] | IconFactor | None): The icon list from a utils function.
             label (str): The label for the option.
             file_path (str | None): The file path
             disabled (bool) = False: The initial enabled/disabled state.

--- a/src/rovr/classes/textual_options.py
+++ b/src/rovr/classes/textual_options.py
@@ -1,17 +1,19 @@
 from os import DirEntry, getcwd, path
-from typing import Literal, NamedTuple
+from typing import Callable, Literal, NamedTuple
 
+import rich.repr
 from textual.content import Content, ContentText
-from textual.visual import VisualType
+from textual.visual import Visual, VisualType
 from textual.widgets import SelectionList
 from textual.widgets.option_list import Option
-from textual.widgets.selection_list import Selection
+from textual.widgets.selection_list import Selection, SelectionType
 from textual_autocomplete import DropdownItem
 
 from rovr.functions import icons as icon_utils
 from rovr.functions.path import normalise
 
 _icon_content_cache: dict[tuple[str, str], Content] = {}
+IconFactory = Callable[[], tuple[str, str]]
 
 
 def _get_cached_icon(icon: tuple[str, str]) -> Content:
@@ -20,6 +22,113 @@ def _get_cached_icon(icon: tuple[str, str]) -> Content:
             f" [{icon[1]}]{icon[0]}[/{icon[1]}] "
         )
     return _icon_content_cache[icon]
+
+
+@rich.repr.auto
+class LazyOption(Option):
+    """Lazier version of option that only renders the prompt when necessary,
+    letting the dev provide a function that generates the prompt so that
+    it is lazy loaded and provided when necessary + also caches the output
+    so that it doesn't have to be re-rendered every time."""
+
+    def __init__(
+        self,
+        prompt: Callable[[], VisualType],
+        id: str | None = None,
+        disabled: bool = False,
+    ) -> None:
+        """Initialise the option.
+
+        Args:
+            prompt: The prompt (text displayed) for the option.
+            id: An option ID for the option.
+            disabled: Disable the option (will be shown grayed out, and will not be selectable).
+
+        """
+        self.__prompt_factory: Callable[[], VisualType] = prompt
+        self._prompt: VisualType | None = None
+        self._visual: Visual | None = None
+        self._id = id
+        self.disabled = disabled
+        self._divider = False
+
+    @property
+    def prompt(self) -> VisualType:
+        """The original prompt.
+
+        Returns:
+            VisualType: The rendered prompt.
+        """
+        if self._prompt is None:
+            self._prompt = self.__prompt_factory()
+        return self._prompt
+
+    @property
+    def id(self) -> str | None:
+        """Optional ID for the option."""
+        return self._id
+
+    def _set_prompt(self, prompt: VisualType) -> None:
+        """Update the prompt.
+
+        Args:
+            prompt: New prompt.
+
+        """
+        self.__prompt_factory = lambda: prompt
+        self._prompt = prompt
+        self._visual = None
+
+    def _invalidate_prompt_cache(self) -> None:
+        """Clear cached prompt and visual so prompt factories rerun lazily."""
+        self._prompt = None
+        self._visual = None
+
+    def __hash__(self) -> int:
+        return id(self)
+
+    def __rich_repr__(self) -> rich.repr.Result:
+        yield "prompt_factory", self.__prompt_factory, None
+        yield "cached_prompt", self._prompt, None
+        yield "id", self._id, None
+        yield "disabled", self.disabled, False
+        yield "_divider", self._divider, False
+
+
+class LazySelection(LazyOption, Selection[SelectionType]):
+    """Lazy version of Selection that inherits from LazyOption, so it has all the lazy loading and caching features, but also has a value associated with it like Selection does."""
+
+    def __init__(
+        self,
+        prompt: Callable[[], VisualType],
+        value: SelectionType,
+        initial_state: bool = False,
+        id: str | None = None,
+        disabled: bool = False,
+    ) -> None:
+        """Initialise the selection.
+
+        Args:
+            prompt: The prompt (text displayed) for the selection.
+            value: The value associated with the selection.
+            initial_state: The initial selected state of the selection. Defaults to False.
+            id: An option ID for the selection.
+            disabled: Disable the selection (will be shown grayed out, and will not be selectable).
+
+        """
+        super().__init__(prompt, id=id, disabled=disabled)
+        self._value: SelectionType = value
+        self._initial_state: bool = initial_state
+
+    @property
+    def value(self) -> SelectionType:
+        """The value associated with the selection."""
+        return self._value
+
+    @property
+    def initial_state(self) -> bool:
+        """The initial selected state of the selection."""
+        return self._initial_state
 
 
 class PinnedSidebarOption(Option):
@@ -42,24 +151,28 @@ class PinnedSidebarOption(Option):
         self.label = label
 
 
-class ArchiveFileListSelection(Selection):
-    def __init__(self, icon: tuple[str, str], label: str) -> None:
+class ArchiveFileListSelection(LazySelection[str]):
+    def __init__(self, icon: tuple[str, str] | IconFactory, label: str) -> None:
         """Initialise the option.
 
         Args:
             icon: The icon for the option
             label: The text for the option
         """
-        prompt = _get_cached_icon(icon) + Content(label)
 
-        super().__init__(prompt=prompt, value="", disabled=True)
+        icon_factory = (lambda icon=icon: icon) if isinstance(icon, tuple) else icon
+
+        def get_prompt() -> Content:
+            return _get_cached_icon(icon_factory()) + Content(label)
+
+        super().__init__(prompt=get_prompt, value="", disabled=True)
         self.label = label
 
 
-class FileListSelectionWidget(Selection):
+class FileListSelectionWidget(LazySelection[str]):
     def __init__(
         self,
-        icon: tuple[str, str],
+        icon: tuple[str, str] | IconFactory,
         label: str,
         dir_entry: DirEntry,
         clipboard: SelectionList,
@@ -69,24 +182,29 @@ class FileListSelectionWidget(Selection):
         Initialise the selection.
 
         Args:
-            icon (tuple[str, str]): The icon list from a utils function.
+            icon (tuple[str, str] | Callable[[], tuple[str, str]]):
+                The icon list from a utils function or a lazy icon resolver.
             label (str): The label for the option.
             dir_entry (DirEntry): The nt.DirEntry class
             disabled (bool) = False: The initial enabled/disabled state. Enabled by default.
         """
-        prompt = _get_cached_icon(icon) + Content(label)
-        dir_entry_path = normalise(dir_entry.path)
-        if any(
-            clipboard_val.type_of_selection == "cut"
-            and dir_entry_path == clipboard_val.path
-            for clipboard_val in clipboard.selected
-        ):
-            prompt = prompt.stylize("dim")
         self.dir_entry = dir_entry
+        dir_entry_path = normalise(dir_entry.path)
         this_id = str(id(self))
+        icon_factory = (lambda icon=icon: icon) if isinstance(icon, tuple) else icon
+
+        def get_prompt() -> Content:
+            prompt = _get_cached_icon(icon_factory()) + Content(label)
+            if any(
+                clipboard_val.type_of_selection == "cut"
+                and dir_entry_path == clipboard_val.path
+                for clipboard_val in clipboard.selected
+            ):
+                return prompt.stylize("dim")
+            return prompt
 
         super().__init__(
-            prompt=prompt,
+            prompt=get_prompt,
             # this is kinda required for FileList.get_selected_object's select mode
             # because it gets selected (which is dictionary of values)
             # which it then queries for `id` (because there's no way to query for
@@ -95,12 +213,7 @@ class FileListSelectionWidget(Selection):
             id=str(this_id),
             disabled=disabled,
         )
-        self._prompt: Content
         self.label = label
-
-    @property
-    def prompt(self) -> Content:
-        return self._prompt
 
 
 class ClipboardSelectionValue(NamedTuple):

--- a/src/rovr/classes/textual_options.py
+++ b/src/rovr/classes/textual_options.py
@@ -189,31 +189,34 @@ class FileListSelectionWidget(LazySelection[str]):
             disabled (bool) = False: The initial enabled/disabled state. Enabled by default.
         """
         self.dir_entry = dir_entry
-        dir_entry_path = normalise(dir_entry.path)
         this_id = str(id(self))
-        icon_factory = (lambda icon=icon: icon) if isinstance(icon, tuple) else icon
-
-        def get_prompt() -> Content:
-            prompt = _get_cached_icon(icon_factory()) + Content(label)
-            if any(
-                clipboard_val.type_of_selection == "cut"
-                and dir_entry_path == clipboard_val.path
-                for clipboard_val in clipboard.selected
-            ):
-                return prompt.stylize("dim")
-            return prompt
+        self.__icon_factory = (
+            (lambda icon=icon: icon) if isinstance(icon, tuple) else icon
+        )
+        self.__label = label
+        self.__clipboard = clipboard
 
         super().__init__(
-            prompt=get_prompt,
+            prompt=self.get_prompt,
             # this is kinda required for FileList.get_selected_object's select mode
             # because it gets selected (which is dictionary of values)
             # which it then queries for `id` (because there's no way to query for
             # values directly)
-            value=str(this_id),
-            id=str(this_id),
+            value=this_id,
+            id=this_id,
             disabled=disabled,
         )
         self.label = label
+
+    def get_prompt(self) -> Content:
+        prompt = _get_cached_icon(self.__icon_factory()) + Content(self.__label)
+        if any(
+            clipboard_val.type_of_selection == "cut"
+            and normalise(self.dir_entry.path) == clipboard_val.path
+            for clipboard_val in self.__clipboard.selected
+        ):
+            return prompt.stylize("dim")
+        return prompt
 
 
 class ClipboardSelectionValue(NamedTuple):

--- a/src/rovr/classes/textual_options.py
+++ b/src/rovr/classes/textual_options.py
@@ -1,5 +1,5 @@
 from os import DirEntry, getcwd, path
-from typing import Callable, Literal, NamedTuple
+from typing import Callable, Literal, NamedTuple, TypeAlias
 
 import rich.repr
 from textual.content import Content, ContentText
@@ -13,7 +13,7 @@ from rovr.functions import icons as icon_utils
 from rovr.functions.path import normalise
 
 _icon_content_cache: dict[tuple[str, str], Content] = {}
-IconFactory = Callable[[], tuple[str, str]]
+IconFactory: TypeAlias = Callable[[], tuple[str, str]]
 
 
 def _get_cached_icon(icon: tuple[str, str]) -> Content:
@@ -292,10 +292,10 @@ class KeybindOption(Option):
         self.is_layer_bind = is_layer
 
 
-class ModalSearcherOption(Option):
+class ModalSearcherOption(LazyOption):
     def __init__(
         self,
-        icon: tuple[str, str] | None,
+        icon: tuple[str, str] | IconFactory | None,
         label: str,
         file_path: str | None = None,
         disabled: bool = False,
@@ -309,11 +309,16 @@ class ModalSearcherOption(Option):
             file_path (str | None): The file path
             disabled (bool) = False: The initial enabled/disabled state.
         """
-        if icon:
-            prompt = _get_cached_icon(icon) + Content.from_markup(label)
-        else:
-            prompt = Content(label)
-        super().__init__(prompt=prompt, disabled=disabled)
+        icon_factory = None
+        if icon is not None:
+            icon_factory = (lambda icon=icon: icon) if isinstance(icon, tuple) else icon
+
+        def get_prompt() -> Content:
+            if icon_factory is None:
+                return Content(label)
+            return _get_cached_icon(icon_factory()) + Content.from_markup(label)
+
+        super().__init__(prompt=get_prompt, disabled=disabled)
         self.label = label
         self.file_path = file_path
 

--- a/src/rovr/classes/textual_options.py
+++ b/src/rovr/classes/textual_options.py
@@ -123,7 +123,7 @@ class LazySelection(LazyOption, Selection[SelectionType]):
     @property
     def value(self) -> SelectionType:
         """The value associated with the selection."""
-        return self._value
+        return self._value  # ty: ignore[invalid-return-type]
 
     @property
     def initial_state(self) -> bool:

--- a/src/rovr/components/special_option_lists.py
+++ b/src/rovr/components/special_option_lists.py
@@ -1,11 +1,12 @@
 from textual import events
 from textual.widgets import OptionList
 
+from rovr.classes.mixins import SingleLineOptionLayoutMixin
 from rovr.classes.textual_options import PaddedOption
 from rovr.variables.constants import bindings
 
 
-class DoubleClickableOptionList(OptionList):
+class DoubleClickableOptionList(SingleLineOptionLayoutMixin, OptionList):
     async def _on_click(self, event: events.Click) -> None:
         """React to the mouse being clicked on an item.
 

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -7,8 +7,7 @@ from textual import events, on, work
 from textual.binding import BindingType
 from textual.content import ContentText
 from textual.css.query import NoMatches
-from textual.geometry import Region
-from textual.style import Style as TextualStyle
+from textual.geometry import Region, Size
 from textual.widgets import Button, Input, OptionList, SelectionList
 from textual.widgets.option_list import Option, OptionDoesNotExist
 from textual.widgets.selection_list import Selection, SelectionType
@@ -487,18 +486,54 @@ class FileList(CheckboxRenderingMixin, SelectionList, inherit_bindings=False):
         Args:
             paths (list[str]): The list of paths to dim.
         """
-        if paths is None:
-            paths = []
+        del paths
         if self.option_count == 0 or self.get_option_at_index(0).disabled:
             return
         for option in self.options:
-            if path_utils.normalise(option.dir_entry.path) in paths:
-                option._set_prompt(option.prompt.stylize("dim"))
-            else:
-                option._set_prompt(option.prompt.stylize(TextualStyle(dim=False)))
+            option._invalidate_prompt_cache()
         self._clear_caches()
         self._update_lines()
         self.refresh()
+
+    def _update_lines(self) -> None:
+        """Update line caches without measuring every option's visual.
+
+        FileList options are rendered as single-line entries, so we can avoid
+        OptionList's eager per-option visual construction (which defeats lazy prompts).
+        """
+        if not self.scrollable_content_region:
+            return
+
+        line_cache = self._line_cache
+        lines = line_cache.lines
+        next_index = lines[-1][0] + 1 if lines else 0
+
+        if next_index < len(self.options):
+            for index, option in enumerate(self.options[next_index:], next_index):
+                line_cache.index_to_line[index] = len(line_cache.lines)
+                line_count = 1 + int(option._divider)
+                line_cache.heights[index] = line_count
+                line_cache.lines.extend(
+                    (index, line_no) for line_no in range(line_count)
+                )
+
+        last_divider = self.options and self.options[-1]._divider
+        width = self.scrollable_content_region.width - self._get_left_gutter_width()
+        virtual_size = Size(width, len(lines) - (1 if last_divider else 0))
+        if virtual_size != self.virtual_size:
+            self.virtual_size = virtual_size
+            self._scroll_update(virtual_size)
+
+    def get_content_width(self, container: Size, viewport: Size) -> int:
+        del viewport
+        return container.width
+
+    def get_content_height(self, container: Size, viewport: Size, width: int) -> int:
+        del container, viewport, width
+        last_divider = self.options and self.options[-1]._divider
+        return sum(1 + int(option._divider) for option in self.options) - (
+            1 if last_divider else 0
+        )
 
     async def on_key(self, event: events.Key) -> None:
         """Handle key events for the file list."""

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -194,6 +194,7 @@ class FileList(
                             )
                         )
                         name_to_index[item["name"]] = i
+                    self.items_in_cwd = set(name_to_index.keys())
 
                     if focus_on in name_to_index:
                         to_highlight_index = name_to_index[focus_on]

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -7,12 +7,12 @@ from textual import events, on, work
 from textual.binding import BindingType
 from textual.content import ContentText
 from textual.css.query import NoMatches
-from textual.geometry import Region, Size
+from textual.geometry import Region
 from textual.widgets import Button, Input, OptionList, SelectionList
 from textual.widgets.option_list import Option, OptionDoesNotExist
 from textual.widgets.selection_list import Selection, SelectionType
 
-from rovr.classes.mixins import CheckboxRenderingMixin
+from rovr.classes.mixins import CheckboxRenderingMixin, SingleLineOptionLayoutMixin
 from rovr.classes.session_manager import SessionManager
 from rovr.classes.textual_options import FileListSelectionWidget
 from rovr.components import PopupOptionList
@@ -29,7 +29,12 @@ from rovr.variables.constants import (
 )
 
 
-class FileList(CheckboxRenderingMixin, SelectionList, inherit_bindings=False):
+class FileList(
+    CheckboxRenderingMixin,
+    SingleLineOptionLayoutMixin,
+    SelectionList,
+    inherit_bindings=False,
+):
     """
     OptionList but can multi-select files and folders.
     """
@@ -494,46 +499,6 @@ class FileList(CheckboxRenderingMixin, SelectionList, inherit_bindings=False):
         self._clear_caches()
         self._update_lines()
         self.refresh()
-
-    def _update_lines(self) -> None:
-        """Update line caches without measuring every option's visual.
-
-        FileList options are rendered as single-line entries, so we can avoid
-        OptionList's eager per-option visual construction (which defeats lazy prompts).
-        """
-        if not self.scrollable_content_region:
-            return
-
-        line_cache = self._line_cache
-        lines = line_cache.lines
-        next_index = lines[-1][0] + 1 if lines else 0
-
-        if next_index < len(self.options):
-            for index, option in enumerate(self.options[next_index:], next_index):
-                line_cache.index_to_line[index] = len(line_cache.lines)
-                line_count = 1 + int(option._divider)
-                line_cache.heights[index] = line_count
-                line_cache.lines.extend(
-                    (index, line_no) for line_no in range(line_count)
-                )
-
-        last_divider = self.options and self.options[-1]._divider
-        width = self.scrollable_content_region.width - self._get_left_gutter_width()
-        virtual_size = Size(width, len(lines) - (1 if last_divider else 0))
-        if virtual_size != self.virtual_size:
-            self.virtual_size = virtual_size
-            self._scroll_update(virtual_size)
-
-    def get_content_width(self, container: Size, viewport: Size) -> int:
-        del viewport
-        return container.width
-
-    def get_content_height(self, container: Size, viewport: Size, width: int) -> int:
-        del container, viewport, width
-        last_divider = self.options and self.options[-1]._divider
-        return sum(1 + int(option._divider) for option in self.options) - (
-            1 if last_divider else 0
-        )
 
     async def on_key(self, event: events.Key) -> None:
         """Handle key events for the file list."""

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -485,13 +485,8 @@ class FileList(
                 if isinstance(option, FileListSelectionWidget)
             ]
 
-    def update_dimmed_items(self, paths: list[str] | None = None) -> None:
-        """Update the dimmed items in the file list based on the cut items.
-
-        Args:
-            paths (list[str]): The list of paths to dim.
-        """
-        del paths
+    def update_dimmed_items(self) -> None:
+        """Update the dimmed items in the file list based on the cut items."""
         if self.option_count == 0 or self.get_option_at_index(0).disabled:
             return
         for option in self.options:

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -181,20 +181,20 @@ class FileList(
                     preview.border_title = ""
                 else:
                     file_list_options = folders + files
+                    self.list_of_options = []
+                    name_to_index: dict[str, int] = {}
 
-                    self.list_of_options = [
-                        FileListSelectionWidget(
-                            icon=item["icon"],
-                            label=item["name"],
-                            dir_entry=item["dir_entry"],
-                            clipboard=self.app.Clipboard,
+                    for i, item in enumerate(file_list_options):
+                        self.list_of_options.append(
+                            FileListSelectionWidget(
+                                icon=item["icon"],
+                                label=item["name"],
+                                dir_entry=item["dir_entry"],
+                                clipboard=self.app.Clipboard,
+                            )
                         )
-                        for item in file_list_options
-                    ]
-                    name_to_index: dict[str, int] = {
-                        item["name"]: i for i, item in enumerate(file_list_options)
-                    }
-                    self.items_in_cwd = set(name_to_index)
+                        name_to_index[item["name"]] = i
+
                     if focus_on in name_to_index:
                         to_highlight_index = name_to_index[focus_on]
 

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -14,7 +14,7 @@ from textual.widgets.selection_list import Selection, SelectionType
 
 from rovr.classes.mixins import CheckboxRenderingMixin, SingleLineOptionLayoutMixin
 from rovr.classes.session_manager import SessionManager
-from rovr.classes.textual_options import FileListSelectionWidget
+from rovr.classes.textual_options import FileListSelectionWidget, LazySelection
 from rovr.components import PopupOptionList
 from rovr.functions import icons as icon_utils
 from rovr.functions import path as path_utils
@@ -636,6 +636,7 @@ class FileList(
         self,
         options: Iterable[
             Selection[SelectionType]
+            | LazySelection[SelectionType]
             | tuple[ContentText, SelectionType]
             | tuple[ContentText, SelectionType, bool]
         ],

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -841,19 +841,18 @@ class PreviewContainer(Container):
         if not self._current_content:
             options = [Selection("  --no-files--", value="", id="", disabled=True)]
         else:
+
+            def get_archive_icon(target_file_path: str) -> tuple[str, str]:
+                if target_file_path.endswith("/"):
+                    return icon_utils.get_icon_for_folder(target_file_path.strip("/"))
+                return icon_utils.get_icon_for_file(target_file_path)
+
             file_list_length = len(self._current_content)
             start_time = time()
             for index, file_path in enumerate(self._current_content):
-                if file_path.endswith("/"):
-                    icon = icon_utils.get_icon_for_folder(file_path.strip("/"))
-                else:
-                    icon = icon_utils.get_icon_for_file(file_path)
-
-                # Create a selection widget similar to FileListSelectionWidget but simpler
-                # since we don't have dir_entry metadata for archive contents
                 options.append(
                     ArchiveFileListSelection(
-                        icon,
+                        lambda file_path=file_path: get_archive_icon(file_path),
                         file_path,
                     )
                 )

--- a/src/rovr/footer/clipboard_container.py
+++ b/src/rovr/footer/clipboard_container.py
@@ -147,11 +147,7 @@ class Clipboard(CheckboxRenderingMixin, SelectionList, inherit_bindings=False):
 
     def _remove_option(self, option: ClipboardSelection) -> Self:  # ty: ignore[invalid-method-override]  # oh my god, will you please stfu
         super()._remove_option(option)
-        self.app.file_list.update_dimmed_items([
-            opt.value.path
-            for opt in self.options
-            if opt.value in self.selected and opt.value.type_of_selection == "cut"
-        ])
+        self.app.file_list.update_dimmed_items()
         return self
 
     async def on_selection_list_selected_changed(
@@ -159,11 +155,7 @@ class Clipboard(CheckboxRenderingMixin, SelectionList, inherit_bindings=False):
     ) -> None:
         self.paste_button.disabled = len(self.selected) == 0
         # go through each option, check if they are both selected and are the cut type, update filelist with that list
-        self.app.file_list.update_dimmed_items([
-            option.value.path
-            for option in self.options
-            if option.value in self.selected and option.value.type_of_selection == "cut"
-        ])
+        self.app.file_list.update_dimmed_items()
 
     @work(thread=True)
     def check_clipboard_existence(self) -> None:

--- a/src/rovr/functions/path.py
+++ b/src/rovr/functions/path.py
@@ -180,7 +180,7 @@ def get_filtered_dir_names(cwd: str | bytes, show_hidden: bool = False) -> set[s
 
 class CWDObjectReturnDict(TypedDict):
     name: str
-    icon: tuple[str, str]
+    icon: Callable[[], tuple[str, str]]
     dir_entry: DirEntryType
 
 
@@ -271,15 +271,17 @@ def sync_get_cwd_object(
                 continue
 
             if item.is_dir():
+                item_name = item.name
                 folders.append({
-                    "name": item.name,
-                    "icon": get_icon_for_folder(item.name),
+                    "name": item_name,
+                    "icon": lambda item_name=item_name: get_icon_for_folder(item_name),
                     "dir_entry": item,
                 })
             else:
+                item_name = item.name
                 files.append({
-                    "name": item.name,
-                    "icon": get_icon_for_file(item.name),
+                    "name": item_name,
+                    "icon": lambda item_name=item_name: get_icon_for_file(item_name),
                     "dir_entry": item,
                 })
             if (

--- a/src/rovr/screens/fd_search.py
+++ b/src/rovr/screens/fd_search.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+from functools import partial
 from os import path
 from typing import ClassVar
 
@@ -219,14 +220,13 @@ class FileSearch(ModalSearchScreen):
             if not file_path_str:
                 continue
             display_text = f" {file_path_str}"
-            icon: tuple[str, str] = (
-                get_icon_for_folder(file_path_str)
-                if path.isdir(file_path_str)
-                else get_icon_for_file(file_path_str)
-            )
+            if path.isdir(file_path_str):
+                icon_factory = partial(get_icon_for_folder, file_path_str)
+            else:
+                icon_factory = partial(get_icon_for_file, file_path_str)
             options.append(
                 ModalSearcherOption(
-                    icon,
+                    icon_factory,
                     display_text,
                     file_path_str,
                 )

--- a/src/rovr/screens/rg_search.py
+++ b/src/rovr/screens/rg_search.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+from functools import partial
 from os import path
 from typing import ClassVar
 
@@ -205,14 +206,13 @@ class ContentSearch(ModalSearchScreen):
             if not file_path:
                 continue
             display_text = f" {file_path}:[dim]{line[1]}[/]"
-            icon: tuple[str, str] = (
-                get_icon_for_folder(file_path)
-                if path.isdir(file_path)
-                else get_icon_for_file(file_path)
-            )
+            if path.isdir(file_path):
+                icon_factory = partial(get_icon_for_folder, file_path)
+            else:
+                icon_factory = partial(get_icon_for_file, file_path)
             options.append(
                 ModalSearcherOption(
-                    icon,
+                    icon_factory,
                     display_text,
                     file_path,
                 )


### PR DESCRIPTION
also create a LazyOption to render Content objects only when necessary, and then use it for the file list.

## Summary by Sourcery

Introduce lazy-rendered options and single-line list layout optimizations to improve file list and search option performance.

New Features:
- Add LazyOption and LazySelection types that defer prompt and icon rendering until needed with caching.
- Support icon factory callables for file and folder options, allowing on-demand icon computation across file lists, archive previews, and search results.

Enhancements:
- Add SingleLineOptionLayoutMixin for OptionList/SelectionList to avoid unnecessary visualization and optimize line cache updates for single-line rows.
- Refactor FileList, archive preview selections, and modal searcher options to use lazy rendering and the new layout mixin for more efficient scrolling and dimming updates.

Build:
- Update pre-commit ty check hook to use ty version 0.0.20.