### PR TITLE
feat: keep focus on sidebar if clicked

### DIFF
--- a/src/rovr/core/pinned_sidebar.py
+++ b/src/rovr/core/pinned_sidebar.py
@@ -209,6 +209,7 @@ class PinnedSidebar(OptionList, inherit_bindings=False):
             else:
                 return
         self.app.cd(file_path, clear_search=True)
+        # do not switch focus for mouse click events
         if not isinstance(event._sender, PinnedSidebar):
             self.app.file_list.focus()
         if self.input.value != "":

--- a/src/rovr/core/pinned_sidebar.py
+++ b/src/rovr/core/pinned_sidebar.py
@@ -209,7 +209,8 @@ class PinnedSidebar(OptionList, inherit_bindings=False):
             else:
                 return
         self.app.cd(file_path, clear_search=True)
-        self.app.file_list.focus()
+        if not isinstance(event._sender, PinnedSidebar):
+            self.app.file_list.focus()
         if self.input.value != "":
             # assume that you don't need to reset the highlighted
             with self.input.prevent(Input.Changed):


### PR DESCRIPTION
<!--describe your pull request-->
Quick hack for my feature request #262. The sidebar retains focus when elements are selected with the mouse, but behaves as before when using the keyboard.

<!--also include videos, screenshots or gifs if applicable if it is a new feature-->

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [ ] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
__There are some errors in the current master branch.__
- [ ] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible
- [ ] the documentation has been updated wherever necessary (run `poe gen-schema` and `poe gen-keys` if applicable)

## Summary by Sourcery

Adjust focus behavior after selecting an option from the pinned sidebar.

New Features:
- Keep focus on the pinned sidebar when selecting items with the mouse so keyboard navigation can continue from the sidebar.

Enhancements:
- Preserve existing focus behavior when selections are made via keyboard while refining it for mouse interactions.