### PR TITLE
feat(drives): add config for hiding drive paths 

### DIFF
--- a/docs/src/content/docs/dev/reference/schema.mdx
+++ b/docs/src/content/docs/dev/reference/schema.mdx
@@ -101,6 +101,8 @@ description: config schema humanified
             - [2.6.1.1.2.2.3. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > directory`](#settings_openers_additionalProperties_items_oneOf_i1_if_directory)
           - [2.6.1.1.2.3. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > orphan`](#settings_openers_additionalProperties_items_oneOf_i1_orphan)
           - [2.6.1.1.2.4. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > name`](#settings_openers_additionalProperties_items_oneOf_i1_name)
+  - [2.7. Property `Rovr Config > settings > drive_exclude`](#settings_drive_exclude)
+    - [2.7.1. Rovr Config > settings > drive_exclude > drive_exclude items](#settings_drive_exclude_items)
 - [3. Property `Rovr Config > metadata`](#metadata)
   - [3.1. Property `Rovr Config > metadata > fields`](#metadata_fields)
     - [3.1.1. Rovr Config > metadata > fields > fields items](#metadata_fields_items)
@@ -837,6 +839,7 @@ Must be one of:
 | [editor](#settings_editor)                                 | object          | Settings related to the editor used for different operations                                                                                                                                                            |
 | [preview_rules](#settings_preview_rules)                   | object          | Map MIME type patterns to preview types. Uses regex patterns. Valid preview types: text, image, pdf, archive, folder, resvg, font, remime.<br />-&gt; Use 'remime' if you want a more accurate description from file(1) |
 | [openers](#settings_openers)                               | object          | A list of openers to open files with. These are used to open files, what were you expecting.<br />Key must be a valid glob pattern, but the value has to be a list that can contain a mix of strings and objects        |
+| [drive_exclude](#settings_drive_exclude)                   | array of string | Glob patterns matched against mountpoint paths. Drives matching any pattern are hidden from the sidebar (e.g. '/run/media/\*', 'D:/').                                                                                  |
 
 ### <a name="settings_use_recycle_bin"></a>2.1. Property `Rovr Config > settings > use_recycle_bin`
 
@@ -1591,10 +1594,11 @@ Key must be a valid glob pattern, but the value has to be a list that can contai
 
 ###### <a name="settings_openers_additionalProperties_items_oneOf_i1_if_os"></a>2.6.1.1.2.2.2. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > os`
 
-|              |                   |
-| ------------ | ----------------- |
-| **Type**     | `array of string` |
-| **Required** | No                |
+|                |                     |
+| -------------- | ------------------- |
+| **Type**       | `array of string`   |
+| **Required**   | No                  |
+| **Defined in** | #/definitions/os_if |
 
 **Description:** Only use this opener if the operating system is one of the following (case insensitive)
 
@@ -1669,6 +1673,35 @@ Must be one of:
 | **Required** | No       |
 
 **Description:** The name of the opener to show in the menu (currently unused)
+
+### <a name="settings_drive_exclude"></a>2.7. Property `Rovr Config > settings > drive_exclude`
+
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of string` |
+| **Required** | No                |
+| **Default**  | `[]`              |
+
+**Description:** Glob patterns matched against mountpoint paths. Drives matching any pattern are hidden from the sidebar (e.g. '/run/media/\*', 'D:/').
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                      | Description |
+| ---------------------------------------------------- | ----------- |
+| [drive_exclude items](#settings_drive_exclude_items) |             |
+
+#### <a name="settings_drive_exclude_items"></a>2.7.1. Rovr Config > settings > drive_exclude > drive_exclude items
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
 
 ## <a name="metadata"></a>3. Property `Rovr Config > metadata`
 

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -632,7 +632,7 @@ class Application(Actionable, App, inherit_bindings=False):
 
                         process = multiprocessing.Process(
                             target=drive_workers.get_mounted_drives_worker,
-                            args=(result_queue, os_type),
+                            args=(result_queue, os_type, config),
                         )
                         process.start()
                         process.join(timeout=2.0)
@@ -647,7 +647,7 @@ class Application(Actionable, App, inherit_bindings=False):
                             # Process completed successfully
                             new_drives = result_queue.get_nowait()
                     else:
-                        new_drives = drive_workers.get_mounted_drives(os_type)
+                        new_drives = drive_workers.get_mounted_drives(os_type, config)
                     if new_drives is not None and new_drives != drives():
                         self.query_one(PinnedSidebar).reload_pins()
                 except Exception as exc:

--- a/src/rovr/classes/config.py
+++ b/src/rovr/classes/config.py
@@ -24,24 +24,28 @@ class _OpenerIf(TypedDict, total=False):
     cwd: list[str]
     r""" Only use this opener if the current working directory matches one (or more) of the glob patterns in this list (look at https://docs.python.org/3/library/fnmatch.html for more info) """
 
-    os: list["_OpenerIfOsItem"]
-    r""" Only use this opener if the operating system is one of the following (case insensitive) """
+    os: "_OsIf"
+    r""" Only use this setting if the operating system is one of the following (case insensitive) """
 
     directory: bool
     r""" Only use this opener if the selected item is a directory (set to true) or a file (set to false) (if unspecified, matches both files and directories) """
 
 
-_OpenerIfOsItem = Union["_OpenerIfOsItemAnyof0", str]
+_OsIf = list["_OsIfItem"]
+r""" Only use this setting if the operating system is one of the following (case insensitive) """
+
+
+_OsIfItem = Union["_OsIfItemAnyof0", str]
 r""" Aggregation type: anyOf """
 
 
-_OpenerIfOsItemAnyof0 = Literal["Windows"] | Literal["Linux"] | Literal["Darwin"]
-_OPENERIFOSITEMANYOF0_WINDOWS: Literal["Windows"] = "Windows"
-r"""The values for the '_OpenerIfOsItemAnyof0' enum"""
-_OPENERIFOSITEMANYOF0_LINUX: Literal["Linux"] = "Linux"
-r"""The values for the '_OpenerIfOsItemAnyof0' enum"""
-_OPENERIFOSITEMANYOF0_DARWIN: Literal["Darwin"] = "Darwin"
-r"""The values for the '_OpenerIfOsItemAnyof0' enum"""
+_OsIfItemAnyof0 = Literal["Windows"] | Literal["Linux"] | Literal["Darwin"]
+_OSIFITEMANYOF0_WINDOWS: Literal["Windows"] = "Windows"
+r"""The values for the '_OsIfItemAnyof0' enum"""
+_OSIFITEMANYOF0_LINUX: Literal["Linux"] = "Linux"
+r"""The values for the '_OsIfItemAnyof0' enum"""
+_OSIFITEMANYOF0_DARWIN: Literal["Darwin"] = "Darwin"
+r"""The values for the '_OsIfItemAnyof0' enum"""
 
 
 _ROVR_CONFIG_ICONS_FILES_DEFAULT: list[Any] = []
@@ -296,6 +300,10 @@ r""" Default value of the field path 'Rovr Config plugins zoxide show_scores' ""
 
 _ROVR_CONFIG_SETTINGS_COPY_INCLUDES_METADATA_DEFAULT = True
 r""" Default value of the field path 'Rovr Config settings copy_includes_metadata' """
+
+
+_ROVR_CONFIG_SETTINGS_DRIVE_EXCLUDE_DEFAULT: list[Any] = []
+r""" Default value of the field path 'Rovr Config settings drive_exclude' """
 
 
 _ROVR_CONFIG_SETTINGS_EDITOR_BULK_EDITOR_RENAME_SHOW_AS_MAPPING_DEFAULT = True
@@ -1458,6 +1466,14 @@ class _RovrConfigSettings(TypedDict, total=False):
     r"""
     A list of openers to open files with. These are used to open files, what were you expecting.
     Key must be a valid glob pattern, but the value has to be a list that can contain a mix of strings and objects
+    """
+
+    drive_exclude: list[str]
+    r"""
+    Glob patterns matched against mountpoint paths. Drives matching any pattern are hidden from the sidebar (e.g. '/run/media/*', 'D:/').
+
+    default:
+      []
     """
 
 

--- a/src/rovr/config/config.toml
+++ b/src/rovr/config/config.toml
@@ -79,6 +79,7 @@ right_click = [
   { label = "\uea74 Properties", action = "sh:powershell -nop -c \"(New-Object -ComObject Shell.Application).NameSpace('${current_working_directory}'.replace('/', '\\')).ParseName('${highlighted_file_name}').InvokeVerb('Properties'); Start-Sleep -m 500; do { Start-Sleep -m 500 } while ((Get-Process | Where-Object { $_.MainWindowTitle -match '${highlighted_file_name} Properties' }))\"", if = { os = ["Windows"] } }
   # { label = " Get SHA256", action = 'sho:pwsh -nop -c "(Get-FileHash -Algorithm SHA256 \"${highlighted_file}\").Hash', if = { directory = false }}
 ]
+drive_exclude = ["/var/*"]
 
 [settings.preview_rules]
 "application/(debian.*-package|redhat-package-manager|rpm|android\\.package-archive)" = "archive"

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -34,6 +34,17 @@
         }
       ]
     },
+    "os_if": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "anyOf": [
+          { "enum": ["Windows", "Linux", "Darwin"] },
+          { "type": "string" }
+        ]
+      },
+      "description": "Only use this setting if the operating system is one of the following (case insensitive)"
+    },
     "opener_if": {
       "type": "object",
       "additionalProperties": false,
@@ -44,15 +55,8 @@
           "items": { "type": "string" }
         },
         "os": {
-          "description": "Only use this opener if the operating system is one of the following (case insensitive)",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "anyOf": [
-              { "enum": ["Windows", "Linux", "Darwin"] },
-              { "type": "string" }
-            ]
-          }
+          "$ref": "#/definitions/os_if",
+          "description": "Only use this opener if the operating system is one of the following (case insensitive)"
         },
         "directory": {
           "type": "boolean",
@@ -444,9 +448,7 @@
             "type": "array",
             "items": {
               "oneOf": [
-                {
-                  "type": "string"
-                },
+                { "type": "string" },
                 {
                   "type": "object",
                   "additionalProperties": false,
@@ -474,6 +476,12 @@
               ]
             }
           }
+        },
+        "drive_exclude": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Glob patterns matched against mountpoint paths. Drives matching any pattern are hidden from the sidebar (e.g. '/run/media/*', 'D:/')."
         }
       }
     },

--- a/src/rovr/core/pinned_sidebar.py
+++ b/src/rovr/core/pinned_sidebar.py
@@ -149,7 +149,7 @@ class PinnedSidebar(Actionable, OptionList, inherit_bindings=False):
                 result_queue: multiprocessing.Queue[list[str]] = multiprocessing.Queue()
                 process = multiprocessing.Process(
                     target=drive_utils.get_mounted_drives_worker,
-                    args=(result_queue, os_type),
+                    args=(result_queue, os_type, config),
                 )
                 process.start()
                 process.join(timeout=2.0)
@@ -166,11 +166,11 @@ class PinnedSidebar(Actionable, OptionList, inherit_bindings=False):
 
                 drives = result_queue.get_nowait()
             else:
-                drives = drive_utils.get_mounted_drives(os_type)
+                drives = drive_utils.get_mounted_drives(os_type, config)
         except Exception as exc:
             if not multiprocessing_process_error_checker(self.app, exc):
                 return
-            drives = drive_utils.get_mounted_drives(os_type)
+            drives = drive_utils.get_mounted_drives(os_type, config)
         self.DRIVES = drives
         new_options: list[PinnedSidebarOption] = []
         for drive in drives:

--- a/src/rovr/functions/drive_workers.py
+++ b/src/rovr/functions/drive_workers.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import multiprocessing
+from fnmatch import fnmatch
 from os import path
+
+from rovr.classes.config import RovrConfig
 
 try:
     import psutil
@@ -37,7 +40,7 @@ def normalise(*location: str | bytes) -> str:
     )
 
 
-def get_mounted_drives(os_type: str) -> list[str]:
+def get_mounted_drives(os_type: str, config: "RovrConfig") -> list[str]:
     """
     Worker function to get mounted drives - isolated from config imports.
 
@@ -77,11 +80,14 @@ def get_mounted_drives(os_type: str) -> list[str]:
             ]
         else:
             drives = ["/"]  # root should definitely exist right
+    exclude_patterns: list[str] = config.get("settings", {}).get("drive_exclude", [])
+    if exclude_patterns:
+        drives = [d for d in drives if not any(fnmatch(d, p) for p in exclude_patterns)]
     return drives
 
 
 def get_mounted_drives_worker(
-    queue: "multiprocessing.Queue[list[str]]", os_type: str
+    queue: "multiprocessing.Queue[list[str]]", os_type: str, config: "RovrConfig"
 ) -> None:
     """
     Multiprocessing worker that gets mounted drives and puts result in a queue.
@@ -89,9 +95,10 @@ def get_mounted_drives_worker(
     Args:
         queue: Multiprocessing queue to put the result into
         os_type: Operating system type ("Windows", "Darwin", or other)
+        config: Application config dict
     """
     try:
-        result = get_mounted_drives(os_type)
+        result = get_mounted_drives(os_type, config)
         queue.put(result)
     except Exception:
         queue.put([])


### PR DESCRIPTION
resolves #286 

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible
- [ ] the documentation has been updated wherever necessary (run `poe gen-schema` and `poe gen-keys` if applicable)

## Summary by Sourcery

Add configuration support for excluding drives from the sidebar using glob patterns and wire this into drive discovery across the app.

New Features:
- Introduce a `settings.drive_exclude` configuration option to hide drives whose mount paths match configured glob patterns.
- Apply drive exclusion rules to both the sidebar drive list and background drive change watcher.

Enhancements:
- Refine the typed configuration model for OS-specific conditionals used in settings and openers.

Documentation:
- Document the new `settings.drive_exclude` option in the generated config schema reference, including type, default, and examples.

Chores:
- Extend the default config file to demonstrate excluding system mount paths from the drive list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `drive_exclude` configuration option enabling users to hide specific mounted drives from the sidebar using glob patterns, allowing for more granular control over which storage devices are displayed.

* **Documentation**
  * Updated configuration schema reference documentation to include the new drive exclusion option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NSPC911/rovr/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->