### PR TITLE
fix: prevent crash on broken symlink + visibly distinct broken symlink

### DIFF
--- a/src/rovr/classes/textual_options.py
+++ b/src/rovr/classes/textual_options.py
@@ -214,6 +214,14 @@ class FileListSelectionWidget(LazySelection):
             return prompt.stylize("dim")
         return prompt
 
+    @property
+    def icon(self) -> tuple[str, str]:
+        return self.__icon_factory()
+
+    def set_icon(self, new_icon: tuple[str, str]) -> None:
+        self.__icon_factory = lambda: new_icon
+        self._invalidate_prompt_cache()
+
 
 class ClipboardSelectionValue(NamedTuple):
     path: str

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -455,16 +455,16 @@ class FileList(
                 await self.app.query_one("PreviewContainer").mount(
                     Static("The symlink target is not found!", classes="special")
                 )
+                # also update option if necessary
+                if highlighted_option.icon != icon_utils.get_icon(
+                    "general", "broken_symlink"
+                ):
+                    highlighted_option.set_icon(
+                        icon_utils.get_icon("general", "broken_symlink")
+                    )
             else:
                 await self.app.query_one("PreviewContainer").mount(
                     Static("This file no longer exists...", classes="special")
-                )
-            # also update option if necessary
-            if highlighted_option.icon != icon_utils.get_icon(
-                "general", "broken_symlink"
-            ):
-                highlighted_option.set_icon(
-                    icon_utils.get_icon("general", "broken_symlink")
                 )
             return
         self.app.query_one("#unzip").disabled = not utils.is_archive(

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -29,7 +29,7 @@ from rovr.variables.constants import (
     buttons_that_depend_on_path,
     config,
 )
-from rovr.widgets import Button, Input, OptionList, SelectionList, Static
+from rovr.widgets import Button, Input, OptionList, SelectionList
 
 
 class FileList(
@@ -448,24 +448,9 @@ class FileList(
             )
         except FileNotFoundError:
             # if the file is deleted, just remove the preview and return
-            await self.app.query_one("PreviewContainer").remove_children()
-            self.app.query_one("PreviewContainer").border_title = ""
-            self.app.query_one("PreviewContainer").border_subtitle = ""
-            if highlighted_option.dir_entry.is_symlink():
-                await self.app.query_one("PreviewContainer").mount(
-                    Static("The symlink target is not found!", classes="special")
-                )
-                # also update option if necessary
-                if highlighted_option.icon != icon_utils.get_icon(
-                    "general", "broken_symlink"
-                ):
-                    highlighted_option.set_icon(
-                        icon_utils.get_icon("general", "broken_symlink")
-                    )
-            else:
-                await self.app.query_one("PreviewContainer").mount(
-                    Static("This file no longer exists...", classes="special")
-                )
+            await self.app.query_one("PreviewContainer").file_not_found(
+                highlighted_option.dir_entry.path, highlighted_option
+            )
             return
         self.app.query_one("#unzip").disabled = not utils.is_archive(
             highlighted_option.dir_entry.path

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -29,7 +29,7 @@ from rovr.variables.constants import (
     buttons_that_depend_on_path,
     config,
 )
-from rovr.widgets import Button, Input, OptionList, SelectionList
+from rovr.widgets import Button, Input, OptionList, SelectionList, Static
 
 
 class FileList(
@@ -401,7 +401,7 @@ class FileList(
                 })
 
     # No clue why I'm using an OptionList method for SelectionList
-    def on_option_list_option_highlighted(
+    async def on_option_list_option_highlighted(
         self, event: OptionList.OptionHighlighted
     ) -> None:
         if self.dummy:
@@ -440,11 +440,33 @@ class FileList(
         else:
             setattr(self.app, "_highlighted_file_mtime", None)
         # preview
-        self.app.query_one("PreviewContainer").show_preview(
-            highlighted_option.dir_entry.path,
-            highlighted_option.dir_entry.stat().st_mtime,
-        )
         self.app.query_one("MetadataContainer").update_metadata(event.option.dir_entry)
+        try:
+            self.app.query_one("PreviewContainer").show_preview(
+                highlighted_option.dir_entry.path,
+                highlighted_option.dir_entry.stat().st_mtime,
+            )
+        except FileNotFoundError:
+            # if the file is deleted, just remove the preview and return
+            await self.app.query_one("PreviewContainer").remove_children()
+            self.app.query_one("PreviewContainer").border_title = ""
+            self.app.query_one("PreviewContainer").border_subtitle = ""
+            if highlighted_option.dir_entry.is_symlink():
+                await self.app.query_one("PreviewContainer").mount(
+                    Static("The symlink target is not found!", classes="special")
+                )
+            else:
+                await self.app.query_one("PreviewContainer").mount(
+                    Static("This file no longer exists...", classes="special")
+                )
+            # also update option if necessary
+            if highlighted_option.icon != icon_utils.get_icon(
+                "general", "broken_symlink"
+            ):
+                highlighted_option.set_icon(
+                    icon_utils.get_icon("general", "broken_symlink")
+                )
+            return
         self.app.query_one("#unzip").disabled = not utils.is_archive(
             highlighted_option.dir_entry.path
         )

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -616,14 +616,6 @@ class PreviewContainer(Container):
                     if should_cancel():
                         return False
                     static_widget.can_focus = True
-                self.app.call_from_thread(
-                    lambda: self.notify(
-                        "Rendered with Bat",
-                        title="Plugins: Bat",
-                        severity="information",
-                    )
-                )
-                self.set_loading(False)
                 return True
             else:
                 error_message = result.stderr.decode("utf-8", errors="ignore")

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -616,7 +616,14 @@ class PreviewContainer(Container):
                     if should_cancel():
                         return False
                     static_widget.can_focus = True
-
+                self.app.call_from_thread(
+                    lambda: self.notify(
+                        "Rendered with Bat",
+                        title="Plugins: Bat",
+                        severity="information",
+                    )
+                )
+                self.set_loading(False)
                 return True
             else:
                 error_message = result.stderr.decode("utf-8", errors="ignore")

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -184,6 +184,31 @@ class PreviewContainer(Container):
         except NoMatches:
             return None
 
+    async def file_not_found(
+        self, location: str, highlighted_option: FileListSelectionWidget | None = None
+    ) -> None:
+        await self.remove_children()
+        self.border_title = ""
+        self.border_subtitle = ""
+        dir_entry = path_utils.get_direntry_for(location)
+        if dir_entry.is_symlink():
+            await self.mount(
+                Static("The symlink target is not found!", classes="special")
+            )
+            # also update option if necessary
+            if (
+                FileListSelectionWidget is not None
+                and highlighted_option.icon
+                != icon_utils.get_icon("general", "broken_symlink")
+            ):
+                highlighted_option.set_icon(
+                    icon_utils.get_icon("general", "broken_symlink")
+                )
+        else:
+            await self.app.query_one("PreviewContainer").mount(
+                Static("This file no longer exists...", classes="special")
+            )
+
     def show_font_preview(self) -> None:
         """Show font preview with PIL.ImageFont and a custom PIL.ImageDraw"""
         from PIL import ImageDraw, ImageFont
@@ -894,7 +919,12 @@ class PreviewContainer(Container):
 
             if file_path == self._current_file_path:
                 # check mtime as well
-                new_mtime = path.getmtime(file_path)
+                try:
+                    new_mtime = path.getmtime(file_path)
+                except FileNotFoundError:
+                    # if file is gone/symlink target is gone
+                    self.app.call_from_thread(self.file_not_found, file_path)
+                    return
                 if self._file_mtime == new_mtime:
                     return
 

--- a/src/rovr/functions/icons.py
+++ b/src/rovr/functions/icons.py
@@ -26,9 +26,13 @@ def get_icon_for_file(location: str) -> tuple[str, str]:
     if not config["interface"]["nerd_font"]:
         return ASCII_ICONS["file"]["default"]
 
-    # 0. check junction/symlink
+    # 0. check symlink
     if path.islink(location):
-        return ICONS["general"]["symlink"]
+        # 0.1. Check if symlink target exists
+        if path.exists(location):
+            return ICONS["general"]["symlink"]
+        else:
+            return ICONS["general"]["broken_symlink"]
 
     file_name = path.basename(location).lower()
 
@@ -70,7 +74,11 @@ def get_icon_for_folder(location: str) -> tuple[str, str]:
 
     # 0. check junction/symlink
     if path.islink(location) or path.isjunction(location):
-        return ICONS["general"]["symlink"]
+        # 0.1. Check if junction/symlink target exists
+        if path.exists(location):
+            return ICONS["general"]["symlink"]
+        else:
+            return ICONS["general"]["broken_symlink"]
 
     folder_name = path.basename(location).lower()
 

--- a/src/rovr/functions/path.py
+++ b/src/rovr/functions/path.py
@@ -196,6 +196,25 @@ def get_extension_sort_key(file_dict: dict) -> tuple[int, str]:
         return (3, name.split(".")[-1].lower())
 
 
+def sorter(
+    thing: CWDObjectReturnDict, sort_st: Literal["ctime", "mtime", "size"]
+) -> int | float | str:
+    try:
+        match sort_st:
+            case "ctime":
+                return thing["dir_entry"].stat().st_ctime_ns
+            case "mtime":
+                return thing["dir_entry"].stat().st_mtime_ns
+            case "size":
+                try:
+                    return thing["dir_entry"].stat().st_size
+                except FileNotFoundError:
+                    return 0  # only for this, since it makes sense
+    except FileNotFoundError:
+        # if  we cant access it, sort with name
+        return thing["name"].lower()
+
+
 @overload
 def sync_get_cwd_object(
     dom_node: DOMNode,
@@ -302,15 +321,15 @@ def sync_get_cwd_object(
             folders.sort(key=lambda x: natsort(x["name"]))
             files.sort(key=lambda x: natsort(x["name"]))
         case "created":
-            folders.sort(key=lambda x: x["dir_entry"].stat().st_ctime_ns)
-            files.sort(key=lambda x: x["dir_entry"].stat().st_ctime_ns)
+            folders.sort(key=lambda x: sorter(x, "ctime"))
+            files.sort(key=lambda x: sorter(x, "ctime"))
         case "modified":
-            folders.sort(key=lambda x: x["dir_entry"].stat().st_mtime_ns)
-            files.sort(key=lambda x: x["dir_entry"].stat().st_mtime_ns)
+            folders.sort(key=lambda x: sorter(x, "mtime"))
+            files.sort(key=lambda x: sorter(x, "mtime"))
         case "size":
             # no we will not be calculating the folder size
             folders.sort(key=lambda x: x["name"].lower())
-            files.sort(key=lambda x: x["dir_entry"].stat().st_size)
+            files.sort(key=lambda x: sorter(x, "size"))
         case "extension":
             # folders dont have extensions btw
             # and i will not count dot prepended folders

--- a/src/rovr/variables/maps.py
+++ b/src/rovr/variables/maps.py
@@ -131,6 +131,7 @@ ICONS = {
         "zip": ("\uf410", "yellow"),
         "link": ("\U000f0337", "cyan"),
         "symlink": ("\uf481", "cyan"),
+        "broken_symlink": ("\uf127", "red"),
         "special": ("\uf2dc", "magenta"),
     },
     "sorting": {


### PR DESCRIPTION
https://github.com/user-attachments/assets/60278a33-1f61-482c-b965-f65fc02b5bf8

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible
- [x] the documentation has been updated wherever necessary (run `poe gen-schema` and `poe gen-keys` if applicable)

## Summary by Sourcery

Handle broken or missing symlink targets more gracefully in the file list and preview UI.

New Features:
- Display a distinct icon and preview message for broken symlinks and deleted files in the file list and preview pane.

Bug Fixes:
- Prevent crashes when highlighting files whose symlink targets or underlying files no longer exist by handling FileNotFoundError in the preview logic.
- Return a broken symlink icon when a file or folder symlink target does not exist instead of treating it as a normal symlink.

Enhancements:
- Add support for updating an option's icon at runtime and notify users when file previews are rendered using the Bat plugin.