### PR TITLE
refactor(key): use a custom keybind handler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,10 +159,12 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
   For example of this, check out `src/rovr/functions/preview_workers.py` and its parent file `src/rovr/core/preview_container.py`
 
 ### Author preferences
-
 - Avoid `if TYPE_CHECKING` blocks for imports; it looks bad
 - Avoid adding unnecessary comments, aim for self-documenting code instead
 - Commit with `NSPBot911 <176916861+NSPBot911@users.noreply.github.com>` to better distinguish between human and bot commits in the history.
   NEVER co-author with your provider (like `NSPBot911 <176916861+NSPBot911@users.noreply.github.com>` or `Claude Opus 4.6 <noreply@anthropic.com>`)
   You can, however, mention the provider used in the commit message, but you must use a syntax of `Used [Provider Name]: [Model Name]`
+
+### Interesting Textual Patterns
+- event handlers do not need to call their super() method. Textual implicitly handles this for you. If you don't want it to bubble to the super() method, call `prevent_default()` on the event.
 - Using `subprocess.run(shell=True)` is completely allowed, there are no security implications to worry about since the user is always in control on the config and are the only ones that can run commands.

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -47,6 +47,7 @@ from rovr.action_buttons import (
     ZipButton,
 )
 from rovr.action_buttons.sort_order import SortOrderButton
