### PR TITLE
feat(new_item)!: add batch creation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `editor`: add support for opening editor as orphan [704400e](https://github.com/NSPC911/rovr/commit/704400e623fe2d47da432a3f6b873dd75841b8f7)
 - `shell_exec`: add command substitution support [464e71c](https://github.com/NSPC911/rovr/commit/464e71c977d48c5e599a17cc1f5b3ee1131683d2)
 - `openers`: add support for opening with a specific app [#281](https://github.com/NSPC911/rovr/pull/281)
+- `new_item`!: add batch creation support
 
 ### Fixed
 

--- a/docs/src/content/docs/dev/features/editor.mdx
+++ b/docs/src/content/docs/dev/features/editor.mdx
@@ -10,41 +10,31 @@ options:
 ```toml
 [settings.editor.file]
 run = "$EDITOR"
-block = false
-suspend = true
+orphan = true
 ```
 - run: the command to open files. `$EDITOR` will use your system's default editor.
-- block: whether to block rovr until the editor is closed (recommended for GUI editors, like `code --wait`)
-- suspend: whether to suspend rovr. ignores blocking (because it is already blocking execution). recommended for TUI editors, like `nvim`.
+- orphan: whether to detach the editor process from rovr. recommended for GUI editors, like `code`.
 
-### configure file editor
+### configure folder editor
 options:
 ```toml
 [settings.editor.folder]
 run = "$EDITOR"
-block = false
-suspend = true
+orphan = true
 ```
 - run: the command to open files. `$EDITOR` will use your system's default editor.
-- block: whether to block rovr until the editor is closed (recommended for GUI editors, like `code --wait`)
-- suspend: whether to suspend rovr. ignores blocking (because it is already blocking execution). recommended for TUI editors, like `nvim`.
+- orphan: whether to detach the editor process from rovr. recommended for GUI editors, like `code`.
 
-### configure bulk renaming editor
+### configure bulk editor
+used for things like bulk renaming and creating files
+
 options:
 ```toml
-[settings.editor.bulk_rename]
+[settings.editor.bulk_editor]
 run = "$EDITOR"
-suspend = true
+rename_show_as_mapping = true
 ```
 - run: the command to open files. `$EDITOR` will use your system's default editor.
-- suspend: whether to suspend rovr. ignores blocking (because it is already blocking execution). recommended for TUI editors, like `nvim`.
+- rename_show_as_mapping: whether to show the bulk rename file as a mapping of old name to new name. if false, the bulk rename file will only show the new names. this is not used for bulk file creation.
 
-blocking is automatically enabled when bulk renaming files, as rovr needs to wait for the renaming to be completed before proceeding.
-
-### additional notes
-there is an additional option
-```toml
-[settings.editor]
-open_all_in_editor = false
-```
-- open_all_in_editor: if enabled, rather than using your system's default opener, it opens them in the relevant editor configured
+orphan is automatically disabled for bulk editor, since it needs to wait for the editor process to finish before it can read the changes.

--- a/docs/src/content/docs/dev/reference/keybindings.mdx
+++ b/docs/src/content/docs/dev/reference/keybindings.mdx
@@ -56,6 +56,7 @@ just copy over the contents of the desired profile into your `config.toml` file 
 | delete                       | Delete                         | <kbd>d</kbd> <kbd>delete</kbd>                 | <kbd>d</kbd>                                   | <kbd>delete</kbd>                        |
 | rename                       | Rename                         | <kbd>r</kbd> <kbd>f2</kbd>                     | <kbd>r</kbd>                                   | <kbd>f2</kbd>                            |
 | new                          | New                            | <kbd>ctrl+n</kbd> <kbd>o</kbd>                 | <kbd>o</kbd>                                   | <kbd>ctrl+n</kbd>                        |
+| bulk_create                  | Bulk create                    | <kbd>N</kbd> <kbd>O</kbd>                      | <kbd>O</kbd>                                   | <kbd>ctrl+shift+n</kbd>                  |
 | toggle_all                   | Select all                     | <kbd>%</kbd> <kbd>ctrl+a</kbd>                 | <kbd>%</kbd> <kbd>ctrl+a</kbd>                 | <kbd>ctrl+a</kbd>                        |
 | zip                          | Zip                            | <kbd>E</kbd>                                   | <kbd>E</kbd>                                   | <kbd>E</kbd>                             |
 | unzip                        | Unzip                          | <kbd>ctrl+e</kbd>                              | <kbd>ctrl+e</kbd>                              | <kbd>ctrl+e</kbd>                        |

--- a/docs/src/content/docs/dev/reference/schema.mdx
+++ b/docs/src/content/docs/dev/reference/schema.mdx
@@ -80,9 +80,9 @@ description: config schema humanified
     - [2.4.2. Property `Rovr Config > settings > editor > folder`](#settings_editor_folder)
       - [2.4.2.1. Property `Rovr Config > settings > editor > folder > run`](#settings_editor_folder_run)
       - [2.4.2.2. Property `Rovr Config > settings > editor > folder > orphan`](#settings_editor_folder_orphan)
-    - [2.4.3. Property `Rovr Config > settings > editor > bulk_rename`](#settings_editor_bulk_rename)
-      - [2.4.3.1. Property `Rovr Config > settings > editor > bulk_rename > run`](#settings_editor_bulk_rename_run)
-      - [2.4.3.2. Property `Rovr Config > settings > editor > bulk_rename > show_as_mapping`](#settings_editor_bulk_rename_show_as_mapping)
+    - [2.4.3. Property `Rovr Config > settings > editor > bulk_editor`](#settings_editor_bulk_editor)
+      - [2.4.3.1. Property `Rovr Config > settings > editor > bulk_editor > run`](#settings_editor_bulk_editor_run)
+      - [2.4.3.2. Property `Rovr Config > settings > editor > bulk_editor > rename_show_as_mapping`](#settings_editor_bulk_editor_rename_show_as_mapping)
   - [2.5. Property `Rovr Config > settings > preview_rules`](#settings_preview_rules)
     - [2.5.1. Property `Rovr Config > settings > preview_rules > additionalProperties`](#settings_preview_rules_additionalProperties)
   - [2.6. Property `Rovr Config > settings > openers`](#settings_openers)
@@ -186,149 +186,151 @@ description: config schema humanified
     - [7.19.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
   - [7.20. Property `Rovr Config > keybinds > new`](#keybinds_new)
     - [7.20.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.21. Property `Rovr Config > keybinds > toggle_all`](#keybinds_toggle_all)
+  - [7.21. Property `Rovr Config > keybinds > bulk_create`](#keybinds_bulk_create)
     - [7.21.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.22. Property `Rovr Config > keybinds > zip`](#keybinds_zip)
+  - [7.22. Property `Rovr Config > keybinds > toggle_all`](#keybinds_toggle_all)
     - [7.22.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.23. Property `Rovr Config > keybinds > unzip`](#keybinds_unzip)
+  - [7.23. Property `Rovr Config > keybinds > zip`](#keybinds_zip)
     - [7.23.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.24. Property `Rovr Config > keybinds > open_right_click_menu`](#keybinds_open_right_click_menu)
+  - [7.24. Property `Rovr Config > keybinds > unzip`](#keybinds_unzip)
     - [7.24.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.25. Property `Rovr Config > keybinds > extra_copy`](#keybinds_extra_copy)
-    - [7.25.1. Property `Rovr Config > keybinds > extra_copy > open_popup`](#keybinds_extra_copy_open_popup)
-      - [7.25.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.25.2. Property `Rovr Config > keybinds > extra_copy > copy_to_rovr`](#keybinds_extra_copy_copy_to_rovr)
-      - [7.25.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.25.3. Property `Rovr Config > keybinds > extra_copy > copy_highlighted`](#keybinds_extra_copy_copy_highlighted)
-      - [7.25.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.25.4. Property `Rovr Config > keybinds > extra_copy > copy_to_system_clip`](#keybinds_extra_copy_copy_to_system_clip)
-      - [7.25.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.25.5. Property `Rovr Config > keybinds > extra_copy > copy_current_directory`](#keybinds_extra_copy_copy_current_directory)
-      - [7.25.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.26. Property `Rovr Config > keybinds > up`](#keybinds_up)
-    - [7.26.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.27. Property `Rovr Config > keybinds > down`](#keybinds_down)
+  - [7.25. Property `Rovr Config > keybinds > open_right_click_menu`](#keybinds_open_right_click_menu)
+    - [7.25.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+  - [7.26. Property `Rovr Config > keybinds > extra_copy`](#keybinds_extra_copy)
+    - [7.26.1. Property `Rovr Config > keybinds > extra_copy > open_popup`](#keybinds_extra_copy_open_popup)
+      - [7.26.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+    - [7.26.2. Property `Rovr Config > keybinds > extra_copy > copy_to_rovr`](#keybinds_extra_copy_copy_to_rovr)
+      - [7.26.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+    - [7.26.3. Property `Rovr Config > keybinds > extra_copy > copy_highlighted`](#keybinds_extra_copy_copy_highlighted)
+      - [7.26.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+    - [7.26.4. Property `Rovr Config > keybinds > extra_copy > copy_to_system_clip`](#keybinds_extra_copy_copy_to_system_clip)
+      - [7.26.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+    - [7.26.5. Property `Rovr Config > keybinds > extra_copy > copy_current_directory`](#keybinds_extra_copy_copy_current_directory)
+      - [7.26.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+  - [7.27. Property `Rovr Config > keybinds > up`](#keybinds_up)
     - [7.27.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.28. Property `Rovr Config > keybinds > up_tree`](#keybinds_up_tree)
+  - [7.28. Property `Rovr Config > keybinds > down`](#keybinds_down)
     - [7.28.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.29. Property `Rovr Config > keybinds > down_tree`](#keybinds_down_tree)
+  - [7.29. Property `Rovr Config > keybinds > up_tree`](#keybinds_up_tree)
     - [7.29.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.30. Property `Rovr Config > keybinds > bypass_up_tree`](#keybinds_bypass_up_tree)
+  - [7.30. Property `Rovr Config > keybinds > down_tree`](#keybinds_down_tree)
     - [7.30.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.31. Property `Rovr Config > keybinds > bypass_down_tree`](#keybinds_bypass_down_tree)
+  - [7.31. Property `Rovr Config > keybinds > bypass_up_tree`](#keybinds_bypass_up_tree)
     - [7.31.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.32. Property `Rovr Config > keybinds > page_up`](#keybinds_page_up)
+  - [7.32. Property `Rovr Config > keybinds > bypass_down_tree`](#keybinds_bypass_down_tree)
     - [7.32.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.33. Property `Rovr Config > keybinds > page_down`](#keybinds_page_down)
+  - [7.33. Property `Rovr Config > keybinds > page_up`](#keybinds_page_up)
     - [7.33.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.34. Property `Rovr Config > keybinds > home`](#keybinds_home)
+  - [7.34. Property `Rovr Config > keybinds > page_down`](#keybinds_page_down)
     - [7.34.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.35. Property `Rovr Config > keybinds > end`](#keybinds_end)
+  - [7.35. Property `Rovr Config > keybinds > home`](#keybinds_home)
     - [7.35.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.36. Property `Rovr Config > keybinds > hist_previous`](#keybinds_hist_previous)
+  - [7.36. Property `Rovr Config > keybinds > end`](#keybinds_end)
     - [7.36.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.37. Property `Rovr Config > keybinds > hist_next`](#keybinds_hist_next)
+  - [7.37. Property `Rovr Config > keybinds > hist_previous`](#keybinds_hist_previous)
     - [7.37.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.38. Property `Rovr Config > keybinds > toggle_visual`](#keybinds_toggle_visual)
+  - [7.38. Property `Rovr Config > keybinds > hist_next`](#keybinds_hist_next)
     - [7.38.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.39. Property `Rovr Config > keybinds > toggle_hidden_files`](#keybinds_toggle_hidden_files)
+  - [7.39. Property `Rovr Config > keybinds > toggle_visual`](#keybinds_toggle_visual)
     - [7.39.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.40. Property `Rovr Config > keybinds > toggle_select_item`](#keybinds_toggle_select_item)
+  - [7.40. Property `Rovr Config > keybinds > toggle_hidden_files`](#keybinds_toggle_hidden_files)
     - [7.40.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.41. Property `Rovr Config > keybinds > select_up`](#keybinds_select_up)
+  - [7.41. Property `Rovr Config > keybinds > toggle_select_item`](#keybinds_toggle_select_item)
     - [7.41.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.42. Property `Rovr Config > keybinds > select_down`](#keybinds_select_down)
+  - [7.42. Property `Rovr Config > keybinds > select_up`](#keybinds_select_up)
     - [7.42.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.43. Property `Rovr Config > keybinds > select_page_up`](#keybinds_select_page_up)
+  - [7.43. Property `Rovr Config > keybinds > select_down`](#keybinds_select_down)
     - [7.43.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.44. Property `Rovr Config > keybinds > select_page_down`](#keybinds_select_page_down)
+  - [7.44. Property `Rovr Config > keybinds > select_page_up`](#keybinds_select_page_up)
     - [7.44.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.45. Property `Rovr Config > keybinds > select_home`](#keybinds_select_home)
+  - [7.45. Property `Rovr Config > keybinds > select_page_down`](#keybinds_select_page_down)
     - [7.45.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.46. Property `Rovr Config > keybinds > select_end`](#keybinds_select_end)
+  - [7.46. Property `Rovr Config > keybinds > select_home`](#keybinds_select_home)
     - [7.46.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.47. Property `Rovr Config > keybinds > tab_next`](#keybinds_tab_next)
+  - [7.47. Property `Rovr Config > keybinds > select_end`](#keybinds_select_end)
     - [7.47.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.48. Property `Rovr Config > keybinds > tab_previous`](#keybinds_tab_previous)
+  - [7.48. Property `Rovr Config > keybinds > tab_next`](#keybinds_tab_next)
     - [7.48.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.49. Property `Rovr Config > keybinds > tab_new`](#keybinds_tab_new)
+  - [7.49. Property `Rovr Config > keybinds > tab_previous`](#keybinds_tab_previous)
     - [7.49.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.50. Property `Rovr Config > keybinds > tab_close`](#keybinds_tab_close)
+  - [7.50. Property `Rovr Config > keybinds > tab_new`](#keybinds_tab_new)
     - [7.50.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.51. Property `Rovr Config > keybinds > preview_scroll_left`](#keybinds_preview_scroll_left)
+  - [7.51. Property `Rovr Config > keybinds > tab_close`](#keybinds_tab_close)
     - [7.51.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.52. Property `Rovr Config > keybinds > preview_scroll_right`](#keybinds_preview_scroll_right)
+  - [7.52. Property `Rovr Config > keybinds > preview_scroll_left`](#keybinds_preview_scroll_left)
     - [7.52.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.53. Property `Rovr Config > keybinds > preview_select_right`](#keybinds_preview_select_right)
+  - [7.53. Property `Rovr Config > keybinds > preview_scroll_right`](#keybinds_preview_scroll_right)
     - [7.53.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.54. Property `Rovr Config > keybinds > preview_select_left`](#keybinds_preview_select_left)
+  - [7.54. Property `Rovr Config > keybinds > preview_select_right`](#keybinds_preview_select_right)
     - [7.54.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.55. Property `Rovr Config > keybinds > show_keybinds`](#keybinds_show_keybinds)
+  - [7.55. Property `Rovr Config > keybinds > preview_select_left`](#keybinds_preview_select_left)
     - [7.55.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.56. Property `Rovr Config > keybinds > change_sort_order`](#keybinds_change_sort_order)
-    - [7.56.1. Property `Rovr Config > keybinds > change_sort_order > open_popup`](#keybinds_change_sort_order_open_popup)
-      - [7.56.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.56.2. Property `Rovr Config > keybinds > change_sort_order > name`](#keybinds_change_sort_order_name)
-      - [7.56.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.56.3. Property `Rovr Config > keybinds > change_sort_order > extension`](#keybinds_change_sort_order_extension)
-      - [7.56.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.56.4. Property `Rovr Config > keybinds > change_sort_order > natural`](#keybinds_change_sort_order_natural)
-      - [7.56.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.56.5. Property `Rovr Config > keybinds > change_sort_order > size`](#keybinds_change_sort_order_size)
-      - [7.56.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.56.6. Property `Rovr Config > keybinds > change_sort_order > created`](#keybinds_change_sort_order_created)
-      - [7.56.6.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.56.7. Property `Rovr Config > keybinds > change_sort_order > modified`](#keybinds_change_sort_order_modified)
-      - [7.56.7.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.56.8. Property `Rovr Config > keybinds > change_sort_order > descending`](#keybinds_change_sort_order_descending)
-      - [7.56.8.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.57. Property `Rovr Config > keybinds > quit_app`](#keybinds_quit_app)
-    - [7.57.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.58. Property `Rovr Config > keybinds > command_palette`](#keybinds_command_palette)
-  - [7.59. Property `Rovr Config > keybinds > suspend_process`](#keybinds_suspend_process)
-    - [7.59.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.60. Property `Rovr Config > keybinds > open_editor`](#keybinds_open_editor)
+  - [7.56. Property `Rovr Config > keybinds > show_keybinds`](#keybinds_show_keybinds)
+    - [7.56.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+  - [7.57. Property `Rovr Config > keybinds > change_sort_order`](#keybinds_change_sort_order)
+    - [7.57.1. Property `Rovr Config > keybinds > change_sort_order > open_popup`](#keybinds_change_sort_order_open_popup)
+      - [7.57.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+    - [7.57.2. Property `Rovr Config > keybinds > change_sort_order > name`](#keybinds_change_sort_order_name)
+      - [7.57.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+    - [7.57.3. Property `Rovr Config > keybinds > change_sort_order > extension`](#keybinds_change_sort_order_extension)
+      - [7.57.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+    - [7.57.4. Property `Rovr Config > keybinds > change_sort_order > natural`](#keybinds_change_sort_order_natural)
+      - [7.57.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+    - [7.57.5. Property `Rovr Config > keybinds > change_sort_order > size`](#keybinds_change_sort_order_size)
+      - [7.57.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+    - [7.57.6. Property `Rovr Config > keybinds > change_sort_order > created`](#keybinds_change_sort_order_created)
+      - [7.57.6.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+    - [7.57.7. Property `Rovr Config > keybinds > change_sort_order > modified`](#keybinds_change_sort_order_modified)
+      - [7.57.7.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+    - [7.57.8. Property `Rovr Config > keybinds > change_sort_order > descending`](#keybinds_change_sort_order_descending)
+      - [7.57.8.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+  - [7.58. Property `Rovr Config > keybinds > quit_app`](#keybinds_quit_app)
+    - [7.58.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+  - [7.59. Property `Rovr Config > keybinds > command_palette`](#keybinds_command_palette)
+  - [7.60. Property `Rovr Config > keybinds > suspend_process`](#keybinds_suspend_process)
     - [7.60.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.61. Property `Rovr Config > keybinds > show_shell_screen`](#keybinds_show_shell_screen)
+  - [7.61. Property `Rovr Config > keybinds > open_editor`](#keybinds_open_editor)
     - [7.61.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.62. Property `Rovr Config > keybinds > filename_conflict`](#keybinds_filename_conflict)
-    - [7.62.1. Property `Rovr Config > keybinds > filename_conflict > overwrite`](#keybinds_filename_conflict_overwrite)
-      - [7.62.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.62.2. Property `Rovr Config > keybinds > filename_conflict > skip`](#keybinds_filename_conflict_skip)
-      - [7.62.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.62.3. Property `Rovr Config > keybinds > filename_conflict > rename`](#keybinds_filename_conflict_rename)
-      - [7.62.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.62.4. Property `Rovr Config > keybinds > filename_conflict > cancel`](#keybinds_filename_conflict_cancel)
-      - [7.62.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.62.5. Property `Rovr Config > keybinds > filename_conflict > dont_ask_again`](#keybinds_filename_conflict_dont_ask_again)
-      - [7.62.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.63. Property `Rovr Config > keybinds > file_in_use`](#keybinds_file_in_use)
-    - [7.63.1. Property `Rovr Config > keybinds > file_in_use > retry`](#keybinds_file_in_use_retry)
+  - [7.62. Property `Rovr Config > keybinds > show_shell_screen`](#keybinds_show_shell_screen)
+    - [7.62.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+  - [7.63. Property `Rovr Config > keybinds > filename_conflict`](#keybinds_filename_conflict)
+    - [7.63.1. Property `Rovr Config > keybinds > filename_conflict > overwrite`](#keybinds_filename_conflict_overwrite)
       - [7.63.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.63.2. Property `Rovr Config > keybinds > file_in_use > skip`](#keybinds_file_in_use_skip)
+    - [7.63.2. Property `Rovr Config > keybinds > filename_conflict > skip`](#keybinds_filename_conflict_skip)
       - [7.63.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.63.3. Property `Rovr Config > keybinds > file_in_use > cancel`](#keybinds_file_in_use_cancel)
+    - [7.63.3. Property `Rovr Config > keybinds > filename_conflict > rename`](#keybinds_filename_conflict_rename)
       - [7.63.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.63.4. Property `Rovr Config > keybinds > file_in_use > dont_ask_again`](#keybinds_file_in_use_dont_ask_again)
+    - [7.63.4. Property `Rovr Config > keybinds > filename_conflict > cancel`](#keybinds_filename_conflict_cancel)
       - [7.63.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.64. Property `Rovr Config > keybinds > filter_modal`](#keybinds_filter_modal)
-    - [7.64.1. Property `Rovr Config > keybinds > filter_modal > exit`](#keybinds_filter_modal_exit)
+    - [7.63.5. Property `Rovr Config > keybinds > filename_conflict > dont_ask_again`](#keybinds_filename_conflict_dont_ask_again)
+      - [7.63.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+  - [7.64. Property `Rovr Config > keybinds > file_in_use`](#keybinds_file_in_use)
+    - [7.64.1. Property `Rovr Config > keybinds > file_in_use > retry`](#keybinds_file_in_use_retry)
       - [7.64.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.64.2. Property `Rovr Config > keybinds > filter_modal > down`](#keybinds_filter_modal_down)
+    - [7.64.2. Property `Rovr Config > keybinds > file_in_use > skip`](#keybinds_file_in_use_skip)
       - [7.64.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.64.3. Property `Rovr Config > keybinds > filter_modal > up`](#keybinds_filter_modal_up)
+    - [7.64.3. Property `Rovr Config > keybinds > file_in_use > cancel`](#keybinds_file_in_use_cancel)
       - [7.64.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.64.4. Property `Rovr Config > keybinds > filter_modal > page_down`](#keybinds_filter_modal_page_down)
+    - [7.64.4. Property `Rovr Config > keybinds > file_in_use > dont_ask_again`](#keybinds_file_in_use_dont_ask_again)
       - [7.64.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.64.5. Property `Rovr Config > keybinds > filter_modal > page_up`](#keybinds_filter_modal_page_up)
-      - [7.64.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-  - [7.65. Property `Rovr Config > keybinds > yes_or_no`](#keybinds_yes_or_no)
-    - [7.65.1. Property `Rovr Config > keybinds > yes_or_no > yes`](#keybinds_yes_or_no_yes)
+  - [7.65. Property `Rovr Config > keybinds > filter_modal`](#keybinds_filter_modal)
+    - [7.65.1. Property `Rovr Config > keybinds > filter_modal > exit`](#keybinds_filter_modal_exit)
       - [7.65.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.65.2. Property `Rovr Config > keybinds > yes_or_no > no`](#keybinds_yes_or_no_no)
+    - [7.65.2. Property `Rovr Config > keybinds > filter_modal > down`](#keybinds_filter_modal_down)
       - [7.65.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
-    - [7.65.3. Property `Rovr Config > keybinds > yes_or_no > dont_ask_again`](#keybinds_yes_or_no_dont_ask_again)
+    - [7.65.3. Property `Rovr Config > keybinds > filter_modal > up`](#keybinds_filter_modal_up)
       - [7.65.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+    - [7.65.4. Property `Rovr Config > keybinds > filter_modal > page_down`](#keybinds_filter_modal_page_down)
+      - [7.65.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+    - [7.65.5. Property `Rovr Config > keybinds > filter_modal > page_up`](#keybinds_filter_modal_page_up)
+      - [7.65.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+  - [7.66. Property `Rovr Config > keybinds > yes_or_no`](#keybinds_yes_or_no)
+    - [7.66.1. Property `Rovr Config > keybinds > yes_or_no > yes`](#keybinds_yes_or_no_yes)
+      - [7.66.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+    - [7.66.2. Property `Rovr Config > keybinds > yes_or_no > no`](#keybinds_yes_or_no_no)
+      - [7.66.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
+    - [7.66.3. Property `Rovr Config > keybinds > yes_or_no > dont_ask_again`](#keybinds_yes_or_no_dont_ask_again)
+      - [7.66.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items](#keybinds_toggle_pin_items)
 - [8. Property `Rovr Config > plugins`](#plugins)
   - [8.1. Property `Rovr Config > plugins > zoxide`](#plugins_zoxide)
     - [8.1.1. Property `Rovr Config > plugins > zoxide > enabled`](#plugins_zoxide_enabled)
@@ -1323,7 +1325,7 @@ Must be one of:
 | ------------------------------------------- | ------ | ----------------------------------- |
 | [file](#settings_editor_file)               | object | Editor to use when opening a file   |
 | [folder](#settings_editor_folder)           | object | Editor to use when opening a folder |
-| [bulk_rename](#settings_editor_bulk_rename) | object | Editor to use for bulk renaming     |
+| [bulk_editor](#settings_editor_bulk_editor) | object | Editor to use for bulk editing      |
 
 #### <a name="settings_editor_file"></a>2.4.1. Property `Rovr Config > settings > editor > file`
 
@@ -1395,7 +1397,7 @@ Must be one of:
 
 **Description:** Whether to open the editor as an orphan process.
 
-#### <a name="settings_editor_bulk_rename"></a>2.4.3. Property `Rovr Config > settings > editor > bulk_rename`
+#### <a name="settings_editor_bulk_editor"></a>2.4.3. Property `Rovr Config > settings > editor > bulk_editor`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -1403,14 +1405,14 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-**Description:** Editor to use for bulk renaming
+**Description:** Editor to use for bulk editing
 
-| Property                                                        | Type    | Title/Description                                                                  |
-| --------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------- |
-| [run](#settings_editor_bulk_rename_run)                         | string  | Editor to use for bulk renaming                                                    |
-| [show_as_mapping](#settings_editor_bulk_rename_show_as_mapping) | boolean | Show as a mapping of \`&lt;old&gt; ➔ &lt;new&gt;\` instead of just \`&lt;old&gt;\` |
+| Property                                                                      | Type    | Title/Description                                                                                                       |
+| ----------------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| [run](#settings_editor_bulk_editor_run)                                       | string  | Editor to use for bulk editing                                                                                          |
+| [rename_show_as_mapping](#settings_editor_bulk_editor_rename_show_as_mapping) | boolean | When doing a bulk rename, show as a mapping of \`&lt;old&gt; ➔ &lt;new&gt;\` instead of just showing only the new names |
 
-##### <a name="settings_editor_bulk_rename_run"></a>2.4.3.1. Property `Rovr Config > settings > editor > bulk_rename > run`
+##### <a name="settings_editor_bulk_editor_run"></a>2.4.3.1. Property `Rovr Config > settings > editor > bulk_editor > run`
 
 |              |             |
 | ------------ | ----------- |
@@ -1418,9 +1420,9 @@ Must be one of:
 | **Required** | No          |
 | **Default**  | `"$EDITOR"` |
 
-**Description:** Editor to use for bulk renaming
+**Description:** Editor to use for bulk editing
 
-##### <a name="settings_editor_bulk_rename_show_as_mapping"></a>2.4.3.2. Property `Rovr Config > settings > editor > bulk_rename > show_as_mapping`
+##### <a name="settings_editor_bulk_editor_rename_show_as_mapping"></a>2.4.3.2. Property `Rovr Config > settings > editor > bulk_editor > rename_show_as_mapping`
 
 |              |           |
 | ------------ | --------- |
@@ -1428,7 +1430,7 @@ Must be one of:
 | **Required** | No        |
 | **Default**  | `true`    |
 
-**Description:** Show as a mapping of `&lt;old&gt; ➔ &lt;new&gt;` instead of just `&lt;old&gt;`
+**Description:** When doing a bulk rename, show as a mapping of `&lt;old&gt; ➔ &lt;new&gt;` instead of just showing only the new names
 
 ### <a name="settings_preview_rules"></a>2.5. Property `Rovr Config > settings > preview_rules`
 
@@ -2250,6 +2252,7 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | [delete_files](#keybinds_delete_files)                                 | object          | Keybinds related to the delete confirmation screen                                                                                           |
 | [rename](#keybinds_rename)                                             | array of string | Rename the selected file in the file list to something else.                                                                                 |
 | [new](#keybinds_new)                                                   | array of string | Create a new item in the current directory.                                                                                                  |
+| [bulk_create](#keybinds_bulk_create)                                   | array of string | Bulk create files or folders using an editor list.                                                                                           |
 | [toggle_all](#keybinds_toggle_all)                                     | array of string | Enter into select mode and select/unselect everything.                                                                                       |
 | [zip](#keybinds_zip)                                                   | array of string | Create a zip archive from selected files.                                                                                                    |
 | [unzip](#keybinds_unzip)                                               | array of string | Extract a selected zip archive.                                                                                                              |
@@ -2950,7 +2953,36 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_toggle_all"></a>7.21. Property `Rovr Config > keybinds > toggle_all`
+### <a name="keybinds_bulk_create"></a>7.21. Property `Rovr Config > keybinds > bulk_create`
+
+|                |                       |
+| -------------- | --------------------- |
+| **Type**       | `array of string`     |
+| **Required**   | No                    |
+| **Defined in** | #/definitions/keybind |
+
+**Description:** Bulk create files or folders using an editor list.
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                | Description |
+| ---------------------------------------------- | ----------- |
+| [toggle_pin items](#keybinds_toggle_pin_items) |             |
+
+#### <a name="keybinds_toggle_pin_items"></a>7.21.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+### <a name="keybinds_toggle_all"></a>7.22. Property `Rovr Config > keybinds > toggle_all`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -2972,14 +3004,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.21.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.22.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_zip"></a>7.22. Property `Rovr Config > keybinds > zip`
+### <a name="keybinds_zip"></a>7.23. Property `Rovr Config > keybinds > zip`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3001,14 +3033,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.22.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.23.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_unzip"></a>7.23. Property `Rovr Config > keybinds > unzip`
+### <a name="keybinds_unzip"></a>7.24. Property `Rovr Config > keybinds > unzip`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3030,14 +3062,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.23.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.24.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_open_right_click_menu"></a>7.24. Property `Rovr Config > keybinds > open_right_click_menu`
+### <a name="keybinds_open_right_click_menu"></a>7.25. Property `Rovr Config > keybinds > open_right_click_menu`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3059,14 +3091,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.24.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.25.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_extra_copy"></a>7.25. Property `Rovr Config > keybinds > extra_copy`
+### <a name="keybinds_extra_copy"></a>7.26. Property `Rovr Config > keybinds > extra_copy`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -3084,7 +3116,7 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | [copy_to_system_clip](#keybinds_extra_copy_copy_to_system_clip)       | array of string | Copy the selected files to the system clipboard               |
 | [copy_current_directory](#keybinds_extra_copy_copy_current_directory) | array of string | Copy the current directory's path to the system clipboard     |
 
-#### <a name="keybinds_extra_copy_open_popup"></a>7.25.1. Property `Rovr Config > keybinds > extra_copy > open_popup`
+#### <a name="keybinds_extra_copy_open_popup"></a>7.26.1. Property `Rovr Config > keybinds > extra_copy > open_popup`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3106,14 +3138,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.25.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.26.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_extra_copy_copy_to_rovr"></a>7.25.2. Property `Rovr Config > keybinds > extra_copy > copy_to_rovr`
+#### <a name="keybinds_extra_copy_copy_to_rovr"></a>7.26.2. Property `Rovr Config > keybinds > extra_copy > copy_to_rovr`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3135,14 +3167,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.25.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.26.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_extra_copy_copy_highlighted"></a>7.25.3. Property `Rovr Config > keybinds > extra_copy > copy_highlighted`
+#### <a name="keybinds_extra_copy_copy_highlighted"></a>7.26.3. Property `Rovr Config > keybinds > extra_copy > copy_highlighted`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3164,14 +3196,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.25.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.26.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_extra_copy_copy_to_system_clip"></a>7.25.4. Property `Rovr Config > keybinds > extra_copy > copy_to_system_clip`
+#### <a name="keybinds_extra_copy_copy_to_system_clip"></a>7.26.4. Property `Rovr Config > keybinds > extra_copy > copy_to_system_clip`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3193,14 +3225,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.25.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.26.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_extra_copy_copy_current_directory"></a>7.25.5. Property `Rovr Config > keybinds > extra_copy > copy_current_directory`
+#### <a name="keybinds_extra_copy_copy_current_directory"></a>7.26.5. Property `Rovr Config > keybinds > extra_copy > copy_current_directory`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3222,14 +3254,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.25.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.26.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_up"></a>7.26. Property `Rovr Config > keybinds > up`
+### <a name="keybinds_up"></a>7.27. Property `Rovr Config > keybinds > up`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3251,14 +3283,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.26.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.27.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_down"></a>7.27. Property `Rovr Config > keybinds > down`
+### <a name="keybinds_down"></a>7.28. Property `Rovr Config > keybinds > down`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3280,14 +3312,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.27.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.28.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_up_tree"></a>7.28. Property `Rovr Config > keybinds > up_tree`
+### <a name="keybinds_up_tree"></a>7.29. Property `Rovr Config > keybinds > up_tree`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3309,14 +3341,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.28.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.29.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_down_tree"></a>7.29. Property `Rovr Config > keybinds > down_tree`
+### <a name="keybinds_down_tree"></a>7.30. Property `Rovr Config > keybinds > down_tree`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3338,14 +3370,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.29.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.30.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_bypass_up_tree"></a>7.30. Property `Rovr Config > keybinds > bypass_up_tree`
+### <a name="keybinds_bypass_up_tree"></a>7.31. Property `Rovr Config > keybinds > bypass_up_tree`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3367,14 +3399,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.30.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.31.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_bypass_down_tree"></a>7.31. Property `Rovr Config > keybinds > bypass_down_tree`
+### <a name="keybinds_bypass_down_tree"></a>7.32. Property `Rovr Config > keybinds > bypass_down_tree`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3396,14 +3428,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.31.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.32.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_page_up"></a>7.32. Property `Rovr Config > keybinds > page_up`
+### <a name="keybinds_page_up"></a>7.33. Property `Rovr Config > keybinds > page_up`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3425,14 +3457,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.32.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.33.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_page_down"></a>7.33. Property `Rovr Config > keybinds > page_down`
+### <a name="keybinds_page_down"></a>7.34. Property `Rovr Config > keybinds > page_down`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3454,14 +3486,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.33.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.34.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_home"></a>7.34. Property `Rovr Config > keybinds > home`
+### <a name="keybinds_home"></a>7.35. Property `Rovr Config > keybinds > home`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3483,14 +3515,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.34.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.35.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_end"></a>7.35. Property `Rovr Config > keybinds > end`
+### <a name="keybinds_end"></a>7.36. Property `Rovr Config > keybinds > end`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3512,14 +3544,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.35.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.36.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_hist_previous"></a>7.36. Property `Rovr Config > keybinds > hist_previous`
+### <a name="keybinds_hist_previous"></a>7.37. Property `Rovr Config > keybinds > hist_previous`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3541,14 +3573,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.36.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.37.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_hist_next"></a>7.37. Property `Rovr Config > keybinds > hist_next`
+### <a name="keybinds_hist_next"></a>7.38. Property `Rovr Config > keybinds > hist_next`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3570,14 +3602,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.37.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.38.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_toggle_visual"></a>7.38. Property `Rovr Config > keybinds > toggle_visual`
+### <a name="keybinds_toggle_visual"></a>7.39. Property `Rovr Config > keybinds > toggle_visual`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3599,14 +3631,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.38.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.39.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_toggle_hidden_files"></a>7.39. Property `Rovr Config > keybinds > toggle_hidden_files`
+### <a name="keybinds_toggle_hidden_files"></a>7.40. Property `Rovr Config > keybinds > toggle_hidden_files`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3628,14 +3660,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.39.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.40.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_toggle_select_item"></a>7.40. Property `Rovr Config > keybinds > toggle_select_item`
+### <a name="keybinds_toggle_select_item"></a>7.41. Property `Rovr Config > keybinds > toggle_select_item`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3657,14 +3689,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.40.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.41.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_select_up"></a>7.41. Property `Rovr Config > keybinds > select_up`
+### <a name="keybinds_select_up"></a>7.42. Property `Rovr Config > keybinds > select_up`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3686,14 +3718,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.41.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.42.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_select_down"></a>7.42. Property `Rovr Config > keybinds > select_down`
+### <a name="keybinds_select_down"></a>7.43. Property `Rovr Config > keybinds > select_down`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3715,14 +3747,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.42.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.43.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_select_page_up"></a>7.43. Property `Rovr Config > keybinds > select_page_up`
+### <a name="keybinds_select_page_up"></a>7.44. Property `Rovr Config > keybinds > select_page_up`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3744,14 +3776,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.43.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.44.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_select_page_down"></a>7.44. Property `Rovr Config > keybinds > select_page_down`
+### <a name="keybinds_select_page_down"></a>7.45. Property `Rovr Config > keybinds > select_page_down`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3773,14 +3805,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.44.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.45.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_select_home"></a>7.45. Property `Rovr Config > keybinds > select_home`
+### <a name="keybinds_select_home"></a>7.46. Property `Rovr Config > keybinds > select_home`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3802,14 +3834,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.45.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.46.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_select_end"></a>7.46. Property `Rovr Config > keybinds > select_end`
+### <a name="keybinds_select_end"></a>7.47. Property `Rovr Config > keybinds > select_end`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3831,14 +3863,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.46.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.47.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_tab_next"></a>7.47. Property `Rovr Config > keybinds > tab_next`
+### <a name="keybinds_tab_next"></a>7.48. Property `Rovr Config > keybinds > tab_next`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3860,14 +3892,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.47.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.48.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_tab_previous"></a>7.48. Property `Rovr Config > keybinds > tab_previous`
+### <a name="keybinds_tab_previous"></a>7.49. Property `Rovr Config > keybinds > tab_previous`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3889,14 +3921,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.48.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.49.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_tab_new"></a>7.49. Property `Rovr Config > keybinds > tab_new`
+### <a name="keybinds_tab_new"></a>7.50. Property `Rovr Config > keybinds > tab_new`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3918,14 +3950,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.49.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.50.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_tab_close"></a>7.50. Property `Rovr Config > keybinds > tab_close`
+### <a name="keybinds_tab_close"></a>7.51. Property `Rovr Config > keybinds > tab_close`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -3947,35 +3979,6 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.50.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
-
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | No       |
-
-### <a name="keybinds_preview_scroll_left"></a>7.51. Property `Rovr Config > keybinds > preview_scroll_left`
-
-|                |                       |
-| -------------- | --------------------- |
-| **Type**       | `array of string`     |
-| **Required**   | No                    |
-| **Defined in** | #/definitions/keybind |
-
-**Description:** Temporarily unused.
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | See below          |
-
-| Each item of this array must be                | Description |
-| ---------------------------------------------- | ----------- |
-| [toggle_pin items](#keybinds_toggle_pin_items) |             |
-
 #### <a name="keybinds_toggle_pin_items"></a>7.51.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
@@ -3983,7 +3986,7 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_preview_scroll_right"></a>7.52. Property `Rovr Config > keybinds > preview_scroll_right`
+### <a name="keybinds_preview_scroll_left"></a>7.52. Property `Rovr Config > keybinds > preview_scroll_left`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4012,7 +4015,7 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_preview_select_right"></a>7.53. Property `Rovr Config > keybinds > preview_select_right`
+### <a name="keybinds_preview_scroll_right"></a>7.53. Property `Rovr Config > keybinds > preview_scroll_right`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4041,7 +4044,7 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_preview_select_left"></a>7.54. Property `Rovr Config > keybinds > preview_select_left`
+### <a name="keybinds_preview_select_right"></a>7.54. Property `Rovr Config > keybinds > preview_select_right`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4070,7 +4073,36 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_show_keybinds"></a>7.55. Property `Rovr Config > keybinds > show_keybinds`
+### <a name="keybinds_preview_select_left"></a>7.55. Property `Rovr Config > keybinds > preview_select_left`
+
+|                |                       |
+| -------------- | --------------------- |
+| **Type**       | `array of string`     |
+| **Required**   | No                    |
+| **Defined in** | #/definitions/keybind |
+
+**Description:** Temporarily unused.
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                | Description |
+| ---------------------------------------------- | ----------- |
+| [toggle_pin items](#keybinds_toggle_pin_items) |             |
+
+#### <a name="keybinds_toggle_pin_items"></a>7.55.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+### <a name="keybinds_show_keybinds"></a>7.56. Property `Rovr Config > keybinds > show_keybinds`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4092,14 +4124,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.55.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.56.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_change_sort_order"></a>7.56. Property `Rovr Config > keybinds > change_sort_order`
+### <a name="keybinds_change_sort_order"></a>7.57. Property `Rovr Config > keybinds > change_sort_order`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -4120,7 +4152,7 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | [modified](#keybinds_change_sort_order_modified)     | array of string | Sort by modification time.        |
 | [descending](#keybinds_change_sort_order_descending) | array of string | Toggle descending sort order.     |
 
-#### <a name="keybinds_change_sort_order_open_popup"></a>7.56.1. Property `Rovr Config > keybinds > change_sort_order > open_popup`
+#### <a name="keybinds_change_sort_order_open_popup"></a>7.57.1. Property `Rovr Config > keybinds > change_sort_order > open_popup`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4142,14 +4174,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.56.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.57.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_change_sort_order_name"></a>7.56.2. Property `Rovr Config > keybinds > change_sort_order > name`
+#### <a name="keybinds_change_sort_order_name"></a>7.57.2. Property `Rovr Config > keybinds > change_sort_order > name`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4171,14 +4203,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.56.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.57.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_change_sort_order_extension"></a>7.56.3. Property `Rovr Config > keybinds > change_sort_order > extension`
+#### <a name="keybinds_change_sort_order_extension"></a>7.57.3. Property `Rovr Config > keybinds > change_sort_order > extension`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4200,14 +4232,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.56.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.57.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_change_sort_order_natural"></a>7.56.4. Property `Rovr Config > keybinds > change_sort_order > natural`
+#### <a name="keybinds_change_sort_order_natural"></a>7.57.4. Property `Rovr Config > keybinds > change_sort_order > natural`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4229,14 +4261,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.56.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.57.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_change_sort_order_size"></a>7.56.5. Property `Rovr Config > keybinds > change_sort_order > size`
+#### <a name="keybinds_change_sort_order_size"></a>7.57.5. Property `Rovr Config > keybinds > change_sort_order > size`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4258,14 +4290,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.56.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.57.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_change_sort_order_created"></a>7.56.6. Property `Rovr Config > keybinds > change_sort_order > created`
+#### <a name="keybinds_change_sort_order_created"></a>7.57.6. Property `Rovr Config > keybinds > change_sort_order > created`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4287,14 +4319,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.56.6.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.57.6.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_change_sort_order_modified"></a>7.56.7. Property `Rovr Config > keybinds > change_sort_order > modified`
+#### <a name="keybinds_change_sort_order_modified"></a>7.57.7. Property `Rovr Config > keybinds > change_sort_order > modified`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4316,14 +4348,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.56.7.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.57.7.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_change_sort_order_descending"></a>7.56.8. Property `Rovr Config > keybinds > change_sort_order > descending`
+#### <a name="keybinds_change_sort_order_descending"></a>7.57.8. Property `Rovr Config > keybinds > change_sort_order > descending`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4345,14 +4377,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.56.8.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.57.8.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_quit_app"></a>7.57. Property `Rovr Config > keybinds > quit_app`
+### <a name="keybinds_quit_app"></a>7.58. Property `Rovr Config > keybinds > quit_app`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4374,14 +4406,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.57.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.58.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_command_palette"></a>7.58. Property `Rovr Config > keybinds > command_palette`
+### <a name="keybinds_command_palette"></a>7.59. Property `Rovr Config > keybinds > command_palette`
 
 |              |          |
 | ------------ | -------- |
@@ -4390,7 +4422,7 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 
 **Description:** Launch Textual's mildly useful command palette (only one keybind is allowed!)
 
-### <a name="keybinds_suspend_process"></a>7.59. Property `Rovr Config > keybinds > suspend_process`
+### <a name="keybinds_suspend_process"></a>7.60. Property `Rovr Config > keybinds > suspend_process`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4412,14 +4444,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.59.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.60.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_open_editor"></a>7.60. Property `Rovr Config > keybinds > open_editor`
+### <a name="keybinds_open_editor"></a>7.61. Property `Rovr Config > keybinds > open_editor`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4441,14 +4473,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.60.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.61.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_show_shell_screen"></a>7.61. Property `Rovr Config > keybinds > show_shell_screen`
+### <a name="keybinds_show_shell_screen"></a>7.62. Property `Rovr Config > keybinds > show_shell_screen`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4470,14 +4502,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-#### <a name="keybinds_toggle_pin_items"></a>7.61.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+#### <a name="keybinds_toggle_pin_items"></a>7.62.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_filename_conflict"></a>7.62. Property `Rovr Config > keybinds > filename_conflict`
+### <a name="keybinds_filename_conflict"></a>7.63. Property `Rovr Config > keybinds > filename_conflict`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -4495,7 +4527,7 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | [cancel](#keybinds_filename_conflict_cancel)                 | array of string | Cancel the entire copy/move operation.                                  |
 | [dont_ask_again](#keybinds_filename_conflict_dont_ask_again) | array of string | Apply the selected action to all future conflicts without asking again. |
 
-#### <a name="keybinds_filename_conflict_overwrite"></a>7.62.1. Property `Rovr Config > keybinds > filename_conflict > overwrite`
+#### <a name="keybinds_filename_conflict_overwrite"></a>7.63.1. Property `Rovr Config > keybinds > filename_conflict > overwrite`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4517,168 +4549,6 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.62.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
-
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | No       |
-
-#### <a name="keybinds_filename_conflict_skip"></a>7.62.2. Property `Rovr Config > keybinds > filename_conflict > skip`
-
-|                |                       |
-| -------------- | --------------------- |
-| **Type**       | `array of string`     |
-| **Required**   | No                    |
-| **Defined in** | #/definitions/keybind |
-
-**Description:** Skip this file and do not copy/move it.
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | See below          |
-
-| Each item of this array must be                | Description |
-| ---------------------------------------------- | ----------- |
-| [toggle_pin items](#keybinds_toggle_pin_items) |             |
-
-##### <a name="keybinds_toggle_pin_items"></a>7.62.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
-
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | No       |
-
-#### <a name="keybinds_filename_conflict_rename"></a>7.62.3. Property `Rovr Config > keybinds > filename_conflict > rename`
-
-|                |                       |
-| -------------- | --------------------- |
-| **Type**       | `array of string`     |
-| **Required**   | No                    |
-| **Defined in** | #/definitions/keybind |
-
-**Description:** Rename the new file being copied/moved.
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | See below          |
-
-| Each item of this array must be                | Description |
-| ---------------------------------------------- | ----------- |
-| [toggle_pin items](#keybinds_toggle_pin_items) |             |
-
-##### <a name="keybinds_toggle_pin_items"></a>7.62.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
-
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | No       |
-
-#### <a name="keybinds_filename_conflict_cancel"></a>7.62.4. Property `Rovr Config > keybinds > filename_conflict > cancel`
-
-|                |                       |
-| -------------- | --------------------- |
-| **Type**       | `array of string`     |
-| **Required**   | No                    |
-| **Defined in** | #/definitions/keybind |
-
-**Description:** Cancel the entire copy/move operation.
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | See below          |
-
-| Each item of this array must be                | Description |
-| ---------------------------------------------- | ----------- |
-| [toggle_pin items](#keybinds_toggle_pin_items) |             |
-
-##### <a name="keybinds_toggle_pin_items"></a>7.62.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
-
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | No       |
-
-#### <a name="keybinds_filename_conflict_dont_ask_again"></a>7.62.5. Property `Rovr Config > keybinds > filename_conflict > dont_ask_again`
-
-|                |                       |
-| -------------- | --------------------- |
-| **Type**       | `array of string`     |
-| **Required**   | No                    |
-| **Defined in** | #/definitions/keybind |
-
-**Description:** Apply the selected action to all future conflicts without asking again.
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | See below          |
-
-| Each item of this array must be                | Description |
-| ---------------------------------------------- | ----------- |
-| [toggle_pin items](#keybinds_toggle_pin_items) |             |
-
-##### <a name="keybinds_toggle_pin_items"></a>7.62.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
-
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | No       |
-
-### <a name="keybinds_file_in_use"></a>7.63. Property `Rovr Config > keybinds > file_in_use`
-
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
-
-**Description:** Keybinds related to handling a file that is in use by another process
-
-| Property                                               | Type            | Title/Description                                                                  |
-| ------------------------------------------------------ | --------------- | ---------------------------------------------------------------------------------- |
-| [retry](#keybinds_file_in_use_retry)                   | array of string | Retry the operation on the file.                                                   |
-| [skip](#keybinds_file_in_use_skip)                     | array of string | Skip this file and do not copy/move it.                                            |
-| [cancel](#keybinds_file_in_use_cancel)                 | array of string | Cancel the entire copy/move operation.                                             |
-| [dont_ask_again](#keybinds_file_in_use_dont_ask_again) | array of string | Apply the selected action to all future 'file in use' errors without asking again. |
-
-#### <a name="keybinds_file_in_use_retry"></a>7.63.1. Property `Rovr Config > keybinds > file_in_use > retry`
-
-|                |                       |
-| -------------- | --------------------- |
-| **Type**       | `array of string`     |
-| **Required**   | No                    |
-| **Defined in** | #/definitions/keybind |
-
-**Description:** Retry the operation on the file.
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | See below          |
-
-| Each item of this array must be                | Description |
-| ---------------------------------------------- | ----------- |
-| [toggle_pin items](#keybinds_toggle_pin_items) |             |
-
 ##### <a name="keybinds_toggle_pin_items"></a>7.63.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
@@ -4686,7 +4556,7 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_file_in_use_skip"></a>7.63.2. Property `Rovr Config > keybinds > file_in_use > skip`
+#### <a name="keybinds_filename_conflict_skip"></a>7.63.2. Property `Rovr Config > keybinds > filename_conflict > skip`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4715,7 +4585,36 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_file_in_use_cancel"></a>7.63.3. Property `Rovr Config > keybinds > file_in_use > cancel`
+#### <a name="keybinds_filename_conflict_rename"></a>7.63.3. Property `Rovr Config > keybinds > filename_conflict > rename`
+
+|                |                       |
+| -------------- | --------------------- |
+| **Type**       | `array of string`     |
+| **Required**   | No                    |
+| **Defined in** | #/definitions/keybind |
+
+**Description:** Rename the new file being copied/moved.
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                | Description |
+| ---------------------------------------------- | ----------- |
+| [toggle_pin items](#keybinds_toggle_pin_items) |             |
+
+##### <a name="keybinds_toggle_pin_items"></a>7.63.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+#### <a name="keybinds_filename_conflict_cancel"></a>7.63.4. Property `Rovr Config > keybinds > filename_conflict > cancel`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4737,14 +4636,147 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.63.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.63.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_file_in_use_dont_ask_again"></a>7.63.4. Property `Rovr Config > keybinds > file_in_use > dont_ask_again`
+#### <a name="keybinds_filename_conflict_dont_ask_again"></a>7.63.5. Property `Rovr Config > keybinds > filename_conflict > dont_ask_again`
+
+|                |                       |
+| -------------- | --------------------- |
+| **Type**       | `array of string`     |
+| **Required**   | No                    |
+| **Defined in** | #/definitions/keybind |
+
+**Description:** Apply the selected action to all future conflicts without asking again.
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                | Description |
+| ---------------------------------------------- | ----------- |
+| [toggle_pin items](#keybinds_toggle_pin_items) |             |
+
+##### <a name="keybinds_toggle_pin_items"></a>7.63.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+### <a name="keybinds_file_in_use"></a>7.64. Property `Rovr Config > keybinds > file_in_use`
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** Keybinds related to handling a file that is in use by another process
+
+| Property                                               | Type            | Title/Description                                                                  |
+| ------------------------------------------------------ | --------------- | ---------------------------------------------------------------------------------- |
+| [retry](#keybinds_file_in_use_retry)                   | array of string | Retry the operation on the file.                                                   |
+| [skip](#keybinds_file_in_use_skip)                     | array of string | Skip this file and do not copy/move it.                                            |
+| [cancel](#keybinds_file_in_use_cancel)                 | array of string | Cancel the entire copy/move operation.                                             |
+| [dont_ask_again](#keybinds_file_in_use_dont_ask_again) | array of string | Apply the selected action to all future 'file in use' errors without asking again. |
+
+#### <a name="keybinds_file_in_use_retry"></a>7.64.1. Property `Rovr Config > keybinds > file_in_use > retry`
+
+|                |                       |
+| -------------- | --------------------- |
+| **Type**       | `array of string`     |
+| **Required**   | No                    |
+| **Defined in** | #/definitions/keybind |
+
+**Description:** Retry the operation on the file.
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                | Description |
+| ---------------------------------------------- | ----------- |
+| [toggle_pin items](#keybinds_toggle_pin_items) |             |
+
+##### <a name="keybinds_toggle_pin_items"></a>7.64.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+#### <a name="keybinds_file_in_use_skip"></a>7.64.2. Property `Rovr Config > keybinds > file_in_use > skip`
+
+|                |                       |
+| -------------- | --------------------- |
+| **Type**       | `array of string`     |
+| **Required**   | No                    |
+| **Defined in** | #/definitions/keybind |
+
+**Description:** Skip this file and do not copy/move it.
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                | Description |
+| ---------------------------------------------- | ----------- |
+| [toggle_pin items](#keybinds_toggle_pin_items) |             |
+
+##### <a name="keybinds_toggle_pin_items"></a>7.64.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+#### <a name="keybinds_file_in_use_cancel"></a>7.64.3. Property `Rovr Config > keybinds > file_in_use > cancel`
+
+|                |                       |
+| -------------- | --------------------- |
+| **Type**       | `array of string`     |
+| **Required**   | No                    |
+| **Defined in** | #/definitions/keybind |
+
+**Description:** Cancel the entire copy/move operation.
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                | Description |
+| ---------------------------------------------- | ----------- |
+| [toggle_pin items](#keybinds_toggle_pin_items) |             |
+
+##### <a name="keybinds_toggle_pin_items"></a>7.64.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+#### <a name="keybinds_file_in_use_dont_ask_again"></a>7.64.4. Property `Rovr Config > keybinds > file_in_use > dont_ask_again`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4766,14 +4798,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.63.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.64.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_filter_modal"></a>7.64. Property `Rovr Config > keybinds > filter_modal`
+### <a name="keybinds_filter_modal"></a>7.65. Property `Rovr Config > keybinds > filter_modal`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -4791,7 +4823,7 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | [page_down](#keybinds_filter_modal_page_down) | array of string | Move the selection down by a page in the modal list. |
 | [page_up](#keybinds_filter_modal_page_up)     | array of string | Move the selection up by a page in the modal list.   |
 
-#### <a name="keybinds_filter_modal_exit"></a>7.64.1. Property `Rovr Config > keybinds > filter_modal > exit`
+#### <a name="keybinds_filter_modal_exit"></a>7.65.1. Property `Rovr Config > keybinds > filter_modal > exit`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4813,14 +4845,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.64.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.65.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_filter_modal_down"></a>7.64.2. Property `Rovr Config > keybinds > filter_modal > down`
+#### <a name="keybinds_filter_modal_down"></a>7.65.2. Property `Rovr Config > keybinds > filter_modal > down`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4842,14 +4874,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.64.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.65.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_filter_modal_up"></a>7.64.3. Property `Rovr Config > keybinds > filter_modal > up`
+#### <a name="keybinds_filter_modal_up"></a>7.65.3. Property `Rovr Config > keybinds > filter_modal > up`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4871,14 +4903,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.64.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.65.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_filter_modal_page_down"></a>7.64.4. Property `Rovr Config > keybinds > filter_modal > page_down`
+#### <a name="keybinds_filter_modal_page_down"></a>7.65.4. Property `Rovr Config > keybinds > filter_modal > page_down`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4900,14 +4932,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.64.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.65.4.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_filter_modal_page_up"></a>7.64.5. Property `Rovr Config > keybinds > filter_modal > page_up`
+#### <a name="keybinds_filter_modal_page_up"></a>7.65.5. Property `Rovr Config > keybinds > filter_modal > page_up`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4929,14 +4961,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.64.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.65.5.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="keybinds_yes_or_no"></a>7.65. Property `Rovr Config > keybinds > yes_or_no`
+### <a name="keybinds_yes_or_no"></a>7.66. Property `Rovr Config > keybinds > yes_or_no`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -4952,7 +4984,7 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | [no](#keybinds_yes_or_no_no)                         | array of string | Decline with 'no'.                                                          |
 | [dont_ask_again](#keybinds_yes_or_no_dont_ask_again) | array of string | Apply the selected action to all future confirmations without asking again. |
 
-#### <a name="keybinds_yes_or_no_yes"></a>7.65.1. Property `Rovr Config > keybinds > yes_or_no > yes`
+#### <a name="keybinds_yes_or_no_yes"></a>7.66.1. Property `Rovr Config > keybinds > yes_or_no > yes`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -4974,14 +5006,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.65.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.66.1.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_yes_or_no_no"></a>7.65.2. Property `Rovr Config > keybinds > yes_or_no > no`
+#### <a name="keybinds_yes_or_no_no"></a>7.66.2. Property `Rovr Config > keybinds > yes_or_no > no`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -5003,14 +5035,14 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.65.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.66.2.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-#### <a name="keybinds_yes_or_no_dont_ask_again"></a>7.65.3. Property `Rovr Config > keybinds > yes_or_no > dont_ask_again`
+#### <a name="keybinds_yes_or_no_dont_ask_again"></a>7.66.3. Property `Rovr Config > keybinds > yes_or_no > dont_ask_again`
 
 |                |                       |
 | -------------- | --------------------- |
@@ -5032,7 +5064,7 @@ Refer to https://textual.textualize.io/guide/design/#additional-variables for mo
 | ---------------------------------------------- | ----------- |
 | [toggle_pin items](#keybinds_toggle_pin_items) |             |
 
-##### <a name="keybinds_toggle_pin_items"></a>7.65.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
+##### <a name="keybinds_toggle_pin_items"></a>7.66.3.1. Rovr Config > keybinds > toggle_pin > toggle_pin items
 
 |              |          |
 | ------------ | -------- |

--- a/src/rovr/action_buttons/new_item_button.py
+++ b/src/rovr/action_buttons/new_item_button.py
@@ -1,8 +1,10 @@
 import contextlib
+import shlex
 from os import getcwd, makedirs, path
+from tempfile import NamedTemporaryFile
 from typing import cast
 
-from textual import work
+from textual import events, work
 from textual.content import Content
 from textual.widgets import Button
 from textual.worker import Worker, WorkerError
@@ -10,6 +12,7 @@ from textual.worker import Worker, WorkerError
 from rovr.classes.textual_validators import IsValidFilePath, PathNoLongerExists
 from rovr.functions.icons import get_icon
 from rovr.functions.path import dump_exc, normalise
+from rovr.functions.utils import run_command
 from rovr.screens import ModalInput
 from rovr.variables.constants import config
 
@@ -21,6 +24,14 @@ class NewItemButton(Button):
         super().__init__(get_icon("general", "new")[0], classes="option", id="new")
         if config["interface"]["tooltips"]:
             self.tooltip = "Create a new file or directory"
+
+    async def _on_click(self, event: events.Click) -> None:
+        event.stop().prevent_default()
+        if not self.has_class("-active"):
+            if event.button == 1:
+                self.press()
+            else:
+                await self.action_bulk_create()
 
     @work
     async def on_button_pressed(self) -> None:
@@ -119,3 +130,118 @@ class NewItemButton(Button):
             dump_exc(self, exc)
         finally:
             self.app.file_list.file_list_pause_check = False
+
+    @work
+    async def action_bulk_create(self) -> None:
+        temp = NamedTemporaryFile("w", encoding="utf-8", delete=False)  # noqa: SIM115
+        temp_path = temp.name
+        temp.write("")
+        temp.flush()
+        temp.close()
+
+        bulk_editor = config["settings"]["editor"]["bulk_editor"]
+
+        def on_error(message: str, title: str) -> None:
+            self.notify(message, title=title, severity="error", markup=False)
+
+        try:
+            run_command(
+                self.app,
+                shlex.split(bulk_editor["run"]) + [temp_path],
+                orphan=False,
+                shell=False,
+                on_error=on_error,
+            )
+        except FileNotFoundError:
+            self.notify(
+                f"Editor '{bulk_editor['run']}' not found. Check your config.",
+                title="Editor not found",
+                severity="error",
+                markup=False,
+            )
+            return
+        except Exception as exc:
+            dump_exc(self, exc)
+            self.notify(
+                f"{type(exc).__name__}: {exc}",
+                title="Error launching editor",
+                severity="error",
+                markup=False,
+            )
+            return
+
+        with open(temp_path, encoding="utf-8") as file_handle:
+            lines = [line.strip() for line in file_handle.read().splitlines()]
+
+        entries = [line for line in lines if line]
+        if not entries:
+            self.notify(
+                "No entries provided.",
+                title="Bulk Create",
+                severity="warning",
+                markup=False,
+            )
+            return
+
+        created: list[str] = []
+        already_exists: list[str] = []
+        errors: list[str] = []
+
+        for entry in entries:
+            is_dir = entry.endswith(("/", "\\"))
+            location = normalise(path.join(getcwd(), entry))
+            if is_dir:
+                location = location + "/"
+            try:
+                if is_dir:
+                    makedirs(location, exist_ok=False)
+                else:
+                    dir_path = path.dirname(location)
+                    if dir_path:
+                        makedirs(dir_path, exist_ok=True)
+                    with open(location, "x") as created_file:
+                        created_file.write("")
+                created.append(location)
+            except FileExistsError:
+                already_exists.append(entry)
+            except Exception as exc:
+                errors.append(f"{entry}: {type(exc).__name__}: {exc}")
+
+        if created:
+            try:
+                self.app.file_list.file_list_pause_check = True
+                self.app.file_list.focus()
+                focus_on = path.basename(created[0].rstrip("/"))
+                worker = self.app.file_list.update_file_list(
+                    add_to_session=False, focus_on=focus_on
+                )
+                with contextlib.suppress(WorkerError):
+                    await worker.wait()
+            except Exception as exc:
+                dump_exc(self, exc)
+            finally:
+                self.app.file_list.file_list_pause_check = False
+
+        if already_exists:
+            self.notify(
+                "Some items already exist:\n" + "\n".join(already_exists),
+                title="Bulk Create",
+                severity="warning",
+                markup=False,
+            )
+        if errors:
+            self.notify(
+                "Errors while creating:\n" + "\n".join(errors),
+                title="Bulk Create",
+                severity="error",
+                markup=False,
+            )
+        if created:
+            self.notify(
+                f"Created {len(created)} item(s).",
+                title="Bulk Create",
+                severity="information",
+                markup=False,
+            )
+        with contextlib.suppress(OSError):
+            path.unlink(temp_path)

--- a/src/rovr/action_buttons/rename_item_button.py
+++ b/src/rovr/action_buttons/rename_item_button.py
@@ -93,10 +93,9 @@ class RenameItemButton(Button):
             # if, IF a human got this exception, please virtually slap me.
             highlighted_file = self.app.file_list.highlighted_option.dir_entry.name
 
+            bulk_editor = config["settings"]["editor"]["bulk_editor"]
             # create file
-            show_as_mapping: bool = config["settings"]["editor"]["bulk_rename"][
-                "show_as_mapping"
-            ]
+            show_as_mapping: bool = bulk_editor["rename_show_as_mapping"]
 
             temp = NamedTemporaryFile(  # noqa: SIM115
                 "w", encoding="utf-8", delete=False
@@ -116,9 +115,6 @@ class RenameItemButton(Button):
                         temp.write(f"{selectedItem}\n")
                 temp.flush()
                 temp.close()
-
-                # spawn editor
-                bulk_editor = config["settings"]["editor"]["bulk_rename"]
 
                 def on_error(message: str, title: str) -> None:
                     self.notify(message, title=title, severity="error", markup=False)

--- a/src/rovr/classes/config.py
+++ b/src/rovr/classes/config.py
@@ -298,12 +298,12 @@ _ROVR_CONFIG_SETTINGS_COPY_INCLUDES_METADATA_DEFAULT = True
 r""" Default value of the field path 'Rovr Config settings copy_includes_metadata' """
 
 
-_ROVR_CONFIG_SETTINGS_EDITOR_BULK_RENAME_RUN_DEFAULT = "$EDITOR"
-r""" Default value of the field path 'Rovr Config settings editor bulk_rename run' """
+_ROVR_CONFIG_SETTINGS_EDITOR_BULK_EDITOR_RENAME_SHOW_AS_MAPPING_DEFAULT = True
+r""" Default value of the field path 'Rovr Config settings editor bulk_editor rename_show_as_mapping' """
 
 
-_ROVR_CONFIG_SETTINGS_EDITOR_BULK_RENAME_SHOW_AS_MAPPING_DEFAULT = True
-r""" Default value of the field path 'Rovr Config settings editor bulk_rename show_as_mapping' """
+_ROVR_CONFIG_SETTINGS_EDITOR_BULK_EDITOR_RUN_DEFAULT = "$EDITOR"
+r""" Default value of the field path 'Rovr Config settings editor bulk_editor run' """
 
 
 _ROVR_CONFIG_SETTINGS_EDITOR_FILE_ORPHAN_DEFAULT = True
@@ -937,6 +937,7 @@ class _RovrConfigKeybinds(TypedDict, total=False):
 
     rename: list[str]
     new: list[str]
+    bulk_create: list[str]
     toggle_all: list[str]
     zip: list[str]
     unzip: list[str]
@@ -1469,23 +1470,23 @@ class _RovrConfigSettingsEditor(TypedDict, total=False):
     folder: "_RovrConfigSettingsEditorFolder"
     r""" Editor to use when opening a folder """
 
-    bulk_rename: "_RovrConfigSettingsEditorBulkRename"
-    r""" Editor to use for bulk renaming """
+    bulk_editor: "_RovrConfigSettingsEditorBulkEditor"
+    r""" Editor to use for bulk editing """
 
 
-class _RovrConfigSettingsEditorBulkRename(TypedDict, total=False):
-    r"""Editor to use for bulk renaming"""
+class _RovrConfigSettingsEditorBulkEditor(TypedDict, total=False):
+    r"""Editor to use for bulk editing"""
 
     run: str
     r"""
-    Editor to use for bulk renaming
+    Editor to use for bulk editing
 
     default: $EDITOR
     """
 
-    show_as_mapping: bool
+    rename_show_as_mapping: bool
     r"""
-    Show as a mapping of `<old> ➔ <new>` instead of just `<old>`
+    When doing a bulk rename, show as a mapping of `<old> ➔ <new>` instead of just showing only the new names
 
     default: True
     """

--- a/src/rovr/config/config.toml
+++ b/src/rovr/config/config.toml
@@ -113,8 +113,8 @@ orphan = false
 run = "$EDITOR"
 orphan = false
 
-[settings.editor.bulk_rename]
-show_as_mapping = true
+[settings.editor.bulk_editor]
+rename_show_as_mapping = true
 run = "$EDITOR"
 
 [metadata]
@@ -200,6 +200,8 @@ cut = ["x", "ctrl+x"]
 delete = ["d", "delete"]
 rename = ["r", "f2"]
 new = ["ctrl+n", "o"]
+# shift+n or shift+o, it isnt literally NO
+bulk_create = ["N", "O"]
 zip = ["E"]
 unzip = ["ctrl+e"]
 # id love to use ctrl+shift+c

--- a/src/rovr/config/keybinds/sane.toml
+++ b/src/rovr/config/keybinds/sane.toml
@@ -1,8 +1,5 @@
 # Sane stuff
 
-[settings.bulk_rename]
-show_as_mapping = true
-
 [keybinds]
 toggle_pin = ["P"]
 toggle_pinned_sidebar = ["S"]
@@ -24,6 +21,7 @@ cut = ["ctrl+x"]
 delete = ["delete"]
 rename = ["f2"]
 new = ["ctrl+n"]
+bulk_create = ["ctrl+shift+n"]
 # off standard but seems reasonable enough
 zip = ["E"]
 unzip = ["ctrl+e"]

--- a/src/rovr/config/keybinds/vim.toml
+++ b/src/rovr/config/keybinds/vim.toml
@@ -1,8 +1,5 @@
 # vim stuff
 
-[settings.bulk_rename]
-show_as_mapping = false
-
 [keybinds]
 toggle_pin = ["P"]
 toggle_pinned_sidebar = ["S"]
@@ -23,6 +20,7 @@ cut = ["x"]
 delete = ["d"]
 rename = ["r"]
 new = ["o"]
+bulk_create = ["O"]
 zip = ["E"]
 unzip = ["ctrl+e"]
 up = ["k", "up"]

--- a/src/rovr/config/migration.json
+++ b/src/rovr/config/migration.json
@@ -1,5 +1,31 @@
 [
   {
+    "keys": ["settings.editor.bulk_rename"],
+    "message": [
+      "The [bright_cyan]settings.editor.bulk_rename[/] has been renamed to [bright_cyan]settings.editor.bulk_[b]editor[/][/] to give way for a bulk creator"
+    ],
+    "extra": "Renamed in v0.9.0",
+    "regex": [
+      {
+        "find": "settings.editor.bulk_rename",
+        "replace": "settings.editor.bulk_editor"
+      }
+    ]
+  },
+  {
+    "keys": ["settings.editor.bulk_rename.show_as_mapping"],
+    "message": [
+      "The [bright_cyan]settings.editor.bulk_rename.show_as_mapping[/] has been renamed to [bright_cyan]settings.editor.bulk_editor.rename_show_as_mapping[/] to reflect the change in the parent setting."
+    ],
+    "extra": "Renamed in v0.9.0",
+    "regex": [
+      {
+        "find": "settings.editor.bulk_rename.show_as_mapping",
+        "replace": "settings.editor.bulk_editor.rename_show_as_mapping"
+      }
+    ]
+  },
+  {
     "keys": ["settings.editor.file.block", "settings.editor.file.suspend", "settings.editor.folder.block", "settings.editor.folder.suspend", "settings.editor.bulk_rename.suspend"],
     "message": [
       "You can no longer block the UI when opening a file or folder. You can either open it as an orphan process or suspend the app.",

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -380,22 +380,22 @@
               "description": "Editor to use when opening a folder",
               "required": ["run", "orphan"]
             },
-            "bulk_rename": {
+            "bulk_editor": {
               "type": "object",
               "additionalProperties": false,
               "properties": {
                 "run": {
                   "type": "string",
                   "default": "$EDITOR",
-                  "description": "Editor to use for bulk renaming"
+                  "description": "Editor to use for bulk editing"
                 },
-                "show_as_mapping": {
+                "rename_show_as_mapping": {
                   "type": "boolean",
                   "default": true,
-                  "description": "Show as a mapping of `<old> ➔ <new>` instead of just `<old>`"
+                  "description": "When doing a bulk rename, show as a mapping of `<old> ➔ <new>` instead of just showing only the new names"
                 }
               },
-              "description": "Editor to use for bulk renaming"
+              "description": "Editor to use for bulk editing"
             }
           }
         },
@@ -832,6 +832,11 @@
           "$ref": "#/definitions/keybind",
           "description": "Create a new item in the current directory.",
           "display_name": "New"
+        },
+        "bulk_create": {
+          "$ref": "#/definitions/keybind",
+          "description": "Bulk create files or folders using an editor list.",
+          "display_name": "Bulk create"
         },
         "toggle_all": {
           "$ref": "#/definitions/keybind",

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -62,6 +62,7 @@ class FileList(
             "cut",
             "paste",
             "new",
+            "bulk_create",
             "rename",
             "delete",
             "zip",
@@ -750,6 +751,9 @@ class FileList(
 
     def action_new(self) -> None:
         self.app.query_one("#new").action_press()
+
+    async def action_bulk_create(self) -> None:
+        self.app.query_one("#new").action_bulk_create()
 
     def action_rename(self) -> None:
         self.app.query_one("#rename").action_press()

--- a/src/rovr/first_launch.py
+++ b/src/rovr/first_launch.py
@@ -415,13 +415,15 @@ open_all_in_editor = false
 
 [settings.editor.file]
 run = "{_escape_toml_string(self.query_one("#editor_input", Input).value)}"
-block = false
-suspend = true
+orphan = false
 
 [settings.editor.folder]
 run = "{_escape_toml_string(self.query_one("#editor_folders_input", Input).value)}"
-block = false
-suspend = true
+orphan = false
+
+[settings.editor.bulk_editor]
+run = "{_escape_toml_string(self.query_one("#editor_input", Input).value)}"
+rename_show_as_mapping = {str(bool(self.query_one("#keybinds", RadioSet).pressed_button.id == "sane")).lower()}
 
 [theme]
 default = "{theme}"

--- a/src/rovr/functions/config.py
+++ b/src/rovr/functions/config.py
@@ -611,7 +611,7 @@ def load_config() -> tuple[dict, RovrConfig]:
         # sixel for some weird unknown reason
         config_dict["interface"]["image_viewer"]["protocol"] = ""
 
-    for key in ["file", "folder", "bulk_rename"]:
+    for key in ["file", "folder", "bulk_editor"]:
         raw_run = config_dict["settings"]["editor"][key]["run"]
         expanded_run = os.path.expandvars(raw_run)
         if expanded_run == raw_run and any(

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -186,6 +186,8 @@ def run_command(
             )
     else:
         with app.suspend():
+            if globals().get("is_dev", False):
+                print(command)
             process = subprocess.run(command, shell=shell)
         if process.returncode != 0 and on_error:
             on_error(f"Error Code {process.returncode}", "Editor Error")


### PR DESCRIPTION
is it really stolen from https://github.com/sxyazi/yazi/pull/3793? or maybe i was thinking about this all along...

anyways yeah batch creation, breaking change involves bulk rename because i didnt think we need two separate configs for what is essentially almost the same thing

video soon, too lazy, am on my phone

---

may need to update docs for this feature and update migration.json

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible
- [ ] the documentation has been updated wherever necessary (run `poe gen-schema` and `poe gen-keys` if applicable)

## Summary by Sourcery

Introduce a configurable bulk editor flow that supports batch creation and renaming, and wire it into new keybindings and editor settings.

New Features:
- Add bulk_create action and keybindings to create multiple files and folders via an editor-driven list.
- Add a bulk_editor configuration block used for both bulk renaming and batch creation workflows.

Enhancements:
- Refine editor configuration semantics to use an orphan flag for file and folder editors and make bulk editor blocking behavior implicit.
- Unify and rename bulk_rename settings and fields to bulk_editor and rename_show_as_mapping for clearer behavior and future extensibility.

Documentation:
- Update editor and schema/keybinding documentation to describe the new bulk editor, bulk_create keybind, and revised editor options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk create: launch an external bulk editor to author multiple new files/folders at once; accessible from the toolbar and new keybinding(s).

* **Documentation**
  * Docs and schema updated for a new bulk editor section and the renamed option rename_show_as_mapping; keybindings reference now documents bulk_create.

* **Chores**
  * First-run config populated with bulk editor settings; individual file/folder editor options now use orphan behaviour while bulk editor waits for completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NSPC911/rovr/pull/283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->