### PR TITLE
feat(app): allow drag and drop from gui to terminal using bracketed paste

### DIFF
--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -77,7 +77,9 @@ from rovr.navigation_widgets import (
     PathInput,
     UpButton,
 )
-from rovr.screens.typed import ShellExecReturnType
+from rovr.screens.drag_and_drop import DragAndDropScreen
+from rovr.screens.typed import DragAndDropReturnType, ShellExecReturnType
+from rovr.screens.way_too_small import TerminalTooSmall
 from rovr.state_manager import StateManager
 from rovr.variables.constants import MaxPossible, config, log_name, os_type
 from rovr.variables.maps import RovrVars
@@ -704,8 +706,6 @@ class Application(Actionable, App, inherit_bindings=False):
 
     @work(exclusive=True)
     async def on_resize(self, event: events.Resize) -> None:
-        from rovr.screens.way_too_small import TerminalTooSmall
-
         if (
             event.size.height < MaxPossible.height
             or event.size.width < MaxPossible.width
@@ -797,6 +797,27 @@ class Application(Actionable, App, inherit_bindings=False):
                 self.stylesheet.update(self)
                 for screen in self.screen_stack:
                     self.stylesheet.update(screen)
+
+    @on(events.Paste)
+    @work
+    async def on_paste(self, event: events.Paste) -> None:
+        if len(self.screen_stack) != 1:
+            return
+        response: DragAndDropReturnType = await self.push_screen_wait(
+            DragAndDropScreen(event)
+        )
+        if response is not None and response.paths:
+            process_container = self.query_one(ProcessContainer)
+            dest = getcwd()
+            match response.action:
+                case "copy":
+                    process_container.paste_items(
+                        copied=response.paths, has_cut=[], dest=dest
+                    )
+                case "move":
+                    process_container.paste_items(
+                        copied=[], has_cut=response.paths, dest=dest
+                    )
 
     def get_system_commands(self, screen: Screen) -> Iterable[SystemCommand]:
         if not self.ansi_color:

--- a/src/rovr/screens/__init__.py
+++ b/src/rovr/screens/__init__.py
@@ -2,6 +2,7 @@ from .archive_creator import ArchiveCreationScreen
 from .common_file_name_do_what import FileNameConflict
 from .delete_files import DeleteFiles
 from .dismissible import Dismissible
+from .drag_and_drop import DragAndDropScreen
 from .fd_search import FileSearch
 from .file_in_use import FileInUse
 from .input import ModalInput
@@ -15,11 +16,12 @@ from .zd_to_directory import ZDToDirectory
 
 __all__ = [
     "ArchiveCreationScreen",
-    "FileNameConflict",
     "ContentSearch",
     "DeleteFiles",
     "Dismissible",
+    "DragAndDropScreen",
     "FileInUse",
+    "FileNameConflict",
     "FileSearch",
     "Keybinds",
     "ModalInput",

--- a/src/rovr/screens/drag_and_drop.py
+++ b/src/rovr/screens/drag_and_drop.py
@@ -1,4 +1,5 @@
 import shlex
+from contextlib import suppress
 from os import path
 from sys import platform
 
@@ -39,15 +40,18 @@ class DragAndDropScreen(ModalScreen[DragAndDropReturnType]):
     @on(events.Paste)
     def on_paste(self, event: events.Paste) -> None:
         # attempt to parse it
-        # first check if it is a full file path
+        # first check if it is a full filepath
         event.text = event.text.strip()
         if path.lexists(event.text):
             self.file_paths.add(event.text.strip().strip('"').strip("'"))
         # otherwise, try to parse it as a list of arguments
         else:
-            file_paths = shlex.split(event.text, posix=platform != "win32")
-            for i in range(len(file_paths)):
-                file_paths[i] = file_paths[i].strip().strip('"').strip("'")
+            file_paths: list[str] = []
+            with suppress(ValueError):
+                file_paths = [
+                    fp.strip().strip('"').strip("'")
+                    for fp in shlex.split(event.text, posix=platform != "win32")
+                ]
             for file_path in file_paths:
                 if path.lexists(file_path):
                     self.file_paths.add(file_path)
@@ -77,6 +81,8 @@ class DragAndDropScreen(ModalScreen[DragAndDropReturnType]):
 
     @on(Button.Pressed)
     def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id not in ("copy", "move"):
+            return
         dismiss(
             self,
             DragAndDropReturnType(sorted(list(self.file_paths)), event.button.id),

--- a/src/rovr/screens/drag_and_drop.py
+++ b/src/rovr/screens/drag_and_drop.py
@@ -1,0 +1,84 @@
+import shlex
+from os import path
+from sys import platform
+
+from textual import events, on
+from textual.app import ComposeResult
+from textual.containers import Grid
+from textual.screen import ModalScreen
+from textual.widgets import Button, OptionList
+
+from rovr.classes.textual_options import OptionWithValue
+from rovr.functions.icons import get_icon_smart
+from rovr.functions.utils import dismiss
+
+from .typed import DragAndDropReturnType
+
+
+class DragAndDropScreen(ModalScreen[DragAndDropReturnType]):
+    def __init__(
+        self,
+        initial_paste_event: events.Paste,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name, id, classes)
+        self.file_paths: set[str] = set()
+        self.call_after_refresh(self.post_message, initial_paste_event)
+
+    def compose(self) -> ComposeResult:
+        with Grid(id="dialog"):
+            yield OptionList(id="drag_and_drop_list")
+            yield Button("Copy", id="copy", variant="success")
+            yield Button("Move", id="move", variant="warning")
+
+    def on_mount(self) -> None:
+        self.query_one(Grid).border_title = "Drag and Drop"
+
+    @on(events.Paste)
+    def on_paste(self, event: events.Paste) -> None:
+        # attempt to parse it
+        # first check if it is a full file path
+        event.text = event.text.strip()
+        if path.lexists(event.text):
+            self.file_paths.add(event.text.strip().strip('"').strip("'"))
+        # otherwise, try to parse it as a list of arguments
+        else:
+            file_paths = shlex.split(event.text, posix=platform != "win32")
+            for i in range(len(file_paths)):
+                file_paths[i] = file_paths[i].strip().strip('"').strip("'")
+            for file_path in file_paths:
+                if path.lexists(file_path):
+                    self.file_paths.add(file_path)
+
+        options: list[OptionWithValue] = []
+        for file_path in sorted(list(self.file_paths)):
+            options.append(
+                OptionWithValue(
+                    lambda file_path=file_path: get_icon_smart(file_path),
+                    path.basename(file_path),
+                    file_path,
+                )
+            )
+        self.query_one(OptionList).set_options(options)
+
+    def on_key(self, event: events.Key) -> None:
+        """Handle escape key to dismiss the dialog."""
+        if event.key == "escape":
+            event.stop()
+            dismiss(self, None, event)
+
+    def on_click(self, event: events.Click) -> None:
+        if event.widget is self:
+            # ie click outside
+            event.stop()
+            dismiss(self, None, event)
+
+    @on(Button.Pressed)
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        dismiss(
+            self,
+            DragAndDropReturnType(sorted(list(self.file_paths)), event.button.id),
+            event,
+        )

--- a/src/rovr/screens/typed.py
+++ b/src/rovr/screens/typed.py
@@ -25,3 +25,8 @@ class ArchiveScreenReturnType(NamedTuple):
 class ShellExecReturnType(NamedTuple):
     command: str
     orphan: bool
+
+
+class DragAndDropReturnType(NamedTuple):
+    paths: list[str]
+    action: Literal["copy", "move"]

--- a/src/rovr/style.tcss
+++ b/src/rovr/style.tcss
@@ -689,7 +689,8 @@ FileNameConflict,
 FileInUse,
 DeleteFiles,
 ModalInput,
-TerminalTooSmall { align: center middle }
+TerminalTooSmall,
+DragAndDropScreen { align: center middle }
 
 YesOrNo #dialog,
 FileNameConflict #dialog,
@@ -973,6 +974,24 @@ ShellExec {
   }
 }
 
+DragAndDropScreen #dialog {
+  border: $border-style $border;
+  padding: 0 1;
+  grid-size: 2 2;
+  grid-gutter: 0 0;
+  grid-rows: 1fr 3;
+
+  Button {
+    margin: 0 3;
+    height: 3;
+    width: 1fr;
+  }
+  OptionList {
+    height: 1fr;
+    column-span: 2;
+  }
+}
+
 PopupOptionList { width: auto }
 
 LoadingIndicator {
@@ -1123,6 +1142,13 @@ Screen {
     &PasteScreen #dialog {
       grid-size: 1 4 !important;
       grid-rows: 0.5fr 1.5fr 3 3 !important;
+    }
+    &DragAndDropScreen #dialog {
+      grid-size: 1 3;
+      grid-rows: 1fr 3 3;
+      Button {
+        margin: 0;
+      }
     }
   }
   &.-no-preview {


### PR DESCRIPTION
at most 5 people will use this feature, but it is still quite a cool feature indeed
need to update docs for this, not sure where tho

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible
- [ ] the documentation has been updated wherever necessary (run `poe gen-schema` and `poe gen-keys` if applicable)

## Summary by Sourcery

Add support for handling terminal paste events as a drag-and-drop file operation into the app.

New Features:
- Introduce a drag-and-drop modal screen that parses pasted file paths and lets users choose between copying or moving them into the current directory from the terminal.

Enhancements:
- Wire terminal paste events to open the drag-and-drop dialog when appropriate and integrate the result with the existing process container for file operations.
- Export the new drag-and-drop screen and its typed return value for use across the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clipboard paste now opens an interactive modal to collect filesystem paths.
  * Modal lets users choose "Copy" or "Move" for pasted items and returns the selected action.
  * Supports multiple paths with validation, visual list, icons and keyboard navigation.

* **Style**
  * Dialog and small-screen layouts refined for centred alignment, sizing and spacing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NSPC911/rovr/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->