### PR TITLE
feat(metadata): show mime type as section

### DIFF
--- a/docs/src/content/docs/dev/reference/schema.mdx
+++ b/docs/src/content/docs/dev/reference/schema.mdx
@@ -1720,11 +1720,11 @@ Must be one of:
 
 ### <a name="metadata_fields"></a>3.1. Property `Rovr Config > metadata > fields`
 
-|              |                                                                                |
-| ------------ | ------------------------------------------------------------------------------ |
-| **Type**     | `array of enum (of string)`                                                    |
-| **Required** | No                                                                             |
-| **Default**  | `["type", "permissions", "size", "modified", "accessed", "created", "hidden"]` |
+|              |                                                                                        |
+| ------------ | -------------------------------------------------------------------------------------- |
+| **Type**     | `array of enum (of string)`                                                            |
+| **Required** | No                                                                                     |
+| **Default**  | `["type", "permissions", "size", "modified", "accessed", "created", "hidden", "mime"]` |
 
 **Description:** The order of the metadata tags that you want to see in the Metadata section.
 
@@ -1756,6 +1756,7 @@ Must be one of:
 - "accessed"
 - "created"
 - "hidden"
+- "mime"
 
 ### <a name="metadata_datetime_format"></a>3.2. Property `Rovr Config > metadata > datetime_format`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ tokei.cmd = "tokei --sort lines --exclude '*.svg' --exclude 'src/rovr/classes/co
 help = "Run tests"
 sequence = [
   "_test_setup",
-  { cmd = "pytest -n ${workers} ${FILES}" }
+  { cmd = "pytest -n ${workers} ${FILES} $POE_EXTRA_ARGS" }
 ]
 args = [
   { name = "FILES", help = "Specific test files or directories to run (optional)", type = "string", positional = true, required = false, multiple = true },

--- a/src/rovr/classes/config.py
+++ b/src/rovr/classes/config.py
@@ -170,6 +170,7 @@ _ROVR_CONFIG_METADATA_FIELDS_DEFAULT = [
     "accessed",
     "created",
     "hidden",
+    "mime",
 ]
 r""" Default value of the field path 'Rovr Config metadata fields' """
 
@@ -1091,6 +1092,7 @@ class _RovrConfigMetadata(TypedDict, total=False):
       - accessed
       - created
       - hidden
+      - mime
     uniqueItems: True
     """
 
@@ -1128,6 +1130,7 @@ _RovrConfigMetadataFieldsItem = (
     | Literal["accessed"]
     | Literal["created"]
     | Literal["hidden"]
+    | Literal["mime"]
 )
 _ROVRCONFIGMETADATAFIELDSITEM_TYPE: Literal["type"] = "type"
 r"""The values for the '_RovrConfigMetadataFieldsItem' enum"""
@@ -1142,6 +1145,8 @@ r"""The values for the '_RovrConfigMetadataFieldsItem' enum"""
 _ROVRCONFIGMETADATAFIELDSITEM_CREATED: Literal["created"] = "created"
 r"""The values for the '_RovrConfigMetadataFieldsItem' enum"""
 _ROVRCONFIGMETADATAFIELDSITEM_HIDDEN: Literal["hidden"] = "hidden"
+r"""The values for the '_RovrConfigMetadataFieldsItem' enum"""
+_ROVRCONFIGMETADATAFIELDSITEM_MIME: Literal["mime"] = "mime"
 r"""The values for the '_RovrConfigMetadataFieldsItem' enum"""
 
 

--- a/src/rovr/classes/textual_options.py
+++ b/src/rovr/classes/textual_options.py
@@ -185,6 +185,7 @@ class FileListSelectionWidget(LazySelection):
             disabled: The initial enabled/disabled state. Enabled by default.
         """
         self.dir_entry = dir_entry
+        self.mime_type: str | None = None
         this_id = str(id(self))
         self.__icon_factory = icon_factory
         self.__label = label

--- a/src/rovr/config/config.toml
+++ b/src/rovr/config/config.toml
@@ -128,6 +128,7 @@ fields = [
   "accessed",
   "created",
   "hidden",
+  "mime",
 ]
 datetime_format = "%Y-%m-%d %H:%M"
 filesize_decimals = 1

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -500,7 +500,8 @@
               "modified",
               "accessed",
               "created",
-              "hidden"
+              "hidden",
+              "mime"
             ]
           },
           "default": [
@@ -510,7 +511,8 @@
             "modified",
             "accessed",
             "created",
-            "hidden"
+            "hidden",
+            "mime"
           ],
           "uniqueItems": true,
           "description": "The order of the metadata tags that you want to see in the Metadata section."

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -535,7 +535,9 @@ class FileList(
         else:
             setattr(self.app, "_highlighted_file_mtime", None)
         # preview
-        self.app.query_one("MetadataContainer").update_metadata(event.option.dir_entry)
+        self.app.query_one("MetadataContainer").update_metadata(
+            event.option.dir_entry, event.option
+        )
         try:
             self.app.query_one("PreviewContainer").show_preview(
                 highlighted_option.dir_entry.path,

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -965,9 +965,18 @@ class PreviewContainer(Actionable, Container):
             or "-filelist-only" in self.screen.classes
         ):
             self._pending_preview_args = (file_path, mtime)
+            self._compute_and_sync_mime(file_path, mtime)
             return
         self._pending_preview_args = None
         self.perform_show_preview(file_path, mtime)
+
+    def _compute_and_sync_mime(self, file_path: str, mtime: int | float) -> None:
+        self._sync_mime(
+            file_path,
+            preview_utils.MimeResult("basic", "inode/directory")
+            if path.isdir(file_path)
+            else preview_utils.get_mime_type(file_path, mtime),
+        )
 
     @work(exclusive=True, thread=True)
     def perform_show_preview(self, file_path: str, mtime: int) -> None:

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import subprocess
 from dataclasses import dataclass
 from functools import partial
@@ -1129,15 +1130,14 @@ class PreviewContainer(Actionable, Container):
         content: str | list[str] | None = None,
         mime_type: preview_utils.MimeResult | None = None,
     ) -> None:
