### PR TITLE
fix(process): forcefully disable multiprocessing if the user's machine is bad

### DIFF
--- a/src/rovr/__main__.py
+++ b/src/rovr/__main__.py
@@ -348,18 +348,11 @@ example_function(10)"""
     if args.force_first_launch:
         return
 
-    import multiprocessing  # noqa: I001
-
-    import rovr.monkey_patches._classes  # noqa: F401
+    import rovr.monkey_patches._classes  # noqa: F401, I001
     import rovr.monkey_patches._platform  # noqa: F401
 
     from rovr.functions.config import set_nested_value
     from rovr.variables.constants import config
-
-    try:
-        multiprocessing.set_start_method("forkserver", force=True)
-    except ValueError:
-        multiprocessing.set_start_method("spawn", force=True)
 
     for feature_path in args.with_features:
         set_nested_value(cast(dict, config), feature_path, True)

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -54,7 +54,7 @@ from rovr.core import (
     PreviewContainer,
 )
 from rovr.footer import Clipboard, MetadataContainer, ProcessContainer
-from rovr.functions.drive_workers import get_mounted_drives_worker
+from rovr.functions import drive_workers
 from rovr.functions.path import (
     dump_exc,
     ensure_existing_directory,
@@ -63,6 +63,7 @@ from rovr.functions.path import (
     normalise,
 )
 from rovr.functions.themes import get_custom_themes
+from rovr.functions.utils import multiprocessing_process_error_checker
 from rovr.header import HeaderArea
 from rovr.navigation_widgets import (
     BackButton,
@@ -125,6 +126,8 @@ class Application(App, inherit_bindings=False):
         else []
     )
     CLICK_CHAIN_TIME_THRESHOLD = config["interface"]["double_click_delay"]
+
+    MULTIPROCESSING_PROCESS_ALLOWED: bool = True
 
     def __init__(
         self,
@@ -588,7 +591,7 @@ class Application(App, inherit_bindings=False):
             state_mtime = path.getmtime(state_path)
         drives = lambda: self.app.query_one(PinnedSidebar).DRIVES  # noqa: E731
         drive_update_every = int(config["interface"]["drive_watcher_frequency"])
-        count: int = 0
+        count: int = -1
         style_available: bool = self.CUSTOM_STYLE_AVAILABLE
         custom_style_path = path.join(RovrVars.ROVRCONFIG, "style.tcss")
 
@@ -656,61 +659,36 @@ class Application(App, inherit_bindings=False):
             # check drives
             if count == 0 and not reload_called:
                 try:
-                    # Run drive check in a separate process using multiprocessing.Process
-                    # Using Queue to get the result back from the process
-                    result_queue: multiprocessing.Queue[list[str]] = (
-                        multiprocessing.Queue()
-                    )
+                    if self.MULTIPROCESSING_PROCESS_ALLOWED:
+                        # Run drive check in a separate process using multiprocessing.Process
+                        # Using Queue to get the result back from the process
+                        result_queue: multiprocessing.Queue[list[str]] = (
+                            multiprocessing.Queue()
+                        )
 
-                    process = multiprocessing.Process(
-                        target=get_mounted_drives_worker, args=(result_queue, os_type)
-                    )
-                    process.start()
-                    process.join(timeout=2.0)
+                        process = multiprocessing.Process(
+                            target=drive_workers.get_mounted_drives_worker,
+                            args=(result_queue, os_type),
+                        )
+                        process.start()
+                        process.join(timeout=2.0)
 
-                    if process.is_alive():
-                        # Timeout - terminate the process
-                        process.terminate()
-                        process.join(timeout=0.5)
                         if process.is_alive():
-                            process.kill()
-                    elif not result_queue.empty():
-                        # Process completed successfully
-                        new_drives = result_queue.get_nowait()
-                        if new_drives != drives():
-                            self.query_one(PinnedSidebar).reload_pins()
+                            # Timeout - terminate the process
+                            process.terminate()
+                            process.join(timeout=0.5)
+                            if process.is_alive():
+                                process.kill()
+                        elif not result_queue.empty():
+                            # Process completed successfully
+                            new_drives = result_queue.get_nowait()
+                    else:
+                        new_drives = drive_workers.get_mounted_drives(os_type)
+                    if new_drives != drives():
+                        self.query_one(PinnedSidebar).reload_pins()
                 except Exception as exc:
-                    if isinstance(exc, ValueError) and "fds_to_keep" in str(exc):
-                        # check spawner
-                        match multiprocessing.get_start_method(allow_none=True):
-                            case None:
-                                # try forkserver
-                                try:
-                                    multiprocessing.set_start_method("forkserver")
-                                    self.notify(
-                                        "multiprocessing is now using forkserver"
-                                    )
-                                except ValueError as val_exc:
-                                    if "cannot find context" in str(val_exc):
-                                        multiprocessing.set_start_method("spawn")
-                                        self.notify(
-                                            "multiprocessing is now using spawn"
-                                        )
-                            case "fork":  # theoretically this shouldn't happen
-                                multiprocessing.set_start_method("forkserver")
-                                self.notify("multiprocessing is now using forkserver")
-                            case "forkserver":
-                                multiprocessing.set_start_method("spawn")
-                                self.notify("multiprocessing is now using spawn")
-                            case "spawn":
-                                # nothing else we can do
-                                self.notify(
-                                    f"ValueError: {exc}",
-                                    title="Drives Watcher (Process)",
-                                    severity="error",
-                                    markup=False,
-                                )
-                                dump_exc(self, exc)
+                    if multiprocessing_process_error_checker(self, exc):
+                        count = -1  # try again immediately on next loop
                     else:
                         self.notify(
                             f"{type(exc).__name__}: {exc}",

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -680,13 +680,45 @@ class Application(App, inherit_bindings=False):
                         if new_drives != drives():
                             self.query_one(PinnedSidebar).reload_pins()
                 except Exception as exc:
-                    self.notify(
-                        f"{type(exc).__name__}: {exc}",
-                        title="Drives Watcher",
-                        severity="warning",
-                        markup=False,
-                    )
-                    dump_exc(self, exc)
+                    if isinstance(exc, ValueError) and "fds_to_keep" in str(exc):
+                        # check spawner
+                        match multiprocessing.get_start_method(allow_none=True):
+                            case None:
+                                # try forkserver
+                                try:
+                                    multiprocessing.set_start_method("forkserver")
+                                    self.notify(
+                                        "multiprocessing is now using forkserver"
+                                    )
+                                except ValueError as val_exc:
+                                    if "cannot find context" in str(val_exc):
+                                        multiprocessing.set_start_method("spawn")
+                                        self.notify(
+                                            "multiprocessing is now using spawn"
+                                        )
+                            case "fork":  # theoretically this shouldn't happen
+                                multiprocessing.set_start_method("forkserver")
+                                self.notify("multiprocessing is now using forkserver")
+                            case "forkserver":
+                                multiprocessing.set_start_method("spawn")
+                                self.notify("multiprocessing is now using spawn")
+                            case "spawn":
+                                # nothing else we can do
+                                self.notify(
+                                    f"ValueError: {exc}",
+                                    title="Drives Watcher (Process)",
+                                    severity="error",
+                                    markup=False,
+                                )
+                                dump_exc(self, exc)
+                    else:
+                        self.notify(
+                            f"{type(exc).__name__}: {exc}",
+                            title="Drives Watcher",
+                            severity="warning",
+                            markup=False,
+                        )
+                        dump_exc(self, exc)
             if i_should_shut_down():
                 return
 

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -591,9 +591,10 @@ class Application(App, inherit_bindings=False):
             state_mtime = path.getmtime(state_path)
         drives = lambda: self.app.query_one(PinnedSidebar).DRIVES  # noqa: E731
         drive_update_every = int(config["interface"]["drive_watcher_frequency"])
-        count: int = -1
+        count: int = -2
         style_available: bool = self.CUSTOM_STYLE_AVAILABLE
         custom_style_path = path.join(RovrVars.ROVRCONFIG, "style.tcss")
+        new_drives = []
 
         i_should_shut_down = lambda: (  # noqa: E731
             self._shutdown_event.is_set() or self.return_code is not None

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -594,7 +594,7 @@ class Application(App, inherit_bindings=False):
         count: int = -2
         style_available: bool = self.CUSTOM_STYLE_AVAILABLE
         custom_style_path = path.join(RovrVars.ROVRCONFIG, "style.tcss")
-        new_drives = []
+        new_drives: list[str] | None = None
 
         i_should_shut_down = lambda: (  # noqa: E731
             self._shutdown_event.is_set() or self.return_code is not None
@@ -685,7 +685,7 @@ class Application(App, inherit_bindings=False):
                             new_drives = result_queue.get_nowait()
                     else:
                         new_drives = drive_workers.get_mounted_drives(os_type)
-                    if new_drives != drives():
+                    if new_drives is not None and new_drives != drives():
                         self.query_one(PinnedSidebar).reload_pins()
                 except Exception as exc:
                     if multiprocessing_process_error_checker(self, exc):

--- a/src/rovr/core/pinned_sidebar.py
+++ b/src/rovr/core/pinned_sidebar.py
@@ -12,6 +12,7 @@ from rovr.functions import drive_workers as drive_utils
 from rovr.functions import icons as icon_utils
 from rovr.functions import path as path_utils
 from rovr.functions import pins as pin_utils
+from rovr.functions.utils import multiprocessing_process_error_checker
 from rovr.variables.constants import bindings, config, os_type
 from rovr.widgets import Input, OptionList
 
@@ -142,28 +143,33 @@ class PinnedSidebar(OptionList, inherit_bindings=False):
     ) -> None:
         # force refresh
         try:
-            result_queue: multiprocessing.Queue[list[str]] = multiprocessing.Queue()
-            process = multiprocessing.Process(
-                target=drive_utils.get_mounted_drives_worker,
-                args=(result_queue, os_type),
-            )
-            process.start()
-            process.join(timeout=2.0)
+            if self.app.MULTIPROCESSING_PROCESS_ALLOWED:
+                result_queue: multiprocessing.Queue[list[str]] = multiprocessing.Queue()
+                process = multiprocessing.Process(
+                    target=drive_utils.get_mounted_drives_worker,
+                    args=(result_queue, os_type),
+                )
+                process.start()
+                process.join(timeout=2.0)
 
-            if process.is_alive():
-                process.terminate()
-                process.join(timeout=0.5)
                 if process.is_alive():
-                    process.kill()
-                return
+                    process.terminate()
+                    process.join(timeout=0.5)
+                    if process.is_alive():
+                        process.kill()
+                    return
 
-            if result_queue.empty():
-                return
+                if result_queue.empty():
+                    return
 
-            drives = result_queue.get_nowait()
-            self.DRIVES = drives
-        except Exception:
-            return
+                drives = result_queue.get_nowait()
+            else:
+                drives = drive_utils.get_mounted_drives(os_type)
+        except Exception as exc:
+            if not multiprocessing_process_error_checker(self.app, exc):
+                return
+            drives = drive_utils.get_mounted_drives(os_type)
+        self.DRIVES = drives
         for drive in drives:
             if access(drive, R_OK):
                 new_id = f"{path_utils.compress(drive)}-drives"

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -33,7 +33,13 @@ from rovr.functions import icons as icon_utils
 from rovr.functions import path as path_utils
 from rovr.functions import preview_utils
 from rovr.functions.pdf import get_pdf_images, get_pdf_info
-from rovr.functions.utils import should_cancel
+from rovr.functions.preview_utils import (
+    load_svg_sync,
+    resample_batch_sync,
+    resample_file_sync,
+    resample_sync,
+)
+from rovr.functions.utils import multiprocessing_process_error_checker, should_cancel
 from rovr.variables.constants import PreviewContainerTitles, config, file_one
 from rovr.widgets import Static
 
@@ -313,7 +319,11 @@ class PreviewContainer(Container):
             return
 
     def show_resvg_preview(self) -> None:
-        """Show svg preview using resvg"""
+        """Show svg preview using resvg.
+
+        Raises:
+            ValueError: If SVG loading fails for non-fds_to_keep reasons.
+        """
         if should_cancel() or self._current_file_path is None:
             return
         self.app.call_from_thread(setattr, self, "border_title", titles.svg)
@@ -321,7 +331,16 @@ class PreviewContainer(Container):
         # load svg as bytes
         try:
             self.call_next(self.LOADER_WIDGET.update, "loading svg...")
-            png_bytes = preview_utils.load_svg(self._current_file_path)
+            if self.app.MULTIPROCESSING_PROCESS_ALLOWED:
+                try:
+                    png_bytes = preview_utils.load_svg(self._current_file_path)
+                except ValueError as exc:
+                    if multiprocessing_process_error_checker(self.app, exc):
+                        png_bytes = load_svg_sync(self._current_file_path)
+                    else:
+                        raise
+            else:
+                png_bytes = load_svg_sync(self._current_file_path)
             if png_bytes is None:
                 self.notify(
                     "Failed to load SVG. The file may be corrupted or not an SVG file.",
@@ -339,7 +358,16 @@ class PreviewContainer(Container):
 
             self.call_next(self.LOADER_WIDGET.update, "resampling svg...")
 
-            pil_object = preview_utils.resample(Image.open(BytesIO(png_bytes)))
+            if self.app.MULTIPROCESSING_PROCESS_ALLOWED:
+                try:
+                    pil_object = preview_utils.resample(Image.open(BytesIO(png_bytes)))
+                except ValueError as exc:
+                    if multiprocessing_process_error_checker(self.app, exc):
+                        pil_object = resample_sync(Image.open(BytesIO(png_bytes)))
+                    else:
+                        raise
+            else:
+                pil_object = resample_sync(Image.open(BytesIO(png_bytes)))
 
             if should_cancel():
                 return
@@ -381,13 +409,26 @@ class PreviewContainer(Container):
             return
 
     def show_image_preview(self) -> None:
-        """Show image preview. Runs in a thread."""
+        """Show image preview. Runs in a thread.
+
+        Raises:
+            ValueError: If image loading fails for non-fds_to_keep reasons.
+        """
         if should_cancel() or self._current_file_path is None:
             return
         self.app.call_from_thread(setattr, self, "border_title", titles.image)
 
         try:
-            pil_object = preview_utils.resample_file(self._current_file_path)
+            if self.app.MULTIPROCESSING_PROCESS_ALLOWED:
+                try:
+                    pil_object = preview_utils.resample_file(self._current_file_path)
+                except ValueError as exc:
+                    if multiprocessing_process_error_checker(self.app, exc):
+                        pil_object = resample_file_sync(self._current_file_path)
+                    else:
+                        raise
+            else:
+                pil_object = resample_file_sync(self._current_file_path)
             if pil_object is None:
                 return
         except UnidentifiedImageError:
@@ -480,7 +521,14 @@ class PreviewContainer(Container):
                 "Obtained 0 pages from Poppler. Something may have gone wrong..."
             )
         # Resample images once when loaded for better performance
-        return preview_utils.resample_batch(result)
+        if self.app.MULTIPROCESSING_PROCESS_ALLOWED:
+            try:
+                return preview_utils.resample_batch(result)
+            except ValueError as exc:
+                if multiprocessing_process_error_checker(self.app, exc):
+                    return resample_batch_sync(result)
+                raise
+        return resample_batch_sync(result)
 
     def show_pdf_preview(self) -> None:
         """