+from rovr.classes.mixins import Action, Actionable
 from rovr.classes.type_aliases import DirEntryType
 from rovr.components.popup_option_list import PopupOptionList
 from rovr.core import (
@@ -84,7 +85,42 @@ if constants.SCREENSHOT_LOCATION:
     constants.SCREENSHOT_LOCATION = normalise(getcwd(), constants.SCREENSHOT_LOCATION)
 
 
-class Application(App, inherit_bindings=False):
+class Application(Actionable, App, inherit_bindings=False):
+    # our own form of BINDINGS that utilises check_key
+    # key: str the action to use
+    # value: bool or callable that returns bool,
+    #        whether the keybind can be used or not
+    ACTIONS: list[Action] = [
+        Action(action, config["keybinds"][action])
+        for action in (
+            "focus_toggle_pinned_sidebar",
+            "focus_file_list",
+            "focus_toggle_preview_sidebar",
+            "focus_toggle_path_switcher",
+            "focus_toggle_processes",
+            "focus_toggle_metadata",
+            "focus_toggle_clipboard",
+            "toggle_pinned_sidebar",
+            "toggle_preview_sidebar",
+            "toggle_footer",
+            "toggle_menu_wrapper",
+            "tab_next",
+            "tab_previous",
+            "tab_new",
+            "tab_close",
+            "show_keybinds",
+            "show_shell_screen",
+            "suspend_process",
+        )
+    ] + [
+        Action(action, config["plugins"][plugin]["keybinds"])
+        for action, plugin in (
+            ("plugin_zoxide", "zoxide"),
+            ("plugin_fd", "fd"),
+            ("plugin_rg", "rg"),
+        )
+    ]
+
     # dont need ctrl+c
     BINDINGS = [
         Binding(
@@ -330,8 +366,6 @@ class Application(App, inherit_bindings=False):
             super().action_focus_previous()
 
     async def on_key(self, event: events.Key) -> None:
-        from rovr.functions.utils import check_key
-
         # show key
         if self._show_keys:
             with suppress(NoMatches):
@@ -346,11 +380,14 @@ class Application(App, inherit_bindings=False):
                     f"\nUsing: {using}"
                 )
 
-        # Not really sure why this can happen, but I will still handle this
-        if self.focused is None or not isinstance(self.focused.parent, DOMNode):
-            return
         # if current screen isn't the app screen
         if len(self.screen_stack) != 1:
+            event.prevent_default()
+            await self._on_key(event)
+            return
+        # Not really sure why this can happen, but I will still handle this
+        if self.focused is None or not isinstance(self.focused.parent, DOMNode):
+            event.prevent_default()
             return
         # Make sure that key binds don't break
         # placeholder, not yet existing
@@ -359,66 +396,14 @@ class Application(App, inherit_bindings=False):
                 self.file_list.focus()
             elif self._focused_id == "search_pinned_sidebar":
                 self.query_one("#pinned_sidebar").focus()
-            return
+            event.prevent_default()
         # backspace is used by default bindings to head up in history
         # so just avoid it
         elif event.key == "backspace" and (
             isinstance(self.focused, Input)
             or (self.focused.id and "search" in self.focused.id)
         ):
-            return
-        # focus toggle pinned sidebar
-        elif check_key(event, config["keybinds"]["focus_toggle_pinned_sidebar"]):
-            self.action_focus_toggle_pinned_sidebar()
-        # Focus file list from anywhere except input
-        elif check_key(event, config["keybinds"]["focus_file_list"]):
-            self.action_focus_file_list()
-        # Focus toggle preview sidebar
-        elif check_key(event, config["keybinds"]["focus_toggle_preview_sidebar"]):
-            self.action_focus_toggle_preview_sidebar()
-        # Focus path switcher
-        elif check_key(event, config["keybinds"]["focus_toggle_path_switcher"]):
-            self.action_focus_path_switcher()
-        # Focus processes
-        elif check_key(event, config["keybinds"]["focus_toggle_processes"]):
-            self.action_focus_toggle_processes()
-        # Focus metadata
-        elif check_key(event, config["keybinds"]["focus_toggle_metadata"]):
-            self.action_focus_toggle_metadata()
-        # Focus clipboard
-        elif check_key(event, config["keybinds"]["focus_toggle_clipboard"]):
-            self.action_focus_toggle_clipboard()
-        # Toggle hiding panels
-        elif check_key(event, config["keybinds"]["toggle_pinned_sidebar"]):
-            self.action_toggle_pinned_sidebar()
-        elif check_key(event, config["keybinds"]["toggle_preview_sidebar"]):
-            self.action_toggle_preview_sidebar()
-        elif check_key(event, config["keybinds"]["toggle_footer"]):
-            self.action_toggle_footer()
-        elif check_key(event, config["keybinds"]["toggle_menu_wrapper"]):
-            self.action_toggle_menu_wrapper()
-        elif check_key(event, config["keybinds"]["tab_next"]):
-            self.action_tab_next()
-        elif check_key(event, config["keybinds"]["tab_previous"]):
-            self.action_tab_previous()
-        elif check_key(event, config["keybinds"]["tab_new"]):
-            await self.action_tab_new()
-        elif check_key(event, config["keybinds"]["tab_close"]):
-            await self.action_tab_close()
-        elif check_key(event, config["keybinds"]["show_keybinds"]):
-            self.action_show_keybinds()
-        elif check_key(event, config["keybinds"]["show_shell_screen"]):
-            self.action_show_shell_screen()
-        # zoxide
-        elif check_key(event, config["plugins"]["zoxide"]["keybinds"]):
-            self.action_plugin_zoxide()
-        # keybinds
-        elif check_key(event, config["plugins"]["fd"]["keybinds"]):
-            self.action_plugin_fd()
-        elif check_key(event, config["plugins"]["rg"]["keybinds"]):
-            self.action_plugin_rg()
-        elif check_key(event, config["keybinds"]["suspend_process"]):
-            self.action_suspend_process()
+            event.prevent_default()
 
     @work
     async def on_shell_exec_response(
@@ -1082,8 +1067,11 @@ class Application(App, inherit_bindings=False):
         else:
             self.file_list.focus()
 
-    def action_focus_path_switcher(self) -> None:
-        self.query_one("#path_switcher").focus()
+    def action_focus_toggle_path_switcher(self) -> None:
+        if (path_switcher := self.query_one("#path_switcher")).has_focus:
+            self.file_list.focus()
+        else:
+            path_switcher.focus()
 
     def action_focus_toggle_processes(self) -> None:
         if (

--- a/src/rovr/classes/mixins.py
+++ b/src/rovr/classes/mixins.py
@@ -1,11 +1,15 @@
+from typing import Any, Awaitable, Callable, NamedTuple
+
 from rich.segment import Segment
 from rich.style import Style
+from textual.events import Key
 from textual.geometry import Region, Size
 from textual.strip import Strip
 from textual.widgets import OptionList
 from textual.widgets.option_list import OptionDoesNotExist
 
 from rovr.functions import icons as icon_utils
+from rovr.functions.utils import check_key
 from rovr.variables.constants import config
 
 
@@ -219,3 +223,38 @@ class ScrollOffMixin:
                 top=top,
                 immediate=True,
             )
+
+
+class Action(NamedTuple):
+    action: str | Callable[[], Any]
+    match_keys: str | list[str]
+    only_if: bool | Callable[[], bool] = True
+
+
+class Actionable:
+    ACTIONS: list[Action]
+
+    async def on_key(self, event: Key) -> None:
+        from inspect import isawaitable
+
+        if not hasattr(self, "ACTIONS"):
+            return
+        for action in self.ACTIONS:
+            if check_key(event, action.match_keys) and (
+                action.only_if() if callable(action.only_if) else action.only_if
+            ):
+                if not isinstance(action.action, str):
+                    func: Callable[[], Any] = action.action
+                else:
+                    func: Callable[[], Any] = getattr(
+                        self, f"action_{action.action}", lambda: None
+                    )
+                    if not callable(func):
+                        continue
+                result: Any | Awaitable = func()
+                if isawaitable(result):
+                    await result
+                event.prevent_default().stop()
+                return
+        if hasattr(super(), "on_key"):
+            await super().on_key(event)

--- a/src/rovr/classes/mixins.py
+++ b/src/rovr/classes/mixins.py
@@ -246,8 +246,8 @@ class Actionable:
                 if not isinstance(action.action, str):
                     func: Callable[[], Any] = action.action
                 else:
-                    func: Callable[[], Any] = getattr(
-                        self, f"action_{action.action}", lambda: None
+                    func: Callable[[], Any] | None = getattr(
+                        self, f"action_{action.action}"
                     )
                     if not callable(func):
                         continue
@@ -256,5 +256,3 @@ class Actionable:
                     await result
                 event.prevent_default().stop()
                 return
-        if hasattr(super(), "on_key"):
-            await super().on_key(event)

--- a/src/rovr/components/base_search_screen.py
+++ b/src/rovr/components/base_search_screen.py
@@ -2,17 +2,23 @@ import asyncio
 from typing import Coroutine
 
 from textual import events, on
+from textual.dom import DOMNode
 from textual.screen import ModalScreen
 from textual.widgets import Input, OptionList
 from textual.worker import Worker
 
+from rovr.classes.mixins import Action, Actionable
 from rovr.classes.textual_options import ModalSearcherOption
 from rovr.components.special_option_lists import DoubleClickableOptionList
-from rovr.functions.utils import check_key, dismiss
+from rovr.functions.utils import dismiss
 from rovr.variables.constants import config
 
 
-class ModalSearchScreen(ModalScreen, inherit_bindings=False):
+def can_do_keybind(self: DOMNode) -> bool:
+    return bool(isinstance(self.focused, Input) and self.search_options.options)
+
+
+class ModalSearchScreen(Actionable, ModalScreen, inherit_bindings=False):
     """Base class for search-as-you-type modal screens."""
 
     def create_proc(
@@ -33,6 +39,31 @@ class ModalSearchScreen(ModalScreen, inherit_bindings=False):
         )
         self.search_input.focus()
         self.search_options.can_focus = False
+        self.ACTIONS: list[Action] = (
+            [
+                Action(
+                    lambda: dismiss(self, None),
+                    config["keybinds"]["filter_modal"]["exit"],
+                ),
+            ]
+            + [
+                Action(
+                    getattr(self.search_options, f"action_{part}"),
+                    config["keybinds"]["filter_modal"][another],
+                    lambda self=self: can_do_keybind(self),
+                )
+                for part, another in (
+                    ("cursor_down", "down"),
+                    ("cursor_up", "up"),
+                    ("page_down", "page_down"),
+                    ("page_up", "page_up"),
+                )
+            ]
+            + [
+                Action(self.focus_next, "tab"),
+                Action(self.focus_previous, "shift+tab"),
+            ]
+        )
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         if any(
@@ -74,41 +105,6 @@ class ModalSearchScreen(ModalScreen, inherit_bindings=False):
             dismiss(self, selected_value)
         else:
             dismiss(self, None)
-
-    def on_key(self, event: events.Key) -> None:
-        if check_key(event, config["keybinds"]["filter_modal"]["exit"]):
-            event.stop()
-            dismiss(self, None)
-        elif check_key(
-            event, config["keybinds"]["filter_modal"]["down"]
-        ) and isinstance(self.focused, Input):
-            event.stop()
-            if self.search_options.options:
-                self.search_options.action_cursor_down()
-        elif check_key(event, config["keybinds"]["filter_modal"]["up"]) and isinstance(
-            self.focused, Input
-        ):
-            event.stop()
-            if self.search_options.options:
-                self.search_options.action_cursor_up()
-        elif check_key(
-            event, config["keybinds"]["filter_modal"]["page_down"]
-        ) and isinstance(self.focused, Input):
-            event.stop()
-            if self.search_options.options:
-                self.search_options.action_page_down()
-        elif check_key(
-            event, config["keybinds"]["filter_modal"]["page_up"]
-        ) and isinstance(self.focused, Input):
-            event.stop()
-            if self.search_options.options:
-                self.search_options.action_page_up()
-        elif event.key == "tab":
-            event.stop()
-            self.focus_next()
-        elif event.key == "shift+tab":
-            event.stop()
-            self.focus_previous()
 
     def on_click(self, event: events.Click) -> None:
         if event.widget is self:

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -14,6 +14,8 @@ from textual.widgets.option_list import OptionDoesNotExist
 from textual.widgets.selection_list import Selection, SelectionType
 
 from rovr.classes.mixins import (
+    Action,
+    Actionable,
     CheckboxRenderingMixin,
     ScrollOffMixin,
     SingleLineOptionLayoutMixin,
@@ -35,6 +37,7 @@ from .file_list_right_click_menu import FileListRightClickMenu, ifed
 
 
 class FileList(
+    Actionable,
     CheckboxRenderingMixin,
     ScrollOffMixin,
     SingleLineOptionLayoutMixin,
@@ -44,6 +47,44 @@ class FileList(
     """
     OptionList but can multi-select files and folders.
     """
+
+    ACTIONS: list[Action] = [
+        Action(action, config["keybinds"][action])
+        for action in (
+            "hist_previous",
+            "hist_next",
+            "up_tree",
+            "bypass_up_tree",
+            "bypass_down_tree",
+            "toggle_pin",
+            "copy",
+            "cut",
+            "paste",
+            "new",
+            "rename",
+            "delete",
+            "zip",
+            "unzip",
+            "focus_search",
+            "toggle_hidden_files",
+            "toggle_visual",
+            "toggle_all",
+            "select_up",
+            "select_down",
+            "select_page_up",
+            "select_page_down",
+            "select_home",
+            "select_end",
+            "open_editor",
+            "open_right_click_menu",
+        )
+    ] + [
+        Action("extra_copy_open_popup", config["keybinds"]["extra_copy"]["open_popup"]),
+        Action(
+            "change_sort_order_open_popup",
+            config["keybinds"]["change_sort_order"]["open_popup"],
+        ),
+    ]
 
     BINDINGS: ClassVar[list[BindingType]] = list(bindings)
 
@@ -553,69 +594,7 @@ class FileList(
     async def on_key(self, event: events.Key) -> None:
         """Handle key events for the file list."""
         if self.dummy:
-            return
-        from rovr.functions.utils import check_key
-
-        # hit buttons with keybinds
-        if check_key(event, config["keybinds"]["hist_previous"]):
-            self.action_hist_previous()
-        elif check_key(event, config["keybinds"]["hist_next"]):
-            self.action_hist_next()
-        elif check_key(event, config["keybinds"]["up_tree"]):
-            self.action_up_tree()
-        elif check_key(event, config["keybinds"]["bypass_up_tree"]):
-            self.action_bypass_up_tree()
-        elif check_key(event, config["keybinds"]["bypass_down_tree"]):
-            self.action_bypass_down_tree()
-        # Toggle pin on current directory
-        elif check_key(event, config["keybinds"]["toggle_pin"]):
-            self.action_toggle_pin()
-        elif check_key(event, config["keybinds"]["copy"]):
-            self.action_copy()
-        elif check_key(event, config["keybinds"]["extra_copy"]["open_popup"]):
-            await self.action_extra_copy_open_popup()
-        elif check_key(event, config["keybinds"]["cut"]):
-            self.action_cut()
-        elif check_key(event, config["keybinds"]["paste"]):
-            self.action_paste()
-        elif check_key(event, config["keybinds"]["new"]):
-            self.action_new()
-        elif check_key(event, config["keybinds"]["rename"]):
-            self.action_rename()
-        elif check_key(event, config["keybinds"]["delete"]):
-            self.action_delete()
-        elif check_key(event, config["keybinds"]["zip"]):
-            self.action_zip()
-        elif check_key(event, config["keybinds"]["unzip"]):
-            self.action_unzip()
-        # search
-        elif check_key(event, config["keybinds"]["focus_search"]):
-            self.action_focus_search()
-        # toggle hidden files
-        elif check_key(event, config["keybinds"]["toggle_hidden_files"]):
-            await self.action_toggle_hidden_files()
-        elif check_key(event, config["keybinds"]["change_sort_order"]["open_popup"]):
-            await self.action_change_sort_order_open_popup()
-        elif check_key(event, config["keybinds"]["toggle_visual"]):
-            await self.action_toggle_visual()
-        elif check_key(event, config["keybinds"]["toggle_all"]):
-            await self.action_toggle_all()
-        elif check_key(event, config["keybinds"]["select_up"]):
-            self.action_select_up()
-        elif check_key(event, config["keybinds"]["select_down"]):
-            self.action_select_down()
-        elif check_key(event, config["keybinds"]["select_page_up"]):
-            self.action_select_page_up()
-        elif check_key(event, config["keybinds"]["select_page_down"]):
-            self.action_select_page_down()
-        elif check_key(event, config["keybinds"]["select_home"]):
-            self.action_select_home()
-        elif check_key(event, config["keybinds"]["select_end"]):
-            self.action_select_end()
-        elif check_key(event, config["keybinds"]["open_editor"]):
-            self.action_open_editor()
-        elif check_key(event, config["keybinds"]["open_right_click_menu"]):
-            await self.action_open_right_click_menu()
+            event.prevent_default()
 
     def update_border_subtitle(self) -> None:
         if self.dummy or type(self.highlighted) is not int or not self.parent:

--- a/src/rovr/core/pinned_sidebar.py
+++ b/src/rovr/core/pinned_sidebar.py
@@ -2,12 +2,13 @@ import multiprocessing
 from os import R_OK, access, path
 from typing import ClassVar, cast
 
-from textual import events, work
+from textual import work
 from textual.binding import BindingType
 from textual.widgets import Input, OptionList
 from textual.widgets.option_list import Option
 
 from rovr.classes.exceptions import FolderNotFileError
+from rovr.classes.mixins import Action, Actionable
 from rovr.classes.textual_options import PinnedSidebarOption
 from rovr.functions import drive_workers as drive_utils
 from rovr.functions import icons as icon_utils
@@ -17,10 +18,11 @@ from rovr.functions.utils import multiprocessing_process_error_checker
 from rovr.variables.constants import bindings, config, os_type
 
 
-class PinnedSidebar(OptionList, inherit_bindings=False):
+class PinnedSidebar(Actionable, OptionList, inherit_bindings=False):
     # Just so that I can disable space
     BINDINGS: ClassVar[list[BindingType]] = list(bindings)
     DRIVES: list[str] = []
+    ACTIONS: list[Action] = [Action("focus_search", config["keybinds"]["focus_search"])]
 
     @work(exclusive=True, thread=True)
     def reload_pins(self) -> None:
@@ -232,10 +234,6 @@ class PinnedSidebar(OptionList, inherit_bindings=False):
                 self.set_options(self.list_of_options)
                 if event.option.id:
                     self.highlighted = self.get_option_index(event.option.id)
-
-    def on_key(self, event: events.Key) -> None:
-        if event.key in config["keybinds"]["focus_search"]:
-            self.action_focus_search()
 
     def action_focus_search(self) -> None:
         self.input.focus()

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -7,7 +7,7 @@ from functools import partial
 from io import BytesIO
 from os import path
 from time import time
-from typing import Literal, cast
+from typing import cast
 
 import textual_image.renderable
 import textual_image.widget
@@ -25,6 +25,7 @@ from textual.message import Message
 from textual.widgets import Static
 from textual.widgets.selection_list import Selection
 
+from rovr.classes.mixins import Action, Actionable
 from rovr.classes.textual_options import (
     ArchiveFileListSelection,
     FileListSelectionWidget,
@@ -127,8 +128,13 @@ class LoadingPreview(Static):
         self.on_mount()
 
 
-class PreviewContainer(Container):
+class PreviewContainer(Actionable, Container):
     LOADER_WIDGET = LoadingPreview()
+
+    ACTIONS: list[Action] = [
+        Action(action, config["keybinds"][action])
+        for action in ("up", "down", "page_up", "page_down", "home", "end")
+    ]
 
     @dataclass
     class SetLoading(Message):
@@ -1236,26 +1242,6 @@ class PreviewContainer(Container):
             self._pending_preview_args = None
             self.show_preview(pending[0], pending[1])
 
-    def on_key(self, event: events.Key) -> None:
-        """Check for vim keybinds."""
-        from rovr.functions.utils import check_key
-
-        if (
-            check_key(event, config["keybinds"]["up"])
-            and self.action_up() is None
-            or check_key(event, config["keybinds"]["down"])
-            and self.action_down() is None
-            or check_key(event, config["keybinds"]["page_up"])
-            and self.action_page_up() is None
-            or check_key(event, config["keybinds"]["page_down"])
-            and self.action_page_down() is None
-            or check_key(event, config["keybinds"]["home"])
-            and self.action_home() is None
-            or check_key(event, config["keybinds"]["end"])
-            and self.action_end() is None
-        ):
-            event.stop()
-
     def on_click(self, event: events.Click) -> None:
         if event.widget is self and self.children:
             self.children[-1].focus()
@@ -1263,62 +1249,50 @@ class PreviewContainer(Container):
     def _is_pdf(self) -> bool:
         return self.border_title == titles.pdf and self._file_type == "pdf"
 
-    def action_up(self) -> Literal[False] | None:
+    def action_up(self) -> None:
         if self._is_pdf() and self.pdf.images is not None:
             self.update_current_pdf_page_by_diff(-1)
         elif self.border_title == titles.archive and (
             filelist := self.get_child(FileList)
         ):
             filelist.scroll_up(animate=False)
-        else:
-            return False
 
-    def action_down(self) -> Literal[False] | None:
+    def action_down(self) -> None:
         if self._is_pdf() and self.pdf.images is not None:
             self.update_current_pdf_page_by_diff(1)
         elif self.border_title == titles.archive and (
             filelist := self.get_child(FileList)
         ):
             filelist.scroll_down(animate=False)
-        else:
-            return False
 
-    def action_page_up(self) -> Literal[False] | None:  # ty: ignore[invalid-method-override]
+    def action_page_up(self) -> None:
         if self._is_pdf() and self.pdf.images is not None:
             self.update_current_pdf_page_by_diff(-1)
         elif self.border_title == titles.archive and (
             filelist := self.get_child(FileList)
         ):
             filelist.scroll_page_up(animate=False)
-        else:
-            return False
 
-    def action_page_down(self) -> Literal[False] | None:  # ty: ignore[invalid-method-override]
+    def action_page_down(self) -> None:
         if self._is_pdf() and self.pdf.images is not None:
             self.update_current_pdf_page_by_diff(1)
         elif self.border_title == titles.archive and (
             filelist := self.get_child(FileList)
         ):
             filelist.scroll_page_down(animate=False)
-        else:
-            return False
 
-    def action_home(self) -> Literal[False] | None:
+    def action_home(self) -> None:
         if self._is_pdf() and self.pdf.images is not None:
             self.update_current_pdf_page(0)
         elif self.border_title == titles.archive and (
             filelist := self.get_child(FileList)
         ):
             filelist.scroll_home(animate=False)
-        else:
-            return False
 
-    def action_end(self) -> Literal[False] | None:
+    def action_end(self) -> None:
         if self._is_pdf() and self.pdf.images is not None:
             self.update_current_pdf_page(self.pdf.total_pages - 1)
         elif self.border_title == titles.archive and (
             filelist := self.get_child(FileList)
         ):
             filelist.scroll_end(animate=False)
-        else:
-            return False

--- a/src/rovr/footer/process_container.py
+++ b/src/rovr/footer/process_container.py
@@ -8,13 +8,14 @@ from typing import Callable, Literal, cast
 
 from multiarchive import Archive
 from send2trash import send2trash
-from textual import events, work
+from textual import work
 from textual.color import Gradient
 from textual.containers import HorizontalGroup, VerticalGroup, VerticalScroll
 from textual.renderables.bar import Bar as BarRenderable
 from textual.types import UnusedParameter
 from textual.widgets import Label, ProgressBar
 
+from rovr.classes.mixins import Action, Actionable
 from rovr.functions import icons as icon_utils
 from rovr.functions import path as path_utils
 from rovr.functions.utils import is_being_used
@@ -148,11 +149,12 @@ class ProgressBarContainer(VerticalGroup, inherit_bindings=False):
         self.app.Clipboard.checker_wrapper()
 
 
-class ProcessContainer(VerticalScroll):
+class ProcessContainer(Actionable, VerticalScroll):
     def __init__(self) -> None:
         super().__init__(id="processes")
         self.has_perm_error: bool = False
         self.has_in_use_error: bool = False
+        self.ACTIONS: list[Action] = [Action("delete", config["keybinds"]["delete"])]
 
     async def new_process_bar(
         self, max: int | None = None, id: str | None = None, classes: str | None = None
@@ -1324,11 +1326,6 @@ class ProcessContainer(VerticalScroll):
         )
         self.app.call_from_thread(bar.progress_bar.advance)
         self.app.call_from_thread(bar.add_class, "done")
-
-    def on_key(self, event: events.Key) -> None:
-        if event.key in config["keybinds"]["delete"]:
-            event.stop()
-            self.action_delete()
 
     def action_delete(self) -> None:
         self.remove_children(".done")

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -228,9 +228,7 @@ def dismiss(
     screen: Screen, result: ScreenResultType | None = None, event: Message | None = None
 ) -> None:
     if event is not None:
-        event.prevent_default()
-        event.stop()
-        event._set_forwarded()
+        event.prevent_default().stop()._set_forwarded()
 
     if screen in screen.app.screen_stack:
         with suppress(ScreenStackError):

--- a/src/rovr/navigation_widgets/path_input.py
+++ b/src/rovr/navigation_widgets/path_input.py
@@ -9,6 +9,7 @@ from textual.validation import Function
 from textual.widgets import Input
 from textual_autocomplete import DropdownItem, PathAutoComplete, TargetState
 
+from rovr.classes.mixins import Action, Actionable
 from rovr.classes.textual_options import PathDropdownItem
 from rovr.functions.icons import get_icon
 from rovr.functions.utils import check_key
@@ -298,7 +299,7 @@ class PathAutoCompleteInput(PathAutoComplete):
         self.post_completion()
 
 
-class PathInput(Input, inherit_bindings=False):
+class PathInput(Actionable, Input, inherit_bindings=False):
     ALLOW_MAXIMIZE = False
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("left", "cursor_left", "Move cursor left", show=False),
@@ -364,6 +365,10 @@ class PathInput(Input, inherit_bindings=False):
             validate_on=["changed"],
             select_on_focus=False,
         )
+        self.ACTIONS: list[Action] = [
+            Action(self.action_delete_left, "backspace"),
+            Action(self.app.file_list.focus, "escape"),
+        ]
 
     def on_mount(self) -> None:
         self.auto_completer = self.app.query_one(PathAutoCompleteInput)
@@ -378,13 +383,8 @@ class PathInput(Input, inherit_bindings=False):
             self.notify("Path provided is not valid.", severity="error")
         self.app.file_list.focus()
 
-    def on_key(self, event: events.Key) -> None:
-        if event.key == "backspace":
-            # might be used for back history, so force the behaviour
-            self.action_delete_left()
-        elif event.key == "escape":
-            self.app.file_list.focus()
-        elif len(event.key) != 1 and not event.is_printable:
+    async def on_key(self, event: events.Key) -> None:
+        if len(event.key) != 1 and not event.is_printable:
             if check_key(event, config["keybinds"]["toggle_all"]):
                 self.select_all()
             elif check_key(event, config["keybinds"]["home"]):
@@ -399,7 +399,6 @@ class PathInput(Input, inherit_bindings=False):
                 return
         else:
             return
-        event.stop()
 
     def on_blur(self) -> None:
         self.auto_completer.action_hide()

--- a/src/rovr/screens/yes_or_no.py
+++ b/src/rovr/screens/yes_or_no.py
@@ -5,7 +5,8 @@ from textual.message import Message
 from textual.screen import ModalScreen
 from textual.widgets import Button, Label, Switch
 
-from rovr.functions.utils import check_key, dismiss, get_shortest_bind
+from rovr.classes.mixins import Action, Actionable
+from rovr.functions.utils import dismiss, get_shortest_bind
 from rovr.variables.constants import config
 
 yes_bind = get_shortest_bind(config["keybinds"]["yes_or_no"]["yes"])
@@ -13,7 +14,7 @@ no_bind = get_shortest_bind(config["keybinds"]["yes_or_no"]["no"])
 dont_ask_bind = get_shortest_bind(config["keybinds"]["yes_or_no"]["dont_ask_again"])
 
 
-class YesOrNo(ModalScreen):
+class YesOrNo(Actionable, ModalScreen):
     """Screen with a dialog that asks whether you accept or deny"""
 
     def __init__(
@@ -30,6 +31,17 @@ class YesOrNo(ModalScreen):
         self.with_toggle = with_toggle
         self.border_title = border_title
         self.border_subtitle = border_subtitle
+        self.ACTIONS: list[Action] = [
+            Action(part, config["keybinds"]["yes_or_no"][part])
+            for part in ("yes", "no")
+        ]
+        self.ACTIONS.append(
+            Action(
+                "dont_ask_again",
+                config["keybinds"]["yes_or_no"]["dont_ask_again"],
+                self.with_toggle,
+            )
+        )
 
     def compose(self) -> ComposeResult:
         with Grid(id="dialog", classes="yes_or_no"):
@@ -67,20 +79,6 @@ class YesOrNo(ModalScreen):
             # ie click outside
             self.action_no(event)
 
-    def on_key(self, event: events.Key) -> None:
-        """Handle key presses."""
-        if check_key(event, config["keybinds"]["yes_or_no"]["yes"]):
-            self.action_yes(event)
-        elif check_key(event, config["keybinds"]["yes_or_no"]["no"]):
-            self.action_no(event)
-        elif self.with_toggle and check_key(
-            event, config["keybinds"]["yes_or_no"]["dont_ask_again"]
-        ):
-            self.action_toggle_dont_ask_again()
-        else:
-            return
-        event.stop()
-
     def action_yes(self, event: Message | None = None) -> None:
         dismiss(
             self,
@@ -99,6 +97,6 @@ class YesOrNo(ModalScreen):
             event,
         )
 
-    def action_toggle_dont_ask_again(self) -> None:
+    def action_dont_ask_again(self) -> None:
         if self.with_toggle:
             self.query_one(Switch).action_toggle_switch()


### PR DESCRIPTION
not a new feature, just a really good refactor

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible
- [x] the documentation has been updated wherever necessary (run `poe gen-schema` and `poe gen-keys` if applicable)

## Summary by Sourcery

Refactor key handling across the app to use a shared Action/Actionable abstraction instead of per-widget key event handlers.

Enhancements:
- Introduce a reusable Action/Actionable mixin to centralise keybinding configuration and dispatch across widgets.
- Migrate Application, FileList, modal search screens, preview container, yes/no dialog, path input, process container, and pinned sidebar to the new action-based keybinding system.
- Adjust focus and toggle behaviours (e.g. path switcher focus toggle, modal dismissal, backspace/escape handling) to integrate with the unified key handling while preventing default key processing where appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralised keyboard action system across the app, standardising keybind handling and unifying input processing.

* **New Features**
  * Added configurable action mappings for navigation, paging, focus toggles and delete, available across panels, modals and inputs.

* **Bug Fixes**
  * Improved focus toggling for the path switcher and stricter suppression of default key behaviour (e.g. backspace) to avoid unintended text or viewport changes.

* **Documentation**
  * Added guidance on using prevent_default() for event suppression in Textual handlers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NSPC911/rovr/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->