-        """
-        Update the preview UI. Runs in a thread, uses call_from_thread for UI ops.
-        """
         self._current_file_path = file_path
         self._current_content = content
         self._mime_type = mime_type
         self._file_mtime = path.getmtime(file_path)
-
         self._file_type = file_type
+
+        self.call_after_refresh(self._sync_mime, file_path, mime_type)
+
         self.app.call_from_thread(self.remove_class, "pdf")
         if file_type == "folder":
             self.log("Showing folder preview")
@@ -1302,3 +1302,20 @@ class PreviewContainer(Actionable, Container):
             filelist := self.get_child(FileList)
         ):
             filelist.scroll_end(animate=False)
+
+    def _sync_mime(
+        self, file_path: str, mime_type: preview_utils.MimeResult | None = None
+    ) -> None:
+        mime_str = mime_type.mime_type if mime_type else "--"
+        with contextlib.suppress(NoMatches):
+            metadata_container = self.app.query_one("MetadataContainer")
+            option = metadata_container._current_option
+            if (
+                isinstance(option, FileListSelectionWidget)
+                and option.dir_entry.path == file_path
+            ):
+                option.mime_type = mime_str
+                with contextlib.suppress(NoMatches):
+                    metadata_container.query_one("#metadata-mime", Static).update(
+                        mime_str or "--"
+                    )

--- a/src/rovr/footer/metadata_container.py
+++ b/src/rovr/footer/metadata_container.py
@@ -11,6 +11,7 @@ from textual.widget import MountError
 from textual.widgets import Static
 from textual.worker import WorkerState
 