--- a/src/rovr/functions/preview_utils.py
+++ b/src/rovr/functions/preview_utils.py
@@ -223,3 +223,26 @@ def load_svg(file_path: str) -> bytes | None:
             raise result
         return result
     return None
+
+
+def load_svg_sync(file_path: str) -> bytes | None:
+    from resvg_py import svg_to_bytes
+
+    return svg_to_bytes(svg_path=file_path)
+
+
+def resample_file_sync(file_path: str) -> Image.Image | None:
+    image = Image.open(file_path)
+    image = _depalette(image)
+    return image.resize(MAX_IMAGE_SIZE, RESAMPLING_METHOD)
+
+
+def resample_sync(image: Image.Image) -> Image.Image:
+    image = _depalette(image)
+    return image.resize(MAX_IMAGE_SIZE, RESAMPLING_METHOD)
+
+
+def resample_batch_sync(images: list[PILImage]) -> list[PILImage]:
+    return [
+        _depalette(image).resize(MAX_IMAGE_SIZE, RESAMPLING_METHOD) for image in images
+    ]

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import shlex
 import subprocess
 from contextlib import suppress
@@ -6,7 +7,7 @@ from typing import Callable, Literal
 
 from humanize import naturalsize
 from textual import events
-from textual.app import ScreenStackError
+from textual.app import App, ScreenStackError
 from textual.dom import DOMNode
 from textual.message import Message
 from textual.screen import Screen, ScreenResultType
