### PR TITLE
feat: detail columns in file list

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -96,6 +96,7 @@ export default defineConfig({
           label: "features",
           items: [
             { label: "sorting", slug: "features/sorting" },
+            { label: "detail columns", slug: "features/detail-columns", badge: { text: "new", variant: "tip" } },
             { label: "editors", slug: "features/editor" },
             { label: "previewing files", slug: "features/previewing-files" },
             { label: "image previews", slug: "features/image-previews" },

--- a/docs/src/content/docs/dev/configuration/theming.mdx
+++ b/docs/src/content/docs/dev/configuration/theming.mdx
@@ -98,6 +98,21 @@ These component classes also come with their own sub classes due to textual limi
 | \*--hovered       | used when the option is currently hovered     | `FileList > .filelist--cut--hovered`      |
 | \*--highlighted   | used when the option is currently highlighted | `FileList > .filelist--link--highlighted` |
 
+[detail columns](/rovr/features/detail-columns) get their own component classes. these do not have `--hovered` or `--highlighted` sub classes; only the foreground color and text style apply, on top of the row's background.
+
+| Component Classes            | Description                                         | Example                                    |
+| ---------------------------- | --------------------------------------------------- | ------------------------------------------ |
+| filelist--detail-size        | applied on the size column                          | `FileList > .filelist--detail-size`        |
+| filelist--detail-mtime       | applied on the modified time column                 | `FileList > .filelist--detail-mtime`       |
+| filelist--detail-atime       | applied on the accessed time column                 | `FileList > .filelist--detail-atime`       |
+| filelist--detail-ctime       | applied on the created time column                  | `FileList > .filelist--detail-ctime`       |
+| filelist--detail-permissions | applied on the permissions column                   | `FileList > .filelist--detail-permissions` |
+| filelist--detail-owner       | applied on the owner column                         | `FileList > .filelist--detail-owner`       |
+| filelist--detail-group       | applied on the group column                         | `FileList > .filelist--detail-group`       |
+| filelist--git-staged         | applied on the staged character of the git column   | `FileList > .filelist--git-staged`         |
+| filelist--git-unstaged       | applied on the unstaged character of the git column | `FileList > .filelist--git-unstaged`       |
+| filelist--git-untracked      | applied on the git column for untracked entries     | `FileList > .filelist--git-untracked`      |
+
 <h4 class="no-lower">ProgressBarContainer</h4>
 
 This is the wrapper container for progress bars seen at the bottom left part of the UI.
@@ -125,14 +140,15 @@ This is the base screen for other screens like ripgrep, fd and zoxide.
 
 This is the root container that holds everything. This is not to be confused with the `Application` container, which is the app itself.
 
-| Class | Description                                      | Example              |
-| ----- | ------------------------------------------------ | -------------------- |
+| Class           | Description                                                            | Example                 |
+| --------------- | ---------------------------------------------------------------------- | ----------------------- |
 | compact-buttons | applied when the `interface.compact_mode.buttons` is enabled in config | `#root.compact-buttons` |
 | compact-panels  | applied when the `interface.compact_mode.panels` is enabled in config  | `#root.compact-panels`  |
 
 Root class also adds an extra class to itself to signify the current theme
 
 Example:
+
 ```css
 #root.theme-<theme-name> { ... }
 /* like */

--- a/docs/src/content/docs/dev/features/detail-columns.mdx
+++ b/docs/src/content/docs/dev/features/detail-columns.mdx
@@ -1,0 +1,65 @@
+---
+title: detail columns
+description: show file metadata in table-like columns next to file names.
+---
+
+rovr can show metadata right-aligned next to each file, similar to the details view in graphical file managers. a header row above the file list labels each column.
+
+this feature is disabled by default. to enable it, add a `details_list` to the `[interface]` section of your config:
+
+```toml
+[interface]
+details_list = [
+  { type = "size" },
+  { type = "mtime", label = "Modified" },
+  { type = "git" }
+]
+```
+
+## column types
+
+| type        | default label | description                                                           |
+| ----------- | ------------- | --------------------------------------------------------------------- |
+| size        | Size          | file size in a compact format. folders show their item count instead. |
+| mtime       | Modified      | last modification time                                                |
+| atime       | Accessed      | last access time                                                      |
+| ctime       | Created       | creation time (metadata change time on linux)                         |
+| permissions | Permissions   | unix-style permission string, like `drwxr-xr-x`                       |
+| owner       | Owner         | owning user's name                                                    |
+| group       | Group         | owning group's name                                                   |
+| git         | Git           | git status of the entry, see [the git column](#the-git-column)        |
+
+:::note
+`owner` and `group` are unavailable on windows for now, and will show `--` instead.
+:::
+
+## per-column options
+
+each entry in `details_list` accepts a few optional keys:
+
+| key        | description                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------------- |
+| label      | the text shown in the header row. defaults to the built-in label for the type.                                   |
+| max_length | caps the column's width in cells. defaults to the natural width of the type. the label's width is a lower bound. |
+| format     | strftime format for `mtime`/`atime`/`ctime` columns. defaults to `metadata.datetime_format`.                     |
+
+values that are too long for their column are truncated with an ellipsis.
+
+## column priority
+
+the order of `details_list` doubles as priority. when the file panel becomes too narrow to fit every column while leaving enough room for file names, columns are dropped from the back of the list; the first entry is the last one standing. they come back automatically when the panel widens again.
+
+## the git column
+
+the git column shows a two character status pair, exactly like `git status --short`:
+
+- the **first** character is the staged (index) status
+- the **second** character is the unstaged (work tree) status
+
+for example, `M ` means the file's changes are fully staged, ` M` means they are unstaged, and `MM` means some changes are staged and some are not. `??` marks untracked files. folders aggregate the statuses beneath them, showing the most severe character for each position.
+
+when the current directory is not inside a git repository, the column hides itself entirely instead of showing an empty column.
+
+## styling
+
+each column can be styled with component classes on `FileList`; the git column additionally styles its staged and unstaged characters separately. see [theming](/rovr/dev/configuration/theming/#styletcss) for the full list. the header row is a plain widget with the id `#file_list_details_header`.

--- a/docs/src/content/docs/dev/reference/schema.mdx
+++ b/docs/src/content/docs/dev/reference/schema.mdx
@@ -587,12 +587,12 @@ later entries are dropped first. Set to [] to disable.
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                               | Type             | Title/Description                                                                                                   |
-| ------------------------------------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------- |
-| [type](#interface_details_list_items_type)             | enum (of string) | What metadata to show. size shows the item count for folders.                                                       |
-| [label](#interface_details_list_items_label)           | string           | Column header label. Defaults to a built-in label for the type.                                                     |
-| [max_length](#interface_details_list_items_max_length) | integer          | Column width cap in cells. Defaults to the natural width of the type.<br />The label's width acts as a lower bound. |
-| [format](#interface_details_list_items_format)         | string           | strftime format for mtime/atime/ctime columns.<br />Defaults to metadata.datetime_format.                           |
+| Property                                               | Type             | Title/Description                                                                                                                                                                                               |
+| ------------------------------------------------------ | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [type](#interface_details_list_items_type)             | enum (of string) | What metadata to show. size shows the item count for folders.<br />git shows the two-char XY status like git status --short (first char staged, second unstaged)<br />and hides itself outside a git work tree. |
+| [label](#interface_details_list_items_label)           | string           | Column header label. Defaults to a built-in label for the type.                                                                                                                                                 |
+| [max_length](#interface_details_list_items_max_length) | integer          | Column width cap in cells. Defaults to the natural width of the type.<br />The label's width acts as a lower bound.                                                                                             |
+| [format](#interface_details_list_items_format)         | string           | strftime format for mtime/atime/ctime columns.<br />Defaults to metadata.datetime_format.                                                                                                                       |
 
 ##### <a name="interface_details_list_items_type"></a>1.10.1.1. Property `Rovr Config > interface > details_list > details_list items > type`
 
@@ -602,6 +602,8 @@ later entries are dropped first. Set to [] to disable.
 | **Required** | Yes                |
 
 **Description:** What metadata to show. size shows the item count for folders.
+git shows the two-char XY status like git status --short (first char staged, second unstaged)
+and hides itself outside a git work tree.
 
 Must be one of:
 
@@ -612,6 +614,7 @@ Must be one of:
 - "permissions"
 - "owner"
 - "group"
+- "git"
 
 ##### <a name="interface_details_list_items_label"></a>1.10.1.2. Property `Rovr Config > interface > details_list > details_list items > label`
 

--- a/docs/src/content/docs/dev/reference/schema.mdx
+++ b/docs/src/content/docs/dev/reference/schema.mdx
@@ -13,29 +13,35 @@ description: config schema humanified
   - [1.7. Property `Rovr Config > interface > show_line_numbers`](#interface_show_line_numbers)
   - [1.8. Property `Rovr Config > interface > scrolloff`](#interface_scrolloff)
   - [1.9. Property `Rovr Config > interface > show_hidden_files`](#interface_show_hidden_files)
-  - [1.10. Property `Rovr Config > interface > image_viewer`](#interface_image_viewer)
-    - [1.10.1. Property `Rovr Config > interface > image_viewer > protocol`](#interface_image_viewer_protocol)
-    - [1.10.2. Property `Rovr Config > interface > image_viewer > max_size`](#interface_image_viewer_max_size)
-      - [1.10.2.1. Rovr Config > interface > image_viewer > max_size > max_size items](#interface_image_viewer_max_size_items)
-    - [1.10.3. Property `Rovr Config > interface > image_viewer > resampling`](#interface_image_viewer_resampling)
-  - [1.11. Property `Rovr Config > interface > font_preview`](#interface_font_preview)
-    - [1.11.1. Property `Rovr Config > interface > font_preview > max_size`](#interface_font_preview_max_size)
-      - [1.11.1.1. Rovr Config > interface > font_preview > max_size > max_size items](#interface_font_preview_max_size_items)
-    - [1.11.2. Property `Rovr Config > interface > font_preview > font_size`](#interface_font_preview_font_size)
-  - [1.12. Property `Rovr Config > interface > allow_tab_nav`](#interface_allow_tab_nav)
-  - [1.13. Property `Rovr Config > interface > append_new_tabs`](#interface_append_new_tabs)
-  - [1.14. Property `Rovr Config > interface > double_click_delay`](#interface_double_click_delay)
-  - [1.15. Property `Rovr Config > interface > drive_watcher_frequency`](#interface_drive_watcher_frequency)
-  - [1.16. Property `Rovr Config > interface > clock`](#interface_clock)
-    - [1.16.1. Property `Rovr Config > interface > clock > enabled`](#interface_clock_enabled)
-    - [1.16.2. Property `Rovr Config > interface > clock > align`](#interface_clock_align)
-  - [1.17. Property `Rovr Config > interface > preview_text`](#interface_preview_text)
-    - [1.17.1. Property `Rovr Config > interface > preview_text > error`](#interface_preview_text_error)
-    - [1.17.2. Property `Rovr Config > interface > preview_text > start`](#interface_preview_text_start)
-    - [1.17.3. Property `Rovr Config > interface > preview_text > font_text`](#interface_preview_text_font_text)
-  - [1.18. Property `Rovr Config > interface > compact_mode`](#interface_compact_mode)
-    - [1.18.1. Property `Rovr Config > interface > compact_mode > buttons`](#interface_compact_mode_buttons)
-    - [1.18.2. Property `Rovr Config > interface > compact_mode > panels`](#interface_compact_mode_panels)
+  - [1.10. Property `Rovr Config > interface > details_list`](#interface_details_list)
+    - [1.10.1. Rovr Config > interface > details_list > details_list items](#interface_details_list_items)
+      - [1.10.1.1. Property `Rovr Config > interface > details_list > details_list items > type`](#interface_details_list_items_type)
+      - [1.10.1.2. Property `Rovr Config > interface > details_list > details_list items > label`](#interface_details_list_items_label)
+      - [1.10.1.3. Property `Rovr Config > interface > details_list > details_list items > max_length`](#interface_details_list_items_max_length)
+      - [1.10.1.4. Property `Rovr Config > interface > details_list > details_list items > format`](#interface_details_list_items_format)
+  - [1.11. Property `Rovr Config > interface > image_viewer`](#interface_image_viewer)
+    - [1.11.1. Property `Rovr Config > interface > image_viewer > protocol`](#interface_image_viewer_protocol)
+    - [1.11.2. Property `Rovr Config > interface > image_viewer > max_size`](#interface_image_viewer_max_size)
+      - [1.11.2.1. Rovr Config > interface > image_viewer > max_size > max_size items](#interface_image_viewer_max_size_items)
+    - [1.11.3. Property `Rovr Config > interface > image_viewer > resampling`](#interface_image_viewer_resampling)
+  - [1.12. Property `Rovr Config > interface > font_preview`](#interface_font_preview)
+    - [1.12.1. Property `Rovr Config > interface > font_preview > max_size`](#interface_font_preview_max_size)
+      - [1.12.1.1. Rovr Config > interface > font_preview > max_size > max_size items](#interface_font_preview_max_size_items)
+    - [1.12.2. Property `Rovr Config > interface > font_preview > font_size`](#interface_font_preview_font_size)
+  - [1.13. Property `Rovr Config > interface > allow_tab_nav`](#interface_allow_tab_nav)
+  - [1.14. Property `Rovr Config > interface > append_new_tabs`](#interface_append_new_tabs)
+  - [1.15. Property `Rovr Config > interface > double_click_delay`](#interface_double_click_delay)
+  - [1.16. Property `Rovr Config > interface > drive_watcher_frequency`](#interface_drive_watcher_frequency)
+  - [1.17. Property `Rovr Config > interface > clock`](#interface_clock)
+    - [1.17.1. Property `Rovr Config > interface > clock > enabled`](#interface_clock_enabled)
+    - [1.17.2. Property `Rovr Config > interface > clock > align`](#interface_clock_align)
+  - [1.18. Property `Rovr Config > interface > preview_text`](#interface_preview_text)
+    - [1.18.1. Property `Rovr Config > interface > preview_text > error`](#interface_preview_text_error)
+    - [1.18.2. Property `Rovr Config > interface > preview_text > start`](#interface_preview_text_start)
+    - [1.18.3. Property `Rovr Config > interface > preview_text > font_text`](#interface_preview_text_font_text)
+  - [1.19. Property `Rovr Config > interface > compact_mode`](#interface_compact_mode)
+    - [1.19.1. Property `Rovr Config > interface > compact_mode > buttons`](#interface_compact_mode_buttons)
+    - [1.19.2. Property `Rovr Config > interface > compact_mode > panels`](#interface_compact_mode_panels)
 - [2. Property `Rovr Config > settings`](#settings)
   - [2.1. Property `Rovr Config > settings > use_recycle_bin`](#settings_use_recycle_bin)
   - [2.2. Property `Rovr Config > settings > right_click`](#settings_right_click)
@@ -431,26 +437,27 @@ description: config schema humanified
 
 **Description:** Settings related to the user interface and experience
 
-| Property                                                              | Type    | Title/Description                                                                                                                                                            |
-| --------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [tooltips](#interface_tooltips)                                       | boolean | Show tooltips when your mouse is over a tooltip supported button.<br />This is not hot reloaded.                                                                             |
-| [nerd_font](#interface_nerd_font)                                     | boolean | Use nerd font for rendering icons instead of weird characters and stuff.<br />Not properly hot-reloaded.                                                                     |
-| [use_reactive_layout](#interface_use_reactive_layout)                 | boolean | Hide certain elements based on the width and height of the terminal.                                                                                                         |
-| [show_progress_eta](#interface_show_progress_eta)                     | boolean | When copying or deleting files, show an ETA for when the action will be completed.                                                                                           |
-| [show_progress_percentage](#interface_show_progress_percentage)       | boolean | When copying or deleting files, show a percentage of how much had been completed.                                                                                            |
-| [truncate_progress_file_path](#interface_truncate_progress_file_path) | boolean | When the process container is using file paths, truncate the file path to only view the first and last names of the path.                                                    |
-| [show_line_numbers](#interface_show_line_numbers)                     | boolean | Add line numbers to the left gutter if you are viewing a text file.                                                                                                          |
-| [scrolloff](#interface_scrolloff)                                     | integer | The number of files to keep above and below the cursor when moving through the file list.                                                                                    |
-| [show_hidden_files](#interface_show_hidden_files)                     | boolean | Show hidden files and folders (those starting with a dot on Unix, or explicitly hidden on Windows/MacOS).                                                                    |
-| [image_viewer](#interface_image_viewer)                               | object  | Settings related to the image viewer used in the preview sidebar                                                                                                             |
-| [font_preview](#interface_font_preview)                               | object  | Settings related to the font preview used in the preview sidebar                                                                                                             |
-| [allow_tab_nav](#interface_allow_tab_nav)                             | boolean | Allow navigating the main app screen with \`tab\` and \`shift+tab\`                                                                                                          |
-| [append_new_tabs](#interface_append_new_tabs)                         | boolean | Choose whether or not to append new tabs instead of inserting them.<br />\`true\` =&gt; Append to the end of the tab list.<br />\`false\` =&gt; Insert after the active tab. |
-| [double_click_delay](#interface_double_click_delay)                   | number  | The delay between two consecutive clicks to enter into a directory, or open a file.                                                                                          |
-| [drive_watcher_frequency](#interface_drive_watcher_frequency)         | number  | How often (in seconds) to check for changes in mounted drives in the sidebar.                                                                                                |
-| [clock](#interface_clock)                                             | object  |                                                                                                                                                                              |
-| [preview_text](#interface_preview_text)                               | object  |                                                                                                                                                                              |
-| [compact_mode](#interface_compact_mode)                               | object  |                                                                                                                                                                              |
+| Property                                                              | Type            | Title/Description                                                                                                                                                                                                |
+| --------------------------------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [tooltips](#interface_tooltips)                                       | boolean         | Show tooltips when your mouse is over a tooltip supported button.<br />This is not hot reloaded.                                                                                                                 |
+| [nerd_font](#interface_nerd_font)                                     | boolean         | Use nerd font for rendering icons instead of weird characters and stuff.<br />Not properly hot-reloaded.                                                                                                         |
+| [use_reactive_layout](#interface_use_reactive_layout)                 | boolean         | Hide certain elements based on the width and height of the terminal.                                                                                                                                             |
+| [show_progress_eta](#interface_show_progress_eta)                     | boolean         | When copying or deleting files, show an ETA for when the action will be completed.                                                                                                                               |
+| [show_progress_percentage](#interface_show_progress_percentage)       | boolean         | When copying or deleting files, show a percentage of how much had been completed.                                                                                                                                |
+| [truncate_progress_file_path](#interface_truncate_progress_file_path) | boolean         | When the process container is using file paths, truncate the file path to only view the first and last names of the path.                                                                                        |
+| [show_line_numbers](#interface_show_line_numbers)                     | boolean         | Add line numbers to the left gutter if you are viewing a text file.                                                                                                                                              |
+| [scrolloff](#interface_scrolloff)                                     | integer         | The number of files to keep above and below the cursor when moving through the file list.                                                                                                                        |
+| [show_hidden_files](#interface_show_hidden_files)                     | boolean         | Show hidden files and folders (those starting with a dot on Unix, or explicitly hidden on Windows/MacOS).                                                                                                        |
+| [details_list](#interface_details_list)                               | array of object | Metadata columns shown right-aligned in the file list, ordered by priority.<br />Earlier entries are dropped last when the panel becomes too narrow;<br />later entries are dropped first. Set to [] to disable. |
+| [image_viewer](#interface_image_viewer)                               | object          | Settings related to the image viewer used in the preview sidebar                                                                                                                                                 |
+| [font_preview](#interface_font_preview)                               | object          | Settings related to the font preview used in the preview sidebar                                                                                                                                                 |
+| [allow_tab_nav](#interface_allow_tab_nav)                             | boolean         | Allow navigating the main app screen with \`tab\` and \`shift+tab\`                                                                                                                                              |
+| [append_new_tabs](#interface_append_new_tabs)                         | boolean         | Choose whether or not to append new tabs instead of inserting them.<br />\`true\` =&gt; Append to the end of the tab list.<br />\`false\` =&gt; Insert after the active tab.                                     |
+| [double_click_delay](#interface_double_click_delay)                   | number          | The delay between two consecutive clicks to enter into a directory, or open a file.                                                                                                                              |
+| [drive_watcher_frequency](#interface_drive_watcher_frequency)         | number          | How often (in seconds) to check for changes in mounted drives in the sidebar.                                                                                                                                    |
+| [clock](#interface_clock)                                             | object          |                                                                                                                                                                                                                  |
+| [preview_text](#interface_preview_text)                               | object          |                                                                                                                                                                                                                  |
+| [compact_mode](#interface_compact_mode)                               | object          |                                                                                                                                                                                                                  |
 
 ### <a name="interface_tooltips"></a>1.1. Property `Rovr Config > interface > tooltips`
 
@@ -548,7 +555,98 @@ Not properly hot-reloaded.
 
 **Description:** Show hidden files and folders (those starting with a dot on Unix, or explicitly hidden on Windows/MacOS).
 
-### <a name="interface_image_viewer"></a>1.10. Property `Rovr Config > interface > image_viewer`
+### <a name="interface_details_list"></a>1.10. Property `Rovr Config > interface > details_list`
+
+|              |                                         |
+| ------------ | --------------------------------------- |
+| **Type**     | `array of object`                       |
+| **Required** | No                                      |
+| **Default**  | `[{"type": "size"}, {"type": "mtime"}]` |
+
+**Description:** Metadata columns shown right-aligned in the file list, ordered by priority.
+Earlier entries are dropped last when the panel becomes too narrow;
+later entries are dropped first. Set to [] to disable.
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                     | Description |
+| --------------------------------------------------- | ----------- |
+| [details_list items](#interface_details_list_items) |             |
+
+#### <a name="interface_details_list_items"></a>1.10.1. Rovr Config > interface > details_list > details_list items
+
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
+
+| Property                                               | Type             | Title/Description                                                                                                   |
+| ------------------------------------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------- |
+| [type](#interface_details_list_items_type)             | enum (of string) | What metadata to show. size shows the item count for folders.                                                       |
+| [label](#interface_details_list_items_label)           | string           | Column header label. Defaults to a built-in label for the type.                                                     |
+| [max_length](#interface_details_list_items_max_length) | integer          | Column width cap in cells. Defaults to the natural width of the type.<br />The label's width acts as a lower bound. |
+| [format](#interface_details_list_items_format)         | string           | strftime format for mtime/atime/ctime columns.<br />Defaults to metadata.datetime_format.                           |
+
+##### <a name="interface_details_list_items_type"></a>1.10.1.1. Property `Rovr Config > interface > details_list > details_list items > type`
+
+|              |                    |
+| ------------ | ------------------ |
+| **Type**     | `enum (of string)` |
+| **Required** | Yes                |
+
+**Description:** What metadata to show. size shows the item count for folders.
+
+Must be one of:
+
+- "size"
+- "mtime"
+- "atime"
+- "ctime"
+- "permissions"
+- "owner"
+- "group"
+
+##### <a name="interface_details_list_items_label"></a>1.10.1.2. Property `Rovr Config > interface > details_list > details_list items > label`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Column header label. Defaults to a built-in label for the type.
+
+##### <a name="interface_details_list_items_max_length"></a>1.10.1.3. Property `Rovr Config > interface > details_list > details_list items > max_length`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `integer` |
+| **Required** | No        |
+
+**Description:** Column width cap in cells. Defaults to the natural width of the type.
+The label's width acts as a lower bound.
+
+| Restrictions |        |
+| ------------ | ------ |
+| **Minimum**  | &ge; 1 |
+
+##### <a name="interface_details_list_items_format"></a>1.10.1.4. Property `Rovr Config > interface > details_list > details_list items > format`
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** strftime format for mtime/atime/ctime columns.
+Defaults to metadata.datetime_format.
+
+### <a name="interface_image_viewer"></a>1.11. Property `Rovr Config > interface > image_viewer`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -564,7 +662,7 @@ Not properly hot-reloaded.
 | [max_size](#interface_image_viewer_max_size)     | array of integer | The maximum size for the image viewer. If the image exceeds this size, it will be scaled down to fit within these dimensions while maintaining its aspect ratio. |
 | [resampling](#interface_image_viewer_resampling) | enum (of string) | The resampling method to use when resizing images. This is only applicable when the image exceeds the maximum size specified in \`max_size\`.                    |
 
-#### <a name="interface_image_viewer_protocol"></a>1.10.1. Property `Rovr Config > interface > image_viewer > protocol`
+#### <a name="interface_image_viewer_protocol"></a>1.11.1. Property `Rovr Config > interface > image_viewer > protocol`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -582,7 +680,7 @@ Must be one of:
 - "Halfcell"
 - "Unicode"
 
-#### <a name="interface_image_viewer_max_size"></a>1.10.2. Property `Rovr Config > interface > image_viewer > max_size`
+#### <a name="interface_image_viewer_max_size"></a>1.11.2. Property `Rovr Config > interface > image_viewer > max_size`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -604,7 +702,7 @@ Must be one of:
 | -------------------------------------------------------- | ----------- |
 | [max_size items](#interface_image_viewer_max_size_items) |             |
 
-##### <a name="interface_image_viewer_max_size_items"></a>1.10.2.1. Rovr Config > interface > image_viewer > max_size > max_size items
+##### <a name="interface_image_viewer_max_size_items"></a>1.11.2.1. Rovr Config > interface > image_viewer > max_size > max_size items
 
 |              |           |
 | ------------ | --------- |
@@ -615,7 +713,7 @@ Must be one of:
 | ------------ | ------ |
 | **Minimum**  | &ge; 1 |
 
-#### <a name="interface_image_viewer_resampling"></a>1.10.3. Property `Rovr Config > interface > image_viewer > resampling`
+#### <a name="interface_image_viewer_resampling"></a>1.11.3. Property `Rovr Config > interface > image_viewer > resampling`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -634,7 +732,7 @@ Must be one of:
 - "box"
 - "hamming"
 
-### <a name="interface_font_preview"></a>1.11. Property `Rovr Config > interface > font_preview`
+### <a name="interface_font_preview"></a>1.12. Property `Rovr Config > interface > font_preview`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -649,7 +747,7 @@ Must be one of:
 | [max_size](#interface_font_preview_max_size)   | array of integer | The maximum size for the font preview. If the rendered font preview exceeds this size, it will be scaled down to fit within these dimensions while maintaining its aspect ratio. |
 | [font_size](#interface_font_preview_font_size) | integer          | The font size to use when rendering font previews. This is only applicable when the font preview exceeds the maximum size specified in \`max_size\`.                             |
 
-#### <a name="interface_font_preview_max_size"></a>1.11.1. Property `Rovr Config > interface > font_preview > max_size`
+#### <a name="interface_font_preview_max_size"></a>1.12.1. Property `Rovr Config > interface > font_preview > max_size`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -671,7 +769,7 @@ Must be one of:
 | -------------------------------------------------------- | ----------- |
 | [max_size items](#interface_font_preview_max_size_items) |             |
 
-##### <a name="interface_font_preview_max_size_items"></a>1.11.1.1. Rovr Config > interface > font_preview > max_size > max_size items
+##### <a name="interface_font_preview_max_size_items"></a>1.12.1.1. Rovr Config > interface > font_preview > max_size > max_size items
 
 |              |           |
 | ------------ | --------- |
@@ -682,7 +780,7 @@ Must be one of:
 | ------------ | ------ |
 | **Minimum**  | &ge; 1 |
 
-#### <a name="interface_font_preview_font_size"></a>1.11.2. Property `Rovr Config > interface > font_preview > font_size`
+#### <a name="interface_font_preview_font_size"></a>1.12.2. Property `Rovr Config > interface > font_preview > font_size`
 
 |              |           |
 | ------------ | --------- |
@@ -692,7 +790,7 @@ Must be one of:
 
 **Description:** The font size to use when rendering font previews. This is only applicable when the font preview exceeds the maximum size specified in `max_size`.
 
-### <a name="interface_allow_tab_nav"></a>1.12. Property `Rovr Config > interface > allow_tab_nav`
+### <a name="interface_allow_tab_nav"></a>1.13. Property `Rovr Config > interface > allow_tab_nav`
 
 |              |           |
 | ------------ | --------- |
@@ -702,7 +800,7 @@ Must be one of:
 
 **Description:** Allow navigating the main app screen with `tab` and `shift+tab`
 
-### <a name="interface_append_new_tabs"></a>1.13. Property `Rovr Config > interface > append_new_tabs`
+### <a name="interface_append_new_tabs"></a>1.14. Property `Rovr Config > interface > append_new_tabs`
 
 |              |           |
 | ------------ | --------- |
@@ -714,7 +812,7 @@ Must be one of:
 `true` =&gt; Append to the end of the tab list.
 `false` =&gt; Insert after the active tab.
 
-### <a name="interface_double_click_delay"></a>1.14. Property `Rovr Config > interface > double_click_delay`
+### <a name="interface_double_click_delay"></a>1.15. Property `Rovr Config > interface > double_click_delay`
 
 |              |          |
 | ------------ | -------- |
@@ -724,7 +822,7 @@ Must be one of:
 
 **Description:** The delay between two consecutive clicks to enter into a directory, or open a file.
 
-### <a name="interface_drive_watcher_frequency"></a>1.15. Property `Rovr Config > interface > drive_watcher_frequency`
+### <a name="interface_drive_watcher_frequency"></a>1.16. Property `Rovr Config > interface > drive_watcher_frequency`
 
 |              |          |
 | ------------ | -------- |
@@ -734,7 +832,7 @@ Must be one of:
 
 **Description:** How often (in seconds) to check for changes in mounted drives in the sidebar.
 
-### <a name="interface_clock"></a>1.16. Property `Rovr Config > interface > clock`
+### <a name="interface_clock"></a>1.17. Property `Rovr Config > interface > clock`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -747,7 +845,7 @@ Must be one of:
 | [enabled](#interface_clock_enabled) | boolean          | Show a clock in the tabs bar.                                    |
 | [align](#interface_clock_align)     | enum (of string) | Align the clock to either the 'right' or 'left' of the tabs bar. |
 
-#### <a name="interface_clock_enabled"></a>1.16.1. Property `Rovr Config > interface > clock > enabled`
+#### <a name="interface_clock_enabled"></a>1.17.1. Property `Rovr Config > interface > clock > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -757,7 +855,7 @@ Must be one of:
 
 **Description:** Show a clock in the tabs bar.
 
-#### <a name="interface_clock_align"></a>1.16.2. Property `Rovr Config > interface > clock > align`
+#### <a name="interface_clock_align"></a>1.17.2. Property `Rovr Config > interface > clock > align`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -772,7 +870,7 @@ Must be one of:
 - "left"
 - "right"
 
-### <a name="interface_preview_text"></a>1.17. Property `Rovr Config > interface > preview_text`
+### <a name="interface_preview_text"></a>1.18. Property `Rovr Config > interface > preview_text`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -786,7 +884,7 @@ Must be one of:
 | [start](#interface_preview_text_start)         | string | This is shown when the rovr starts up. You may see it for a split second, but it will never appear afterwards. You cannot view this properly in this docs. |
 | [font_text](#interface_preview_text_font_text) | string | When a font file is previewed, this text will be rendered in the font if possible.                                                                         |
 
-#### <a name="interface_preview_text_error"></a>1.17.1. Property `Rovr Config > interface > preview_text > error`
+#### <a name="interface_preview_text_error"></a>1.18.1. Property `Rovr Config > interface > preview_text > error`
 
 |              |                                     |
 | ------------ | ----------------------------------- |
@@ -796,7 +894,7 @@ Must be one of:
 
 **Description:** If for any reason the file preview refused to show, this appears.
 
-#### <a name="interface_preview_text_start"></a>1.17.2. Property `Rovr Config > interface > preview_text > start`
+#### <a name="interface_preview_text_start"></a>1.18.2. Property `Rovr Config > interface > preview_text > start`
 
 |              |                                                                                                                                      |
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
@@ -806,7 +904,7 @@ Must be one of:
 
 **Description:** This is shown when the rovr starts up. You may see it for a split second, but it will never appear afterwards. You cannot view this properly in this docs.
 
-#### <a name="interface_preview_text_font_text"></a>1.17.3. Property `Rovr Config > interface > preview_text > font_text`
+#### <a name="interface_preview_text_font_text"></a>1.18.3. Property `Rovr Config > interface > preview_text > font_text`
 
 |              |                                                                                                                            |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------- |
@@ -816,7 +914,7 @@ Must be one of:
 
 **Description:** When a font file is previewed, this text will be rendered in the font if possible.
 
-### <a name="interface_compact_mode"></a>1.18. Property `Rovr Config > interface > compact_mode`
+### <a name="interface_compact_mode"></a>1.19. Property `Rovr Config > interface > compact_mode`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -829,7 +927,7 @@ Must be one of:
 | [buttons](#interface_compact_mode_buttons) | boolean | Whether to compact the buttons and path input to one line instead of three.  |
 | [panels](#interface_compact_mode_panels)   | boolean | Whether to make the panels smaller to add more room for the file list itself |
 
-#### <a name="interface_compact_mode_buttons"></a>1.18.1. Property `Rovr Config > interface > compact_mode > buttons`
+#### <a name="interface_compact_mode_buttons"></a>1.19.1. Property `Rovr Config > interface > compact_mode > buttons`
 
 |              |           |
 | ------------ | --------- |
@@ -839,7 +937,7 @@ Must be one of:
 
 **Description:** Whether to compact the buttons and path input to one line instead of three.
 
-#### <a name="interface_compact_mode_panels"></a>1.18.2. Property `Rovr Config > interface > compact_mode > panels`
+#### <a name="interface_compact_mode_panels"></a>1.19.2. Property `Rovr Config > interface > compact_mode > panels`
 
 |              |           |
 | ------------ | --------- |

--- a/docs/src/content/docs/dev/reference/schema.mdx
+++ b/docs/src/content/docs/dev/reference/schema.mdx
@@ -557,11 +557,11 @@ Not properly hot-reloaded.
 
 ### <a name="interface_details_list"></a>1.10. Property `Rovr Config > interface > details_list`
 
-|              |                                         |
-| ------------ | --------------------------------------- |
-| **Type**     | `array of object`                       |
-| **Required** | No                                      |
-| **Default**  | `[{"type": "size"}, {"type": "mtime"}]` |
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of object` |
+| **Required** | No                |
+| **Default**  | `[]`              |
 
 **Description:** Metadata columns shown right-aligned in the file list, ordered by priority.
 Earlier entries are dropped last when the panel becomes too narrow;

--- a/docs/src/content/docs/features/detail-columns.mdx
+++ b/docs/src/content/docs/features/detail-columns.mdx
@@ -1,0 +1,6 @@
+---
+title: detail columns
+description: show file metadata in table-like columns next to file names.
+---
+
+this feature is only available in the dev version for now. check out the [dev docs](/rovr/dev/features/detail-columns) instead.

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -763,6 +763,8 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
                             dir_entry = get_direntry_for(highlighted_path)
                             if dir_entry is not None:
                                 highlighted_option.dir_entry = dir_entry
+                                highlighted_option._invalidate_prompt_cache()
+                                file_list.refresh()
                                 self.query_one(MetadataContainer).update_metadata(
                                     dir_entry
                                 )

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -764,7 +764,7 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
                             if dir_entry is not None:
                                 highlighted_option.dir_entry = dir_entry
                                 highlighted_option._invalidate_prompt_cache()
-                                file_list.refresh()
+                                file_list.call_next(file_list.refresh)
                                 self.query_one(MetadataContainer).update_metadata(
                                     dir_entry
                                 )

--- a/src/rovr/classes/config.pyi
+++ b/src/rovr/classes/config.pyi
@@ -785,7 +785,8 @@ class _RovrConfigInterfaceDetailsListItem(TypedDict, total=False):
     type: Required["_RovrConfigInterfaceDetailsListItemType"]
     r"""
     What metadata to show. size shows the item count for folders.
-    git shows the most severe git status char (UDMRCA?) per entry and hides itself outside a git work tree.
+    git shows the two-char XY status like git status --short (first char staged, second unstaged)
+    and hides itself outside a git work tree.
 
     Required property
     """
@@ -819,7 +820,8 @@ _RovrConfigInterfaceDetailsListItemType = (
 )
 r"""
 What metadata to show. size shows the item count for folders.
-git shows the most severe git status char (UDMRCA?) per entry and hides itself outside a git work tree.
+git shows the two-char XY status like git status --short (first char staged, second unstaged)
+and hides itself outside a git work tree.
 """
 _ROVRCONFIGINTERFACEDETAILSLISTITEMTYPE_SIZE: Literal["size"] = "size"
 r"""The values for the 'What metadata to show. size shows the item count for folders' enum"""

--- a/src/rovr/classes/config.pyi
+++ b/src/rovr/classes/config.pyi
@@ -69,7 +69,7 @@ r""" Default value of the field path 'Rovr Config interface compact_mode buttons
 _ROVR_CONFIG_INTERFACE_COMPACT_MODE_PANELS_DEFAULT = False
 r""" Default value of the field path 'Rovr Config interface compact_mode panels' """
 
-_ROVR_CONFIG_INTERFACE_DETAILS_LIST_DEFAULT = [{"type": "size"}, {"type": "mtime"}]
+_ROVR_CONFIG_INTERFACE_DETAILS_LIST_DEFAULT: list[Any] = []
 r""" Default value of the field path 'Rovr Config interface details_list' """
 
 _ROVR_CONFIG_INTERFACE_DOUBLE_CLICK_DELAY_DEFAULT = 0.25
@@ -696,8 +696,7 @@ class _RovrConfigInterface(TypedDict, total=False):
     later entries are dropped first. Set to [] to disable.
 
     default:
-      - type: size
-      - type: mtime
+      []
     """
 
     image_viewer: "_RovrConfigInterfaceImageViewer"

--- a/src/rovr/classes/config.pyi
+++ b/src/rovr/classes/config.pyi
@@ -785,6 +785,7 @@ class _RovrConfigInterfaceDetailsListItem(TypedDict, total=False):
     type: Required["_RovrConfigInterfaceDetailsListItemType"]
     r"""
     What metadata to show. size shows the item count for folders.
+    git shows the most severe git status char (UDMRCA?) per entry and hides itself outside a git work tree.
 
     Required property
     """
@@ -814,8 +815,12 @@ _RovrConfigInterfaceDetailsListItemType = (
     | Literal["permissions"]
     | Literal["owner"]
     | Literal["group"]
+    | Literal["git"]
 )
-r""" What metadata to show. size shows the item count for folders. """
+r"""
+What metadata to show. size shows the item count for folders.
+git shows the most severe git status char (UDMRCA?) per entry and hides itself outside a git work tree.
+"""
 _ROVRCONFIGINTERFACEDETAILSLISTITEMTYPE_SIZE: Literal["size"] = "size"
 r"""The values for the 'What metadata to show. size shows the item count for folders' enum"""
 _ROVRCONFIGINTERFACEDETAILSLISTITEMTYPE_MTIME: Literal["mtime"] = "mtime"
@@ -831,6 +836,8 @@ r"""The values for the 'What metadata to show. size shows the item count for fol
 _ROVRCONFIGINTERFACEDETAILSLISTITEMTYPE_OWNER: Literal["owner"] = "owner"
 r"""The values for the 'What metadata to show. size shows the item count for folders' enum"""
 _ROVRCONFIGINTERFACEDETAILSLISTITEMTYPE_GROUP: Literal["group"] = "group"
+r"""The values for the 'What metadata to show. size shows the item count for folders' enum"""
+_ROVRCONFIGINTERFACEDETAILSLISTITEMTYPE_GIT: Literal["git"] = "git"
 r"""The values for the 'What metadata to show. size shows the item count for folders' enum"""
 
 class _RovrConfigInterfaceFontPreview(TypedDict, total=False):

--- a/src/rovr/classes/config.pyi
+++ b/src/rovr/classes/config.pyi
@@ -69,6 +69,9 @@ r""" Default value of the field path 'Rovr Config interface compact_mode buttons
 _ROVR_CONFIG_INTERFACE_COMPACT_MODE_PANELS_DEFAULT = False
 r""" Default value of the field path 'Rovr Config interface compact_mode panels' """
 
+_ROVR_CONFIG_INTERFACE_DETAILS_LIST_DEFAULT = [{"type": "size"}, {"type": "mtime"}]
+r""" Default value of the field path 'Rovr Config interface details_list' """
+
 _ROVR_CONFIG_INTERFACE_DOUBLE_CLICK_DELAY_DEFAULT = 0.25
 r""" Default value of the field path 'Rovr Config interface double_click_delay' """
 
@@ -686,6 +689,17 @@ class _RovrConfigInterface(TypedDict, total=False):
     default: False
     """
 
+    details_list: list["_RovrConfigInterfaceDetailsListItem"]
+    r"""
+    Metadata columns shown right-aligned in the file list, ordered by priority.
+    Earlier entries are dropped last when the panel becomes too narrow;
+    later entries are dropped first. Set to [] to disable.
+
+    default:
+      - type: size
+      - type: mtime
+    """
+
     image_viewer: "_RovrConfigInterfaceImageViewer"
     r""" Settings related to the image viewer used in the preview sidebar """
 
@@ -766,6 +780,58 @@ class _RovrConfigInterfaceCompactMode(TypedDict, total=False):
 
     default: False
     """
+
+class _RovrConfigInterfaceDetailsListItem(TypedDict, total=False):
+    type: Required["_RovrConfigInterfaceDetailsListItemType"]
+    r"""
+    What metadata to show. size shows the item count for folders.
+
+    Required property
+    """
+
+    label: str
+    r""" Column header label. Defaults to a built-in label for the type. """
+
+    max_length: int
+    r"""
+    Column width cap in cells. Defaults to the natural width of the type.
+    The label's width acts as a lower bound.
+
+    minimum: 1
+    """
+
+    format: str
+    r"""
+    strftime format for mtime/atime/ctime columns.
+    Defaults to metadata.datetime_format.
+    """
+
+_RovrConfigInterfaceDetailsListItemType = (
+    Literal["size"]
+    | Literal["mtime"]
+    | Literal["atime"]
+    | Literal["ctime"]
+    | Literal["permissions"]
+    | Literal["owner"]
+    | Literal["group"]
+)
+r""" What metadata to show. size shows the item count for folders. """
+_ROVRCONFIGINTERFACEDETAILSLISTITEMTYPE_SIZE: Literal["size"] = "size"
+r"""The values for the 'What metadata to show. size shows the item count for folders' enum"""
+_ROVRCONFIGINTERFACEDETAILSLISTITEMTYPE_MTIME: Literal["mtime"] = "mtime"
+r"""The values for the 'What metadata to show. size shows the item count for folders' enum"""
+_ROVRCONFIGINTERFACEDETAILSLISTITEMTYPE_ATIME: Literal["atime"] = "atime"
+r"""The values for the 'What metadata to show. size shows the item count for folders' enum"""
+_ROVRCONFIGINTERFACEDETAILSLISTITEMTYPE_CTIME: Literal["ctime"] = "ctime"
+r"""The values for the 'What metadata to show. size shows the item count for folders' enum"""
+_ROVRCONFIGINTERFACEDETAILSLISTITEMTYPE_PERMISSIONS: Literal["permissions"] = (
+    "permissions"
+)
+r"""The values for the 'What metadata to show. size shows the item count for folders' enum"""
+_ROVRCONFIGINTERFACEDETAILSLISTITEMTYPE_OWNER: Literal["owner"] = "owner"
+r"""The values for the 'What metadata to show. size shows the item count for folders' enum"""
+_ROVRCONFIGINTERFACEDETAILSLISTITEMTYPE_GROUP: Literal["group"] = "group"
+r"""The values for the 'What metadata to show. size shows the item count for folders' enum"""
 
 class _RovrConfigInterfaceFontPreview(TypedDict, total=False):
     r"""Settings related to the font preview used in the preview sidebar"""

--- a/src/rovr/classes/textual_options.py
+++ b/src/rovr/classes/textual_options.py
@@ -188,7 +188,9 @@ class FileListSelectionWidget(LazySelection):
         self.dir_entry = dir_entry
         self.mime_type: str | None = None
         self.folder_item_count: int | None = None
+        self.git_status: str = ""
         self._detail_cells: tuple[str, ...] | None = None
+        self._detail_cells_key: tuple[detail_utils.DetailColumn, ...] | None = None
         this_id = str(id(self))
         self.__icon_factory = icon_factory
         self.__label = label
@@ -209,15 +211,22 @@ class FileListSelectionWidget(LazySelection):
     def get_prompt(self) -> Content:
         return _get_cached_icon(self.__icon_factory()) + Content(self.__label)
 
-    def detail_cells(self) -> tuple[str, ...]:
-        if self._detail_cells is None:
+    def detail_cells(
+        self, columns: tuple[detail_utils.DetailColumn, ...]
+    ) -> tuple[str, ...]:
+        if self._detail_cells is None or self._detail_cells_key != columns:
             self._detail_cells = detail_utils.detail_cells(
-                self.dir_entry, self, detail_utils.get_detail_columns()
+                self.dir_entry, self, columns
             )
+            self._detail_cells_key = columns
         return self._detail_cells
 
     def set_folder_item_count(self, count: int) -> None:
         self.folder_item_count = count
+        self._detail_cells = None
+
+    def set_git_status(self, status: str) -> None:
+        self.git_status = status
         self._detail_cells = None
 
     def _invalidate_prompt_cache(self) -> None:

--- a/src/rovr/classes/textual_options.py
+++ b/src/rovr/classes/textual_options.py
@@ -12,6 +12,7 @@ from textual.widgets.option_list import Option
 from textual.widgets.selection_list import Selection, SelectionType
 from textual_autocomplete import DropdownItem
 
+from rovr.functions import details as detail_utils
 from rovr.functions import icons as icon_utils
 from rovr.functions.path import is_hidden_file, normalise
 
@@ -186,6 +187,8 @@ class FileListSelectionWidget(LazySelection):
         """
         self.dir_entry = dir_entry
         self.mime_type: str | None = None
+        self.folder_item_count: int | None = None
+        self._detail_cells: tuple[str, ...] | None = None
         this_id = str(id(self))
         self.__icon_factory = icon_factory
         self.__label = label
@@ -205,6 +208,21 @@ class FileListSelectionWidget(LazySelection):
 
     def get_prompt(self) -> Content:
         return _get_cached_icon(self.__icon_factory()) + Content(self.__label)
+
+    def detail_cells(self) -> tuple[str, ...]:
+        if self._detail_cells is None:
+            self._detail_cells = detail_utils.detail_cells(
+                self.dir_entry, self, detail_utils.get_detail_columns()
+            )
+        return self._detail_cells
+
+    def set_folder_item_count(self, count: int) -> None:
+        self.folder_item_count = count
+        self._detail_cells = None
+
+    def _invalidate_prompt_cache(self) -> None:
+        self._detail_cells = None
+        super()._invalidate_prompt_cache()
 
     def get_component_classes(self) -> list[str]:
         classes: list[str] = []

--- a/src/rovr/config/config.toml
+++ b/src/rovr/config/config.toml
@@ -17,6 +17,10 @@ drive_watcher_frequency = 3.0
 # yazi style is 5
 # but it has more space
 scrolloff = 3
+details_list = [
+  { type = "size" },
+  { type = "mtime" },
+]
 
 [interface.image_viewer]
 protocol = "Auto"

--- a/src/rovr/config/config.toml
+++ b/src/rovr/config/config.toml
@@ -19,7 +19,8 @@ drive_watcher_frequency = 3.0
 scrolloff = 3
 details_list = [
   { type = "size" },
-  { type = "mtime" },
+  { type = "mtime", label = "mtime" },
+  { type = "git" }
 ]
 
 [interface.image_viewer]

--- a/src/rovr/config/config.toml
+++ b/src/rovr/config/config.toml
@@ -17,11 +17,6 @@ drive_watcher_frequency = 3.0
 # yazi style is 5
 # but it has more space
 scrolloff = 3
-details_list = [
-  { type = "size" },
-  { type = "mtime", label = "mtime" },
-  { type = "git" }
-]
 
 [interface.image_viewer]
 protocol = "Auto"

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -220,6 +220,36 @@
           "default": false,
           "description": "Show hidden files and folders (those starting with a dot on Unix, or explicitly hidden on Windows/MacOS)."
         },
+        "details_list": {
+          "type": "array",
+          "default": [{ "type": "size" }, { "type": "mtime" }],
+          "description": "Metadata columns shown right-aligned in the file list, ordered by priority.\nEarlier entries are dropped last when the panel becomes too narrow;\nlater entries are dropped first. Set to [] to disable.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type"],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["size", "mtime", "atime", "ctime", "permissions", "owner", "group"],
+                "description": "What metadata to show. size shows the item count for folders."
+              },
+              "label": {
+                "type": "string",
+                "description": "Column header label. Defaults to a built-in label for the type."
+              },
+              "max_length": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Column width cap in cells. Defaults to the natural width of the type.\nThe label's width acts as a lower bound."
+              },
+              "format": {
+                "type": "string",
+                "description": "strftime format for mtime/atime/ctime columns.\nDefaults to metadata.datetime_format."
+              }
+            }
+          }
+        },
         "image_viewer": {
           "type": "object",
           "description": "Settings related to the image viewer used in the preview sidebar",

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -231,8 +231,8 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["size", "mtime", "atime", "ctime", "permissions", "owner", "group"],
-                "description": "What metadata to show. size shows the item count for folders."
+                "enum": ["size", "mtime", "atime", "ctime", "permissions", "owner", "group", "git"],
+                "description": "What metadata to show. size shows the item count for folders.\ngit shows the two-char XY status like git status --short (first char staged, second unstaged)\nand hides itself outside a git work tree."
               },
               "label": {
                 "type": "string",

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -222,7 +222,7 @@
         },
         "details_list": {
           "type": "array",
-          "default": [{ "type": "size" }, { "type": "mtime" }],
+          "default": [],
           "description": "Metadata columns shown right-aligned in the file list, ordered by priority.\nEarlier entries are dropped last when the panel becomes too narrow;\nlater entries are dropped first. Set to [] to disable.",
           "items": {
             "type": "object",

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -5,8 +5,10 @@ from typing import Callable, ClassVar, Iterable, Self, Sequence
 
 from rich.cells import cell_len
 from rich.segment import Segment
+from rich.style import Style
 from textual import events, work
 from textual.binding import BindingType
+from textual.color import Color
 from textual.content import ContentText
 from textual.css.query import NoMatches
 from textual.errors import NoWidget
@@ -65,6 +67,16 @@ class FileList(
         "filelist--hidden",
         "filelist--hidden--highlighted",
         "filelist--hidden--hovered",
+        "filelist--detail-size",
+        "filelist--detail-mtime",
+        "filelist--detail-atime",
+        "filelist--detail-ctime",
+        "filelist--detail-permissions",
+        "filelist--detail-owner",
+        "filelist--detail-group",
+        "filelist--git-staged",
+        "filelist--git-unstaged",
+        "filelist--git-untracked",
     }
 
     ACTIONS: list[Action] = [
@@ -183,13 +195,77 @@ class FileList(
             return line
         if not isinstance(option, FileListSelectionWidget):
             return line
-        details = "  ".join(option.detail_cells(columns)[:fitted]) + " "
+        cells = option.detail_cells(columns)[:fitted]
         segments = list(line)
-        style = segments[-1].style if segments else self.rich_style
+        style = (segments[-1].style if segments else None) or self.rich_style
+        detail_segments: list[Segment] = []
+        details_width = 1
+        for column, cell in zip(columns[:fitted], cells):
+            details_width += column.width + 2
+            detail_segments.append(Segment("  ", style))
+            if column.type == "git":
+                pad, pair = cell[:-2], cell[-2:]
+                if pad:
+                    detail_segments.append(Segment(pad, style))
+                if pair == "??":
+                    detail_segments.append(
+                        Segment(
+                            pair,
+                            self._detail_rich_style("filelist--git-untracked", style),
+                        )
+                    )
+                elif pair.strip():
+                    detail_segments.append(
+                        Segment(
+                            pair[0],
+                            self._detail_rich_style("filelist--git-staged", style),
+                        )
+                    )
+                    detail_segments.append(
+                        Segment(
+                            pair[1],
+                            self._detail_rich_style("filelist--git-unstaged", style),
+                        )
+                    )
+                else:
+                    detail_segments.append(Segment(pair, style))
+            else:
+                detail_segments.append(
+                    Segment(
+                        cell,
+                        self._detail_rich_style(
+                            f"filelist--detail-{column.type}", style
+                        ),
+                    )
+                )
+        detail_segments.append(Segment(" ", style))
         return Strip([
-            *line.adjust_cell_length(width - cell_len(details), style),
-            Segment(details, style=style),
+            *line.adjust_cell_length(width - details_width, style),
+            *detail_segments,
         ])
+
+    def _detail_rich_style(self, component_class: str, base: Style) -> Style:
+        """The row style with the component class's foreground and text style on top.
+
+        Returns:
+            Style: The merged rich style.
+        """
+        visual = self.get_visual_style("option-list--option", component_class)
+        foreground = visual.foreground
+        if foreground is None:
+            return base
+        if foreground.a < 1 and base.bgcolor is not None:
+            foreground = Color.from_rich_color(base.bgcolor).blend(
+                foreground, foreground.a
+            )
+        return base + Style(
+            color=foreground.rich_color,
+            bold=visual.bold,
+            dim=visual.dim,
+            italic=visual.italic,
+            underline=visual.underline,
+            strike=visual.strike,
+        )
 
     def details_header_text(self) -> str:
         """The header line aligned with the name and detail columns.

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -1,16 +1,20 @@
 import shlex
 from contextlib import suppress
-from os import getcwd, path
+from os import getcwd, path, scandir
 from typing import Callable, ClassVar, Iterable, Self, Sequence
 
+from rich.cells import cell_len
+from rich.segment import Segment
 from textual import events, work
 from textual.binding import BindingType
 from textual.content import ContentText
 from textual.css.query import NoMatches
 from textual.errors import NoWidget
+from textual.strip import Strip
 from textual.widgets import Button, Input, OptionList, SelectionList
 from textual.widgets.option_list import OptionDoesNotExist
 from textual.widgets.selection_list import Selection, SelectionType
+from textual.worker import get_current_worker
 
 from rovr.classes.mixins import (
     Action,
@@ -21,6 +25,7 @@ from rovr.classes.mixins import (
 )
 from rovr.classes.session_manager import SessionManager, SessionOptionDict
 from rovr.classes.textual_options import FileListSelectionWidget, LazySelection
+from rovr.functions import details as detail_utils
 from rovr.functions import path as path_utils
 from rovr.functions import pins as pin_utils
 from rovr.functions import utils
@@ -147,6 +152,73 @@ class FileList(
             return self.options[self.highlighted]
         else:
             return None
+
+    def render_line(self, y: int) -> Strip:
+        line = super().render_line(y)
+        if self.dummy:
+            return line
+        columns = detail_utils.get_detail_columns()
+        if not columns:
+            return line
+        width = self.scrollable_content_region.width
+        fitted = detail_utils.fit_column_count(width, columns)
+        if not fitted:
+            return line
+        try:
+            option_index, _ = self._lines[self.scroll_offset.y + y]
+            option = self.options[option_index]
+        except (IndexError, KeyError):
+            return line
+        if not isinstance(option, FileListSelectionWidget):
+            return line
+        details = "  ".join(option.detail_cells()[:fitted]) + " "
+        segments = list(line)
+        style = segments[-1].style if segments else self.rich_style
+        return Strip([
+            *line.adjust_cell_length(width - cell_len(details), style),
+            Segment(details, style=style),
+        ])
+
+    def details_header_text(self) -> str:
+        """The header line aligned with the name and detail columns.
+
+        Returns:
+            str: The full-width header text.
+        """
+        columns = detail_utils.get_detail_columns()
+        width = self.scrollable_content_region.width
+        fitted = detail_utils.fit_column_count(width, columns)
+        gutter = self._get_left_gutter_width()
+        labels = "  ".join(
+            detail_utils._pad(column.label, column.width) for column in columns[:fitted]
+        )
+        left = " " * gutter + "   Name"
+        if labels:
+            labels += " "
+        pad = max(1, width - cell_len(left) - cell_len(labels))
+        return left + " " * pad + labels
+
+    @work(thread=True, exclusive=True, group="folder_counts")
+    def fill_folder_item_counts(self) -> None:
+        if self.dummy or not any(
+            column.type == "size" for column in detail_utils.get_detail_columns()
+        ):
+            return
+        worker = get_current_worker()
+        options = self._options
+        dirty = False
+        for option in options:
+            if worker.is_cancelled or options is not self._options:
+                return
+            if not isinstance(option, FileListSelectionWidget):
+                continue
+            with suppress(OSError):
+                if option.dir_entry.is_dir():
+                    with scandir(option.dir_entry.path) as entries:
+                        option.set_folder_item_count(sum(1 for _ in entries))
+                    dirty = True
+        if dirty and not worker.is_cancelled:
+            self.app.call_from_thread(self.refresh)
 
     # ignore single clicks
     async def _on_click(self, event: events.Click) -> None:
@@ -314,6 +386,10 @@ class FileList(
             self.app.query_one("#up").disabled = cwd == path.dirname(cwd)
 
             self.set_options(self.list_of_options)
+            self.fill_folder_item_counts()
+            update_header = getattr(self.parent, "update_details_header", None)
+            if callable(update_header):
+                self.call_after_refresh(update_header)
             # fix selected options
             if (has_selected or self.select_mode_enabled) and name_to_index:
                 self.update_from_session(session, name_to_index)
@@ -564,6 +640,9 @@ class FileList(
             self.add_class("select-mode")
         else:
             self.remove_class("select-mode")
+        update_header = getattr(self.parent, "update_details_header", None)
+        if callable(update_header):
+            update_header()
 
     async def get_selected_objects(self) -> list[str] | None:
         """Get the selected objects in the file list.

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -199,7 +199,7 @@ class FileList(
         segments = list(line)
         style = (segments[-1].style if segments else None) or self.rich_style
         detail_segments: list[Segment] = []
-        details_width = 1
+        details_width = 1  # is 1 and not 0 because minor right padding
         for column, cell in zip(columns[:fitted], cells):
             details_width += column.width + 2
             detail_segments.append(Segment("  ", style))

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -135,6 +135,7 @@ class FileList(
             self.items_in_cwd: set[str] = set()
         self.file_list_pause_check = False
         self._ignore_next_click: bool = False
+        self._in_git_repo: bool = False
 
     def on_mount(self) -> None:
         if not self.dummy and self.parent:
@@ -153,11 +154,22 @@ class FileList(
         else:
             return None
 
+    def _detail_columns(self) -> tuple[detail_utils.DetailColumn, ...]:
+        """The configured columns, with the git column hidden outside a work tree.
+
+        Returns:
+            tuple[DetailColumn, ...]: The columns to render.
+        """
+        columns = detail_utils.get_detail_columns()
+        if not self._in_git_repo:
+            columns = tuple(column for column in columns if column.type != "git")
+        return columns
+
     def render_line(self, y: int) -> Strip:
         line = super().render_line(y)
         if self.dummy:
             return line
-        columns = detail_utils.get_detail_columns()
+        columns = self._detail_columns()
         if not columns:
             return line
         width = self.scrollable_content_region.width
@@ -171,7 +183,7 @@ class FileList(
             return line
         if not isinstance(option, FileListSelectionWidget):
             return line
-        details = "  ".join(option.detail_cells()[:fitted]) + " "
+        details = "  ".join(option.detail_cells(columns)[:fitted]) + " "
         segments = list(line)
         style = segments[-1].style if segments else self.rich_style
         return Strip([
@@ -185,7 +197,7 @@ class FileList(
         Returns:
             str: The full-width header text.
         """
-        columns = detail_utils.get_detail_columns()
+        columns = self._detail_columns()
         width = self.scrollable_content_region.width
         fitted = detail_utils.fit_column_count(width, columns)
         gutter = self._get_left_gutter_width()
@@ -198,27 +210,50 @@ class FileList(
         pad = max(1, width - cell_len(left) - cell_len(labels))
         return left + " " * pad + labels
 
-    @work(thread=True, exclusive=True, group="folder_counts")
-    def fill_folder_item_counts(self) -> None:
-        if self.dummy or not any(
-            column.type == "size" for column in detail_utils.get_detail_columns()
-        ):
+    @work(thread=True, exclusive=True, group="detail_fill")
+    def fill_async_details(self) -> None:
+        column_types = {column.type for column in detail_utils.get_detail_columns()} & {
+            "size",
+            "git",
+        }
+        if self.dummy or not column_types:
             return
         worker = get_current_worker()
         options = self._options
+        file_options = [
+            option for option in options if isinstance(option, FileListSelectionWidget)
+        ]
+        if not file_options:
+            return
         dirty = False
-        for option in options:
-            if worker.is_cancelled or options is not self._options:
-                return
-            if not isinstance(option, FileListSelectionWidget):
-                continue
-            with suppress(OSError):
-                if option.dir_entry.is_dir():
-                    with scandir(option.dir_entry.path) as entries:
-                        option.set_folder_item_count(sum(1 for _ in entries))
+        if "git" in column_types:
+            cwd = path.dirname(file_options[0].dir_entry.path)
+            statuses = detail_utils.git_statuses(cwd)
+            in_git_repo = statuses is not None
+            if in_git_repo != self._in_git_repo:
+                self._in_git_repo = in_git_repo
+                dirty = True
+            for option in file_options:
+                if worker.is_cancelled or options is not self._options:
+                    return
+                status = (statuses or {}).get(option.dir_entry.name, "")
+                if status != option.git_status:
+                    option.set_git_status(status)
                     dirty = True
+        if "size" in column_types:
+            for option in file_options:
+                if worker.is_cancelled or options is not self._options:
+                    return
+                with suppress(OSError):
+                    if option.dir_entry.is_dir():
+                        with scandir(option.dir_entry.path) as entries:
+                            option.set_folder_item_count(sum(1 for _ in entries))
+                        dirty = True
         if dirty and not worker.is_cancelled:
             self.app.call_from_thread(self.refresh)
+            update_header = getattr(self.parent, "update_details_header", None)
+            if callable(update_header):
+                self.app.call_from_thread(update_header)
 
     # ignore single clicks
     async def _on_click(self, event: events.Click) -> None:
@@ -386,7 +421,7 @@ class FileList(
             self.app.query_one("#up").disabled = cwd == path.dirname(cwd)
 
             self.set_options(self.list_of_options)
-            self.fill_folder_item_counts()
+            self.fill_async_details()
             update_header = getattr(self.parent, "update_details_header", None)
             if callable(update_header):
                 self.call_after_refresh(update_header)

--- a/src/rovr/core/file_list_container.py
+++ b/src/rovr/core/file_list_container.py
@@ -1,8 +1,10 @@
 from textual import events
 from textual.app import ComposeResult
 from textual.containers import VerticalGroup
+from textual.widgets import Static
 
 from rovr.components import SearchInput
+from rovr.functions import details as detail_utils
 from rovr.functions import icons
 
 from .file_list import FileList
@@ -15,6 +17,7 @@ class FileListContainer(VerticalGroup):
             name="File List",
             classes="file-list",
         )
+        self.details_header = Static(id="file_list_details_header")
         super().__init__(
             id="file_list_container",
         )
@@ -23,10 +26,14 @@ class FileListContainer(VerticalGroup):
         yield SearchInput(
             placeholder=f"({icons.get_icon('general', 'search')[0]}) Search something..."
         )
+        if detail_utils.get_detail_columns():
+            yield self.details_header
         yield self.filelist
 
     def on_resize(self, event: events.Resize) -> None:
         self.filelist.scroll_to_highlight()
+        if detail_utils.get_detail_columns():
+            self.details_header.update(self.filelist.details_header_text())
 
     def remount_filelist(self) -> None:
         """Remount the file list to reset its state"""

--- a/src/rovr/core/file_list_container.py
+++ b/src/rovr/core/file_list_container.py
@@ -30,10 +30,13 @@ class FileListContainer(VerticalGroup):
             yield self.details_header
         yield self.filelist
 
-    def on_resize(self, event: events.Resize) -> None:
-        self.filelist.scroll_to_highlight()
+    def update_details_header(self) -> None:
         if detail_utils.get_detail_columns():
             self.details_header.update(self.filelist.details_header_text())
+
+    def on_resize(self, event: events.Resize) -> None:
+        self.filelist.scroll_to_highlight()
+        self.update_details_header()
 
     def remount_filelist(self) -> None:
         """Remount the file list to reset its state"""

--- a/src/rovr/functions/details.py
+++ b/src/rovr/functions/details.py
@@ -1,0 +1,162 @@
+import stat
+from datetime import datetime
+from functools import lru_cache
+from os import DirEntry, lstat
+from typing import NamedTuple
+
+from rich.cells import cell_len
+from textual.widgets.option_list import Option
+
+from rovr.functions.utils import natural_size
+from rovr.variables.constants import config
+
+try:
+    from grp import getgrgid
+    from pwd import getpwuid
+except ImportError:  # windows
+    getpwuid = None  # ty: ignore[invalid-assignment]
+    getgrgid = None  # ty: ignore[invalid-assignment]
+
+MIN_NAME_WIDTH = 20
+
+DEFAULT_LABELS = {
+    "size": "Size",
+    "mtime": "Modified",
+    "atime": "Accessed",
+    "ctime": "Created",
+    "permissions": "Permissions",
+    "owner": "Owner",
+    "group": "Group",
+}
+
+
+class DetailColumn(NamedTuple):
+    type: str
+    label: str
+    width: int
+    format: str
+
+
+def _pad(value: str, width: int) -> str:
+    """Right-align ``value`` into exactly ``width`` cells, truncating with an ellipsis.
+
+    Returns:
+        str: The padded (or truncated) value.
+    """
+    length = cell_len(value)
+    if length > width:
+        while value and cell_len(value) > width - 1:
+            value = value[:-1]
+        value += "…"
+        length = cell_len(value)
+    return " " * (width - length) + value
+
+
+@lru_cache(maxsize=1)
+def get_detail_columns() -> tuple[DetailColumn, ...]:
+    # ponytail: cached once at first use; details_list is not hot-reloaded
+    columns: list[DetailColumn] = []
+    for entry in config["interface"]["details_list"]:
+        column_type = entry["type"]
+        if column_type not in DEFAULT_LABELS:
+            continue
+        label = entry.get("label", DEFAULT_LABELS[column_type])
+        time_format = entry.get("format", config["metadata"]["datetime_format"])
+        match column_type:
+            case "size":
+                natural_width = 7
+            case "mtime" | "atime" | "ctime":
+                natural_width = cell_len(datetime.now().strftime(time_format))
+            case "permissions":
+                natural_width = 10
+            case _:  # owner/group
+                natural_width = 8
+        width = max(cell_len(label), entry.get("max_length", natural_width))
+        columns.append(DetailColumn(column_type, label, width, time_format))
+    return tuple(columns)
+
+
+def fit_column_count(width: int, columns: tuple[DetailColumn, ...]) -> int:
+    """How many leading columns fit, leaving the name at least MIN_NAME_WIDTH cells.
+
+    Returns:
+        int: The number of columns, from the start of the list, that fit.
+    """
+    available = width - MIN_NAME_WIDTH
+    count = 0
+    used = 0
+    for column in columns:
+        used += column.width + 2
+        if used > available:
+            break
+        count += 1
+    return count
+
+
+@lru_cache(maxsize=512)
+def _user_name(uid: int) -> str:
+    if getpwuid is None:
+        return "--"
+    try:
+        return getpwuid(uid).pw_name
+    except KeyError:
+        return str(uid)
+
+
+@lru_cache(maxsize=512)
+def _group_name(gid: int) -> str:
+    if getgrgid is None:
+        return "--"
+    try:
+        return getgrgid(gid).gr_name
+    except KeyError:
+        return str(gid)
+
+
+def detail_cells(
+    dir_entry: DirEntry, option: Option, columns: tuple[DetailColumn, ...]
+) -> tuple[str, ...]:
+    """Format one fixed-width cell per configured column for a directory entry.
+
+    Returns:
+        tuple[str, ...]: One padded cell per column.
+    """
+    cells: list[str] = []
+    for column in columns:
+        try:
+            file_stat = dir_entry.stat()
+            match column.type:
+                case "size":
+                    if dir_entry.is_dir():
+                        count = getattr(option, "folder_item_count", None)
+                        value = "--" if count is None else str(count)
+                    else:
+                        value = natural_size(
+                            file_stat.st_size,
+                            "gnu",
+                            config["metadata"]["filesize_decimals"],
+                        )
+                case "mtime":
+                    value = datetime.fromtimestamp(file_stat.st_mtime).strftime(
+                        column.format
+                    )
+                case "atime":
+                    value = datetime.fromtimestamp(file_stat.st_atime).strftime(
+                        column.format
+                    )
+                case "ctime":
+                    value = datetime.fromtimestamp(file_stat.st_ctime).strftime(
+                        column.format
+                    )
+                case "permissions":
+                    value = stat.filemode(lstat(dir_entry.path).st_mode)
+                case "owner":
+                    value = _user_name(file_stat.st_uid)
+                case "group":
+                    value = _group_name(file_stat.st_gid)
+                case _:
+                    value = "--"
+        except (OSError, ValueError):
+            value = "--"
+        cells.append(_pad(value, column.width))
+    return tuple(cells)

--- a/src/rovr/functions/details.py
+++ b/src/rovr/functions/details.py
@@ -1,7 +1,7 @@
 import stat
 from datetime import datetime
 from functools import lru_cache
-from os import DirEntry, lstat
+from os import DirEntry, lstat, stat_result
 from subprocess import TimeoutExpired, run
 from typing import NamedTuple
 
@@ -151,8 +151,8 @@ def git_statuses(cwd: str) -> dict[str, str] | None:
     """Git status chars for every changed entry directly inside ``cwd``.
 
     Returns:
-        dict[str, str] | None: Name -> status char, or None when ``cwd`` is not
-            inside a git work tree (or git is unavailable).
+        dict[str, str]: Name in cwd -> two chars of UDMRCA? (space = clean).
+        None if cwd is not a git repository or git is unavailable.
     """
     try:
         prefix_proc = run(
@@ -204,9 +204,10 @@ def detail_cells(
         tuple[str, ...]: One padded cell per column.
     """
     cells: list[str] = []
+    file_stat = dir_entry.stat()
+    lstats: stat_result | None = None
     for column in columns:
         try:
-            file_stat = dir_entry.stat()
             match column.type:
                 case "size":
                     if dir_entry.is_dir():
@@ -231,7 +232,9 @@ def detail_cells(
                         column.format
                     )
                 case "permissions":
-                    value = stat.filemode(lstat(dir_entry.path).st_mode)
+                    if not lstats:
+                        lstats = lstat(dir_entry.path)
+                    value = stat.filemode(lstats.st_mode)
                 case "owner":
                     value = _user_name(file_stat.st_uid)
                 case "group":

--- a/src/rovr/functions/details.py
+++ b/src/rovr/functions/details.py
@@ -2,6 +2,7 @@ import stat
 from datetime import datetime
 from functools import lru_cache
 from os import DirEntry, lstat
+from subprocess import TimeoutExpired, run
 from typing import NamedTuple
 
 from rich.cells import cell_len
@@ -27,7 +28,11 @@ DEFAULT_LABELS = {
     "permissions": "Permissions",
     "owner": "Owner",
     "group": "Group",
+    "git": "Git",
 }
+
+# most severe first; a folder shows the most severe status found beneath it
+_GIT_SEVERITY = "UDMRCA?"
 
 
 class DetailColumn(NamedTuple):
@@ -65,6 +70,8 @@ def get_detail_columns() -> tuple[DetailColumn, ...]:
         match column_type:
             case "size":
                 natural_width = 7
+            case "git":
+                natural_width = 2
             case "mtime" | "atime" | "ctime":
                 natural_width = cell_len(datetime.now().strftime(time_format))
             case "permissions":
@@ -91,6 +98,81 @@ def fit_column_count(width: int, columns: tuple[DetailColumn, ...]) -> int:
             break
         count += 1
     return count
+
+
+def _worst_git_char(*candidates: str) -> str:
+    worst = ""
+    for candidate in candidates:
+        for char in candidate:
+            if char in _GIT_SEVERITY and (
+                not worst or _GIT_SEVERITY.index(char) < _GIT_SEVERITY.index(worst)
+            ):
+                worst = char
+    return worst
+
+
+def parse_git_porcelain(output: bytes, prefix: str) -> dict[str, str]:
+    """Map each top-level name under ``prefix`` to its git XY status pair.
+
+    Like ``git status --short``: the first char is the staged (index) status,
+    the second the unstaged (work tree) status. Folders aggregate each
+    position independently to the most severe char found beneath them.
+
+    Args:
+        output: Raw ``git status --porcelain -z`` output.
+        prefix: The cwd relative to the repository root (``git rev-parse --show-prefix``).
+
+    Returns:
+        dict[str, str]: Name in cwd -> two chars of UDMRCA? (space = clean).
+    """
+    statuses: dict[str, str] = {}
+    entries = output.decode(errors="replace").split("\0")
+    index = 0
+    while index < len(entries):
+        entry = entries[index]
+        index += 1
+        if len(entry) < 4:
+            continue
+        xy, rel_path = entry[:2], entry[3:]
+        if xy[0] in "RC":
+            index += 1  # skip the rename/copy source path
+        if not rel_path.startswith(prefix):
+            continue
+        name = rel_path[len(prefix) :].split("/", 1)[0]
+        if name:
+            existing = statuses.get(name, "  ")
+            statuses[name] = (_worst_git_char(xy[0], existing[0]) or " ") + (
+                _worst_git_char(xy[1], existing[1]) or " "
+            )
+    return statuses
+
+
+def git_statuses(cwd: str) -> dict[str, str] | None:
+    """Git status chars for every changed entry directly inside ``cwd``.
+
+    Returns:
+        dict[str, str] | None: Name -> status char, or None when ``cwd`` is not
+            inside a git work tree (or git is unavailable).
+    """
+    try:
+        prefix_proc = run(
+            ["git", "-C", cwd, "rev-parse", "--show-prefix"],
+            capture_output=True,
+            timeout=5,
+        )
+        if prefix_proc.returncode != 0:
+            return None
+        status_proc = run(
+            ["git", "-C", cwd, "status", "--porcelain", "-z", "."],
+            capture_output=True,
+            timeout=10,
+        )
+        if status_proc.returncode != 0:
+            return None
+    except (OSError, TimeoutExpired):
+        return None
+    prefix = prefix_proc.stdout.decode(errors="replace").strip()
+    return parse_git_porcelain(status_proc.stdout, prefix)
 
 
 @lru_cache(maxsize=512)
@@ -154,6 +236,8 @@ def detail_cells(
                     value = _user_name(file_stat.st_uid)
                 case "group":
                     value = _group_name(file_stat.st_gid)
+                case "git":
+                    value = getattr(option, "git_status", "")
                 case _:
                     value = "--"
         except (OSError, ValueError):

--- a/src/rovr/functions/details.py
+++ b/src/rovr/functions/details.py
@@ -206,7 +206,10 @@ def detail_cells(
         tuple[str, ...]: One padded cell per column.
     """
     cells: list[str] = []
-    file_stat = dir_entry.stat()
+    try:
+        file_stat = dir_entry.stat()
+    except OSError:
+        file_stat = None
     lstats: stat_result | None = None
     for column in columns:
         try:
@@ -215,6 +218,8 @@ def detail_cells(
                     if dir_entry.is_dir():
                         count = getattr(option, "folder_item_count", None)
                         value = "--" if count is None else str(count)
+                    elif file_stat is None:
+                        value = "--"
                     else:
                         value = natural_size(
                             file_stat.st_size,
@@ -222,25 +227,37 @@ def detail_cells(
                             config["metadata"]["filesize_decimals"],
                         )
                 case "mtime":
-                    value = datetime.fromtimestamp(file_stat.st_mtime).strftime(
-                        column.format
+                    value = (
+                        datetime.fromtimestamp(file_stat.st_mtime).strftime(
+                            column.format
+                        )
+                        if file_stat
+                        else "--"
                     )
                 case "atime":
-                    value = datetime.fromtimestamp(file_stat.st_atime).strftime(
-                        column.format
+                    value = (
+                        datetime.fromtimestamp(file_stat.st_atime).strftime(
+                            column.format
+                        )
+                        if file_stat
+                        else "--"
                     )
                 case "ctime":
-                    value = datetime.fromtimestamp(file_stat.st_ctime).strftime(
-                        column.format
+                    value = (
+                        datetime.fromtimestamp(file_stat.st_ctime).strftime(
+                            column.format
+                        )
+                        if file_stat
+                        else "--"
                     )
                 case "permissions":
                     if not lstats:
                         lstats = lstat(dir_entry.path)
                     value = stat.filemode(lstats.st_mode)
                 case "owner":
-                    value = _user_name(file_stat.st_uid)
+                    value = _user_name(file_stat.st_uid) if file_stat else "--"
                 case "group":
-                    value = _group_name(file_stat.st_gid)
+                    value = _group_name(file_stat.st_gid) if file_stat else "--"
                 case "git":
                     value = getattr(option, "git_status", "")
                 case _:

--- a/src/rovr/functions/details.py
+++ b/src/rovr/functions/details.py
@@ -43,11 +43,13 @@ class DetailColumn(NamedTuple):
 
 
 def _pad(value: str, width: int) -> str:
-    """Right-align ``value`` into exactly ``width`` cells, truncating with an ellipsis.
+    """Right-align `value` into exactly `width` cells, truncating with an ellipsis.
 
     Returns:
         str: The padded (or truncated) value.
     """
+    if width <= 0:
+        return ""
     length = cell_len(value)
     if length > width:
         while value and cell_len(value) > width - 1:
@@ -112,15 +114,15 @@ def _worst_git_char(*candidates: str) -> str:
 
 
 def parse_git_porcelain(output: bytes, prefix: str) -> dict[str, str]:
-    """Map each top-level name under ``prefix`` to its git XY status pair.
+    """Map each top-level name under `prefix` to its git XY status pair.
 
-    Like ``git status --short``: the first char is the staged (index) status,
+    Like `git status --short`: the first char is the staged (index) status,
     the second the unstaged (work tree) status. Folders aggregate each
     position independently to the most severe char found beneath them.
 
     Args:
-        output: Raw ``git status --porcelain -z`` output.
-        prefix: The cwd relative to the repository root (``git rev-parse --show-prefix``).
+        output: Raw `git status --porcelain -z` output.
+        prefix: The cwd relative to the repository root (`git rev-parse --show-prefix`).
 
     Returns:
         dict[str, str]: Name in cwd -> two chars of UDMRCA? (space = clean).
@@ -148,7 +150,7 @@ def parse_git_porcelain(output: bytes, prefix: str) -> dict[str, str]:
 
 
 def git_statuses(cwd: str) -> dict[str, str] | None:
-    """Git status chars for every changed entry directly inside ``cwd``.
+    """Git status chars for every changed entry directly inside `cwd`.
 
     Returns:
         dict[str, str]: Name in cwd -> two chars of UDMRCA? (space = clean).
@@ -216,7 +218,7 @@ def detail_cells(
                     else:
                         value = natural_size(
                             file_stat.st_size,
-                            "gnu",
+                            config["metadata"]["filesize_suffix"],
                             config["metadata"]["filesize_decimals"],
                         )
                 case "mtime":

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -42,21 +42,12 @@ def set_scuffed_subtitle(element: DOMNode, *sections: str) -> None:
 def natural_size(
     integer: int, suffix: Literal["gnu", "binary", "decimal"], filesize_decimals: int
 ) -> str:
-    match suffix:
-        case "gnu":
-            return naturalsize(
-                value=integer,
-                gnu=True,
-                format=f"%.{filesize_decimals}f",
-            )
-        case "binary":
-            return naturalsize(
-                value=integer,
-                binary=True,
-                format=f"%.{filesize_decimals}f",
-            )
-        case "decimal":
-            return naturalsize(value=integer, format=f"%.{filesize_decimals}f")
+    return naturalsize(
+        value=integer,
+        gnu=suffix == "gnu",
+        binary=suffix == "binary",
+        format=f"%.{filesize_decimals}f",
+    ).replace("Bytes", "B")
 
 
 def is_being_used(exc: OSError) -> bool:

--- a/src/rovr/style.tcss
+++ b/src/rovr/style.tcss
@@ -322,6 +322,12 @@ Tooltip {
 
 #file_list, #file_list_visual { height: 1fr }
 
+#file_list_details_header {
+  height: 1;
+  color: $text-muted;
+  text-style: bold;
+}
+
 #pinned_sidebar_container,
 #file_list_container,
 #keybinds_group {

--- a/src/rovr/style.tcss
+++ b/src/rovr/style.tcss
@@ -540,6 +540,25 @@ FileList {
     background: $error-lighten-3;
     color: $background;
   }
+
+  .filelist--detail-size,
+  .filelist--detail-mtime,
+  .filelist--detail-atime,
+  .filelist--detail-ctime,
+  .filelist--detail-permissions,
+  .filelist--detail-owner,
+  .filelist--detail-group {
+    color: $text-muted;
+  }
+  .filelist--git-staged {
+    color: $success;
+  }
+  .filelist--git-unstaged {
+    color: $warning;
+  }
+  .filelist--git-untracked {
+    color: $text-muted;
+  }
 }
 
 #dialog {

--- a/tests/test_details.py
+++ b/tests/test_details.py
@@ -1,4 +1,9 @@
-from rovr.functions.details import DetailColumn, _pad, fit_column_count
+from rovr.functions.details import (
+    DetailColumn,
+    _pad,
+    fit_column_count,
+    parse_git_porcelain,
+)
 
 SIZE = DetailColumn("size", "Size", 7, "")
 MTIME = DetailColumn("mtime", "Modified", 16, "")
@@ -16,6 +21,37 @@ def test_pad_truncates_with_ellipsis() -> None:
 def test_pad_handles_wide_chars() -> None:
     assert _pad("日本語", 6) == "日本語"
     assert _pad("日本語", 5) == "日本…"
+
+
+def test_parse_git_porcelain_keeps_staged_and_unstaged_positions() -> None:
+    output = b" M unstaged.py\x00M  staged.py\x00MM both.py\x00?? untracked.txt\x00"
+    assert parse_git_porcelain(output, "") == {
+        "unstaged.py": " M",
+        "staged.py": "M ",
+        "both.py": "MM",
+        "untracked.txt": "??",
+    }
+
+
+def test_parse_git_porcelain_folder_aggregates_each_position() -> None:
+    output = b"?? pkg/new.py\x00 M pkg/old.py\x00A  pkg/added.py\x00"
+    assert parse_git_porcelain(output, "") == {"pkg": "AM"}
+
+
+def test_parse_git_porcelain_respects_prefix() -> None:
+    output = b" M sub/dir/file.py\x00 M elsewhere.py\x00?? sub/dir/nested/thing\x00"
+    assert parse_git_porcelain(output, "sub/dir/") == {
+        "file.py": " M",
+        "nested": "??",
+    }
+
+
+def test_parse_git_porcelain_skips_rename_source() -> None:
+    output = b"R  new_name.py\x00old_name.py\x00 M other.py\x00"
+    assert parse_git_porcelain(output, "") == {
+        "new_name.py": "R ",
+        "other.py": " M",
+    }
 
 
 def test_fit_drops_trailing_columns_first() -> None:

--- a/tests/test_details.py
+++ b/tests/test_details.py
@@ -1,0 +1,29 @@
+from rovr.functions.details import DetailColumn, _pad, fit_column_count
+
+SIZE = DetailColumn("size", "Size", 7, "")
+MTIME = DetailColumn("mtime", "Modified", 16, "")
+GIT = DetailColumn("git", "Git", 3, "")
+
+
+def test_pad_right_aligns() -> None:
+    assert _pad("42K", 7) == "    42K"
+
+
+def test_pad_truncates_with_ellipsis() -> None:
+    assert _pad("longvalue", 5) == "long…"
+
+
+def test_pad_handles_wide_chars() -> None:
+    assert _pad("日本語", 6) == "日本語"
+    assert _pad("日本語", 5) == "日本…"
+
+
+def test_fit_drops_trailing_columns_first() -> None:
+    columns = (SIZE, MTIME, GIT)
+    assert fit_column_count(200, columns) == 3
+    # room for size + mtime but not git
+    assert fit_column_count(20 + 9 + 18 + 2, columns) == 2
+    # room for size only
+    assert fit_column_count(20 + 9, columns) == 1
+    # too narrow for anything
+    assert fit_column_count(25, columns) == 0

--- a/tests/test_details.py
+++ b/tests/test_details.py
@@ -1,4 +1,5 @@
 from rovr.functions.details import (
+    MIN_NAME_WIDTH,
     DetailColumn,
     _pad,
     fit_column_count,
@@ -14,13 +15,32 @@ def test_pad_right_aligns() -> None:
     assert _pad("42K", 7) == "    42K"
 
 
+def test_pad_width_equals_cell_len() -> None:
+    # Width exactly matches the display width of the value: no padding or truncation.
+    assert _pad("42K", 3) == "42K"
+
+
 def test_pad_truncates_with_ellipsis() -> None:
+    # When the width is smaller than the value, it should be truncated and end with an ellipsis.
     assert _pad("longvalue", 5) == "long…"
 
 
 def test_pad_handles_wide_chars() -> None:
+    # Wide characters should be measured by their display width, not code-point count.
     assert _pad("日本語", 6) == "日本語"
     assert _pad("日本語", 5) == "日本…"
+
+
+def test_pad_width_zero_and_one() -> None:
+    # Width 0 should produce an empty string; width 1 should still show an ellipsis.
+    assert _pad("value", 0) == ""
+    assert _pad("value", 1) == "…"
+
+
+def test_pad_empty_string() -> None:
+    # Empty values should still be padded to the requested width.
+    assert _pad("", 0) == ""
+    assert _pad("", 4) == "    "
 
 
 def test_parse_git_porcelain_keeps_staged_and_unstaged_positions() -> None:
@@ -63,3 +83,17 @@ def test_fit_drops_trailing_columns_first() -> None:
     assert fit_column_count(20 + 9, columns) == 1
     # too narrow for anything
     assert fit_column_count(25, columns) == 0
+
+
+def test_fit_exact_min_name_width_plus_one_column() -> None:
+    # exact fit: name gutter at MIN_NAME_WIDTH plus one SIZE column including padding
+    columns = (SIZE,)
+    width = MIN_NAME_WIDTH + SIZE.width + 2
+    assert fit_column_count(width, columns) == 1
+
+
+def test_fit_just_below_min_name_width_returns_zero() -> None:
+    # width just below MIN_NAME_WIDTH should result in 0 columns, even if the column itself would fit
+    columns = (SIZE,)
+    width = MIN_NAME_WIDTH - 1
+    assert fit_column_count(width, columns) == 0


### PR DESCRIPTION
wowzas, this wasnt as bad to implement as i thought

<img width="923" height="483" alt="image" src="https://github.com/user-attachments/assets/6b836429-523f-4158-83ab-09fbb3129261" />

due to reasons, i wont be doing this on the preview sidebar

closes #280 

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible
- [x] the documentation has been updated wherever necessary (run `poe gen-schema` and `poe gen-keys` if applicable)

## Summary by Sourcery

Add configurable metadata detail columns to the file list and document their configuration and theming.

New Features:
- Introduce an `interface.details_list` config option to show configurable metadata columns (e.g., size, timestamps, permissions, owner/group, git) alongside file names in the file list.
- Add a header row above the file list that labels the active detail columns and dynamically adjusts to available width.
- Expose new theming component classes for detail columns and git status states to allow styling of the added metadata.

Enhancements:
- Compute and cache per-entry detail cell values, including async population of git status and folder item counts, and refresh them when metadata changes.
- Extend dev and user-facing documentation with a new detail columns feature page and updated schema references, including navigation entries in the docs sidebar.

Tests:
- Add unit tests for detail column layout and git porcelain parsing, including padding, truncation, width handling, and aggregation of git statuses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional “detail columns” to the file list (size, timestamps, permissions, owner/group, Git status), configurable via `interface.details_list`, with a new details header and width-priority/ellipsis truncation.
* **Bug Fixes**
  * Improved live updating by refreshing the file list and invalidating cached prompt/detail values when the highlighted entry changes; Git details now auto-hide when outside a work tree.
* **Documentation**
  * Added/expanded documentation and theming guidance for detail columns, plus the related schema updates.
* **Tests**
  * Added unit tests for formatting helpers, Git porcelain parsing, and column fitting/truncation.
* **Style**
  * Updated styling for the new details header and column variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->