+from rovr.classes.textual_options import FileListSelectionWidget
 from rovr.functions import utils
 from rovr.functions.path import get_direntry_for, is_hidden_file
 from rovr.variables.constants import config, scroll_bindings
@@ -27,6 +28,7 @@ class MetadataContainer(VerticalScroll, inherit_bindings=False):
         self._update_task = None
         self._queued_task = None
         self._queued_task_args: None | DirEntry = None
+        self._current_option: FileListSelectionWidget | None = None
 
     def info_of_dir_entry(self, dir_entry: DirEntry, type_string: str) -> str:
         """Get the permission line from a given DirEntry object
@@ -77,12 +79,16 @@ class MetadataContainer(VerticalScroll, inherit_bindings=False):
             return True
         return False
 
-    def update_metadata(self, dir_entry: DirEntry) -> None:
+    def update_metadata(
+        self, dir_entry: DirEntry, option: FileListSelectionWidget | None = None
+    ) -> None:
         """
         Debounce the update, because some people can be speed travellers
         Args:
             dir_entry (DirEntry): The nt.DirEntry object
+            option (FileListSelectionWidget | None): The highlighted option, if available
         """
+        self._current_option = option
         if any(
             worker.is_running
             and worker.node is self
@@ -184,6 +190,16 @@ class MetadataContainer(VerticalScroll, inherit_bindings=False):
                                 )
                             )
                         )
+                    case "mime":
+                        option = self._current_option
+                        mime_str = (
+                            option.mime_type
+                            if isinstance(option, FileListSelectionWidget)
+                            and option.dir_entry.path == dir_entry.path
+                            and option.mime_type is not None
+                            else "--"
+                        )
+                        values_list.append(Static(mime_str, id="metadata-mime"))
             except OSError as exc:
                 # can appear here because of stupid nt epoch stuff
                 if exc.errno in (22, 23, 123):
@@ -220,6 +236,8 @@ class MetadataContainer(VerticalScroll, inherit_bindings=False):
                         keys_list.append(Static("Accessed"))
                     case "created":
                         keys_list.append(Static("Created"))
+                    case "mime":
+                        keys_list.append(Static("MIME"))
             keys = VerticalGroup(*keys_list, id="metadata-keys")
             try:
                 self.app.call_from_thread(self.mount, keys, values)

--- a/src/rovr/functions/preview_utils.py
+++ b/src/rovr/functions/preview_utils.py
@@ -272,7 +272,6 @@ def match_mime_to_preview_type(
     """
     for pattern, preview_type in config["settings"]["preview_rules"].items():
         if recache(pattern).fullmatch(mime_type):
-            print("Matched MIME Type")
             return preview_type
     return None
 


### PR DESCRIPTION
shows mime type in metadata container, thats about it

<img width="454" height="139" alt="image" src="https://github.com/user-attachments/assets/3d43b33e-7854-4dc8-9ae1-184d3123e622" />

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible
- [x] the documentation has been updated wherever necessary (run `poe gen-schema` and `poe gen-keys` if applicable)

## Summary by Sourcery

Add support for displaying a file's MIME type in the metadata panel and wire it into the preview and file list selection flow.

New Features:
- Display the current file's MIME type as a configurable field in the metadata section.

Enhancements:
- Propagate MIME type information from preview detection to the highlighted file option and metadata container for accurate display.

Documentation:
- Document the new `mime` metadata field in the configuration schema and update the default metadata fields list.

Tests:
- Allow passing extra arguments to pytest via POE_EXTRA_ARGS in the test task configuration.

Chores:
- Remove an obsolete debug print from MIME-to-preview matching logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MIME type as a visible metadata field so file MIME types appear in metadata displays.

* **Improvements**
  * UI now synchronises and shows MIME information for highlighted items; metadata display and defaults updated to include MIME.
  * Minor logging cleaned up to remove an extra debug print.

* **Chores**
  * Test task updated to allow passing extra pytest arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->