@@ -205,3 +206,28 @@ def dismiss(
     if screen in screen.app.screen_stack:
         with suppress(ScreenStackError):
             screen.dismiss(result)
+
+
+def multiprocessing_process_error_checker(app: App, exc: Exception) -> bool:
+    if isinstance(exc, ValueError) and "fds_to_keep" in str(exc):
+        match multiprocessing.get_start_method(allow_none=True):
+            case None:
+                # try forkserver
+                try:
+                    multiprocessing.set_start_method("forkserver")
+                    app.notify("multiprocessing is now using forkserver")
+                except ValueError as val_exc:
+                    if "cannot find context" in str(val_exc):
+                        multiprocessing.set_start_method("spawn")
+                        app.notify("multiprocessing is now using spawn")
+            case "fork":  # theoretically this shouldn't happen
+                multiprocessing.set_start_method("forkserver")
+                app.notify("multiprocessing is now using forkserver")
+            case "forkserver":
+                multiprocessing.set_start_method("spawn")
+                app.notify("multiprocessing is now using spawn")
+            case "spawn":
+                # nothing else we can do, except forcefully stop using Process
+                app.MULTIPROCESSING_PROCESS_ALLOWED = False
+        return True
+    return False

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -214,17 +214,17 @@ def multiprocessing_process_error_checker(app: App, exc: Exception) -> bool:
             case None:
                 # try forkserver
                 try:
-                    multiprocessing.set_start_method("forkserver")
+                    multiprocessing.set_start_method("forkserver", force=True)
                     app.notify("multiprocessing is now using forkserver")
                 except ValueError as val_exc:
                     if "cannot find context" in str(val_exc):
-                        multiprocessing.set_start_method("spawn")
+                        multiprocessing.set_start_method("spawn", force=True)
                         app.notify("multiprocessing is now using spawn")
             case "fork":  # theoretically this shouldn't happen
-                multiprocessing.set_start_method("forkserver")
+                multiprocessing.set_start_method("forkserver", force=True)
                 app.notify("multiprocessing is now using forkserver")
             case "forkserver":
-                multiprocessing.set_start_method("spawn")
+                multiprocessing.set_start_method("spawn", force=True)
                 app.notify("multiprocessing is now using spawn")
             case "spawn":
                 # nothing else we can do, except forcefully stop using Process


### PR DESCRIPTION
keep retrying the process until a method works, or you just disable multiprocessing (which isnt the best outcome, but whatever tbh i hate how elusive this bug is)

resolves #266 again

## Summary by Sourcery

Adjust multiprocessing usage to dynamically fall back to synchronous processing or disable it on problematic systems, improving robustness of drive watching and preview generation.

Bug Fixes:
- Handle multiprocessing ValueError related to fds_to_keep by switching start methods or disabling multiprocessing to avoid crashes during drive watching and previews.
- Ensure drive refresh and automatic drive watching fall back to synchronous drive discovery when multiprocessing fails or is disabled.
- Avoid failing SVG, image, and PDF previews when multiprocessing-based resampling or loading raises specific errors by retrying synchronously.

Enhancements:
- Introduce an application-level flag to control whether multiprocessing-based processes are allowed at runtime.
- Add a shared utility to manage multiprocessing start method selection and update UI notifications accordingly.
- Document potential ValueError conditions in preview methods to clarify error behavior for SVG and image previews.

Chores:
- Remove global configuration of the multiprocessing start method at application startup in favor of on-demand adjustment when errors occur.