### PR TITLE
fix(shell): use separate bg implementation instead of orphans

### DIFF
--- a/src/rovr/action_buttons/new_item_button.py
+++ b/src/rovr/action_buttons/new_item_button.py
@@ -148,7 +148,7 @@ class NewItemButton(Button):
             run_command(
                 self.app,
                 shlex.split(bulk_editor["run"]) + [temp_path],
-                orphan=False,
+                run_type="suspend",
                 shell=False,
                 on_error=on_error,
             )

--- a/src/rovr/action_buttons/rename_item_button.py
+++ b/src/rovr/action_buttons/rename_item_button.py
@@ -123,7 +123,7 @@ class RenameItemButton(Button):
                     run_command(
                         self.app,
                         shlex.split(bulk_editor["run"]) + [temp_path],
-                        orphan=False,
+                        run_type="suspend",
                         on_error=on_error,
                     )
                 except FileNotFoundError:

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -412,7 +412,7 @@ class Application(Actionable, App, inherit_bindings=False):
         if response is None or response.command == "":
             return
 
-        run_command(self, response.command, orphan=response.orphan)
+        run_command(self, response.command, run_type=response.run_type)
 
     def on_app_blur(self, event: events.AppBlur) -> None:
         self.app_blurred = True

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -403,7 +403,9 @@ class FileList(
                 utils.run_command(
                     self.app,
                     shlex.split(editor_config["run"]) + [target_path],
-                    orphan=editor_config.get("orphan", True),
+                    run_type="orphan"
+                    if editor_config.get("orphan", True)
+                    else "suspend",
                     on_error=on_error,
                 )
             except Exception as exc:
@@ -432,9 +434,13 @@ class FileList(
                             utils.run_command(
                                 self.app,
                                 runner,
-                                opener.get("orphan", True)
+                                run_type=(
+                                    "orphan"
+                                    if opener.get("orphan", True)
+                                    else "suspend"
+                                )
                                 if isinstance(opener, dict)
-                                else True,
+                                else "orphan",
                             )
                             opened = True
                             break
@@ -934,7 +940,9 @@ class FileList(
                 utils.run_command(
                     self.app,
                     shlex.split(editor_config["run"]) + [target_path],
-                    orphan=editor_config.get("orphan", True),
+                    run_type="orphan"
+                    if editor_config.get("orphan", True)
+                    else "suspend",
                     on_error=lambda message, title: self.notify(
                         message=message, title=title, severity="error", markup=False
                     ),

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -158,40 +158,49 @@ def get_shortest_bind(binds: list[str]) -> str:
 def run_command(
     app: App,
     command: str | list[str],
-    orphan: bool,
+    run_type: Literal["suspend", "background", "orphan"],
     shell: bool = True,
     on_error: Callable[[str, str], None] | None = None,
 ) -> subprocess.CompletedProcess | None:
-    if orphan:
-        import sys
+    match run_type:
+        case "orphan":
+            import sys
 
-        if sys.platform == "win32":
+            if sys.platform == "win32":
+                subprocess.Popen(
+                    command,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    creationflags=subprocess.CREATE_NEW_PROCESS_GROUP
+                    | subprocess.DETACHED_PROCESS,
+                    shell=shell,
+                )
+            else:
+                subprocess.Popen(
+                    command,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                    shell=shell,
+                )
+        case "background":
             subprocess.Popen(
                 command,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
-                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP
-                | subprocess.DETACHED_PROCESS,
                 shell=shell,
             )
-        else:
-            subprocess.Popen(
-                command,
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                start_new_session=True,
-                shell=shell,
-            )
-    else:
-        with app.suspend():
-            if globals().get("is_dev", False):
-                print(command)
-            process = subprocess.run(command, shell=shell)
-        if process.returncode != 0 and on_error:
-            on_error(f"Error Code {process.returncode}", "Editor Error")
-        return process
+        case _:
+            with app.suspend():
+                if globals().get("is_dev", False):
+                    print(command)
+                process = subprocess.run(command, shell=shell)
+            if process.returncode != 0 and on_error:
+                on_error(f"Error Code {process.returncode}", "Editor Error")
+            return process
 
 
 def dismiss(

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -161,13 +161,13 @@ def run_command(
     run_type: Literal["suspend", "background", "orphan"],
     shell: bool = True,
     on_error: Callable[[str, str], None] | None = None,
-) -> subprocess.CompletedProcess | None:
+) -> subprocess.CompletedProcess | subprocess.Popen:
     match run_type:
         case "orphan":
             import sys
 
             if sys.platform == "win32":
-                subprocess.Popen(
+                return subprocess.Popen(
                     command,
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
@@ -177,7 +177,7 @@ def run_command(
                     shell=shell,
                 )
             else:
-                subprocess.Popen(
+                return subprocess.Popen(
                     command,
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
@@ -186,14 +186,14 @@ def run_command(
                     shell=shell,
                 )
         case "background":
-            subprocess.Popen(
+            return subprocess.Popen(
                 command,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 shell=shell,
             )
-        case _:
+        case "suspend":
             with app.suspend():
                 if globals().get("is_dev", False):
                     print(command)
@@ -201,6 +201,10 @@ def run_command(
             if process.returncode != 0 and on_error:
                 on_error(f"Error Code {process.returncode}", "Editor Error")
             return process
+        case _:
+            from typing import assert_never
+
+            assert_never(run_type)
 
 
 def dismiss(

--- a/src/rovr/screens/shell_exec.py
+++ b/src/rovr/screens/shell_exec.py
@@ -31,7 +31,7 @@ class ShellExec(ModalInput):
 
     def on_mount(self) -> None:
         super().on_mount()
-        self.horizontal_group.add_class(f"orphan--{str(self.in_bg).lower()}")
+        self.horizontal_group.add_class(f"in-bg--{str(self.in_bg).lower()}")
 
     def on_click(self, event: events.Click) -> None:
         if event.widget is self:
@@ -51,9 +51,9 @@ class ShellExec(ModalInput):
         )
 
     def action_cycle_mode(self) -> None:
-        self.horizontal_group.remove_class(f"orphan--{str(self.in_bg).lower()}")
+        self.horizontal_group.remove_class(f"in-bg--{str(self.in_bg).lower()}")
         self.in_bg = not self.in_bg
         self.horizontal_group.border_subtitle = (
             "Run in background" if self.in_bg else "Run in foreground"
         )
-        self.horizontal_group.add_class(f"orphan--{str(self.in_bg).lower()}")
+        self.horizontal_group.add_class(f"in-bg--{str(self.in_bg).lower()}")

--- a/src/rovr/screens/shell_exec.py
+++ b/src/rovr/screens/shell_exec.py
@@ -27,11 +27,11 @@ class ShellExec(ModalInput):
         super().__init__(
             border_title="Execute Shell Command", border_subtitle="Run in background"
         )
-        self.orphan: bool = True
+        self.in_bg: bool = True
 
     def on_mount(self) -> None:
         super().on_mount()
-        self.horizontal_group.add_class(f"orphan--{str(self.orphan).lower()}")
+        self.horizontal_group.add_class(f"orphan--{str(self.in_bg).lower()}")
 
     def on_click(self, event: events.Click) -> None:
         if event.widget is self:
@@ -45,15 +45,15 @@ class ShellExec(ModalInput):
             self,
             ShellExecReturnType(
                 command=await expand_command(self.app, event.input.value),
-                orphan=self.orphan,
+                run_type="background" if self.in_bg else "suspend",
             ),
             event,
         )
 
     def action_cycle_mode(self) -> None:
-        self.horizontal_group.remove_class(f"orphan--{str(self.orphan).lower()}")
-        self.orphan = not self.orphan
+        self.horizontal_group.remove_class(f"orphan--{str(self.in_bg).lower()}")
+        self.in_bg = not self.in_bg
         self.horizontal_group.border_subtitle = (
-            "Run in background" if self.orphan else "Run in foreground"
+            "Run in background" if self.in_bg else "Run in foreground"
         )
-        self.horizontal_group.add_class(f"orphan--{str(self.orphan).lower()}")
+        self.horizontal_group.add_class(f"orphan--{str(self.in_bg).lower()}")

--- a/src/rovr/screens/typed.py
+++ b/src/rovr/screens/typed.py
@@ -24,7 +24,7 @@ class ArchiveScreenReturnType(NamedTuple):
 
 class ShellExecReturnType(NamedTuple):
     command: str
-    orphan: bool
+    run_type: Literal["suspend", "background"]
 
 
 class DragAndDropReturnType(NamedTuple):

--- a/src/rovr/style.tcss
+++ b/src/rovr/style.tcss
@@ -965,11 +965,11 @@ ArchiveCreationScreen {
 
 ShellExec {
   #modalInput_group {
-    &.orphan--true { border: $border-style $success-lighten-3 }
-    &.orphan--false { border: $border-style $error-lighten-3 }
+    &.in-bg--true { border: $border-style $success-lighten-3 }
+    &.in-bg--false { border: $border-style $error-lighten-3 }
     &:light {
-      &.orphan--true { border: $border-style $success-darken-1 }
-      &.orphan--false { border: $border-style $error-darken-1 }
+      &.in-bg--true { border: $border-style $success-darken-1 }
+      &.in-bg--false { border: $border-style $error-darken-1 }
     }
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce explicit run types for command execution to distinguish suspended, background, and orphaned processes, and propagate this through shell execution and editor-related flows.

Enhancements:
- Refine command execution helper to use a run_type discriminator instead of a boolean orphan flag, clearly separating suspend, background, and orphan modes.
- Update shell execution UI state and return types to represent background vs foreground execution explicitly rather than via an orphan boolean.
- Adjust file and item editor launch paths to select between orphaned and suspended execution based on configuration while using the new run_type API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked process execution handling to use three explicit modes (suspend, background, orphan) instead of a boolean flag; updated call sites and return types for consistent behaviour when launching editors and commands.
* **UI**
  * Added a foreground/background toggle for shell execution with corresponding mode text and behaviour.
* **Style**
  * Renamed mode-related CSS classes to reflect the new background/foreground terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->