### PR TITLE
refactor(openers)!: implement grouping mechanism

### DIFF
--- a/docs/src/content/docs/dev/features/custom-openers.md
+++ b/docs/src/content/docs/dev/features/custom-openers.md
@@ -7,24 +7,29 @@ rovr allows you to configure custom commands to open files based on their MIME t
 
 ## configuration
 
-you can define your custom openers in the `settings.openers` section of your configuration file. the keys are glob patterns that match against the file's MIME type or path, and the values are lists of opener definitions.
+openers are declared as named groups in `settings.openers.groups`, then glob patterns are mapped to one or more of those group names in `settings.openers.match`.
 
 ```toml
-[settings.openers]
-"*.py" = [
+[settings.openers.groups]
+text = [
     { run = "$EDITOR", orphan = true },
     { run = "code", orphan = true }
 ]
-"*.png" = [
+image = [
     "imv"
 ]
-"*" = [
+fallback = [
     { run = "explorer.exe", if = { os = ["Windows"] } },
     { run = "xdg-open", if = { os = ["Linux"] } }
 ]
+
+[settings.openers.match]
+"*.py" = ["text"]
+"*.png" = ["image"]
+"*" = ["fallback"]
 ```
 
-if a `*` key is provided, it acts as a fallback for any unmatched file. if no custom opener matches, rovr will fall back to the operating system's default opener.
+if a `*` key is provided in `match`, it acts as a fallback for any unmatched file. if no custom opener matches, rovr will fall back to the operating system's default opener.
 
 ## opener definitions
 
@@ -44,10 +49,13 @@ the `if` property allows you to restrict when an opener is used based on specifi
 - `cwd` (array of strings): glob patterns that must match the current working directory.
 
 ```toml
-[settings.openers]
-".*\\.py" = [
+[settings.openers.groups]
+py = [
     { run = "python", orphan = false, if = { os = ["Linux", "Darwin"] } }
 ]
+
+[settings.openers.match]
+".*\\.py" = ["py"]
 ```
 
 ### adding more openers

--- a/docs/src/content/docs/dev/features/custom-openers.md
+++ b/docs/src/content/docs/dev/features/custom-openers.md
@@ -29,7 +29,7 @@ fallback = [
 "*" = ["fallback"]
 ```
 
-if a `*` key is provided in `match`, it acts as a fallback for any unmatched file. if no custom opener matches, rovr will fall back to the operating system's default opener.
+the matching is done in order of declaration. this means if `"*"` is defined before `"*.py"`, the fallback opener will be used for python files instead of the text opener.
 
 ## opener definitions
 

--- a/docs/src/content/docs/dev/reference/schema.mdx
+++ b/docs/src/content/docs/dev/reference/schema.mdx
@@ -104,22 +104,26 @@ description: config schema humanified
   - [2.5. Property `Rovr Config > settings > preview_rules`](#settings_preview_rules)
     - [2.5.1. Property `Rovr Config > settings > preview_rules > additionalProperties`](#settings_preview_rules_additionalProperties)
   - [2.6. Property `Rovr Config > settings > openers`](#settings_openers)
-    - [2.6.1. Property `Rovr Config > settings > openers > additionalProperties`](#settings_openers_additionalProperties)
-      - [2.6.1.1. Rovr Config > settings > openers > additionalProperties > additionalProperties items](#settings_openers_additionalProperties_items)
-        - [2.6.1.1.1. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 0`](#settings_openers_additionalProperties_items_oneOf_i0)
-        - [2.6.1.1.2. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1`](#settings_openers_additionalProperties_items_oneOf_i1)
-          - [2.6.1.1.2.1. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > run`](#settings_openers_additionalProperties_items_oneOf_i1_run)
-          - [2.6.1.1.2.2. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if`](#settings_openers_additionalProperties_items_oneOf_i1_if)
-            - [2.6.1.1.2.2.1. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd`](#settings_openers_additionalProperties_items_oneOf_i1_if_cwd)
-              - [2.6.1.1.2.2.1.1. Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd > cwd items](#settings_openers_additionalProperties_items_oneOf_i1_if_cwd_items)
-            - [2.6.1.1.2.2.2. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > os`](#settings_openers_additionalProperties_items_oneOf_i1_if_os)
-              - [2.6.1.1.2.2.2.1. Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items](#settings_openers_additionalProperties_items_oneOf_i1_if_os_items)
-                - [2.6.1.1.2.2.2.1.1. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 0`](#settings_openers_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i0)
-                - [2.6.1.1.2.2.2.1.2. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 1`](#settings_openers_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i1)
-            - [2.6.1.1.2.2.3. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > directory`](#settings_openers_additionalProperties_items_oneOf_i1_if_directory)
-          - [2.6.1.1.2.3. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > orphan`](#settings_openers_additionalProperties_items_oneOf_i1_orphan)
-          - [2.6.1.1.2.4. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > name`](#settings_openers_additionalProperties_items_oneOf_i1_name)
-          - [2.6.1.1.2.5. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > shell`](#settings_openers_additionalProperties_items_oneOf_i1_shell)
+    - [2.6.1. Property `Rovr Config > settings > openers > groups`](#settings_openers_groups)
+      - [2.6.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties`](#settings_openers_groups_additionalProperties)
+        - [2.6.1.1.1. Rovr Config > settings > openers > groups > additionalProperties > opener](#settings_openers_groups_additionalProperties_items)
+          - [2.6.1.1.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 0`](#settings_openers_groups_additionalProperties_items_oneOf_i0)
+          - [2.6.1.1.1.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1`](#settings_openers_groups_additionalProperties_items_oneOf_i1)
+            - [2.6.1.1.1.2.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > run`](#settings_openers_groups_additionalProperties_items_oneOf_i1_run)
+            - [2.6.1.1.1.2.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if)
+              - [2.6.1.1.1.2.2.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_cwd)
+                - [2.6.1.1.1.2.2.1.1. Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd > cwd items](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_cwd_items)
+              - [2.6.1.1.1.2.2.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os)
+                - [2.6.1.1.1.2.2.2.1. Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items)
+                  - [2.6.1.1.1.2.2.2.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 0`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i0)
+                  - [2.6.1.1.1.2.2.2.1.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 1`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i1)
+              - [2.6.1.1.1.2.2.3. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > directory`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_directory)
+            - [2.6.1.1.1.2.3. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > orphan`](#settings_openers_groups_additionalProperties_items_oneOf_i1_orphan)
+            - [2.6.1.1.1.2.4. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > name`](#settings_openers_groups_additionalProperties_items_oneOf_i1_name)
+            - [2.6.1.1.1.2.5. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > shell`](#settings_openers_groups_additionalProperties_items_oneOf_i1_shell)
+    - [2.6.2. Property `Rovr Config > settings > openers > match`](#settings_openers_match)
+      - [2.6.2.1. Property `Rovr Config > settings > openers > match > additionalProperties`](#settings_openers_match_additionalProperties)
+        - [2.6.2.1.1. Rovr Config > settings > openers > match > additionalProperties > additionalProperties items](#settings_openers_match_additionalProperties_items)
   - [2.7. Property `Rovr Config > settings > drive_exclude`](#settings_drive_exclude)
     - [2.7.1. Rovr Config > settings > drive_exclude > drive_exclude items](#settings_drive_exclude_items)
 - [3. Property `Rovr Config > metadata`](#metadata)
@@ -866,7 +870,7 @@ Must be one of:
 | [copy_includes_metadata](#settings_copy_includes_metadata) | boolean         | When copying over a file, preserve metadata from the original file, such as creation and modification times.                                                                                                            |
 | [editor](#settings_editor)                                 | object          | Settings related to the editor used for different operations                                                                                                                                                            |
 | [preview_rules](#settings_preview_rules)                   | object          | Map MIME type patterns to preview types. Uses regex patterns. Valid preview types: text, image, pdf, archive, folder, resvg, font, remime.<br />-&gt; Use 'remime' if you want a more accurate description from file(1) |
-| [openers](#settings_openers)                               | object          | A list of openers to open files with. These are used to open files, what were you expecting.<br />Key must be a valid glob pattern, but the value has to be a list that can contain a mix of strings and objects        |
+| [openers](#settings_openers)                               | object          | Openers to open files with, grouped by name and matched against file paths by glob pattern.                                                                                                                             |
 | [drive_exclude](#settings_drive_exclude)                   | array of string | Glob patterns matched against mountpoint paths. Drives matching any pattern are hidden from the sidebar (e.g. '/run/media/\*', 'D:/').                                                                                  |
 
 ### <a name="settings_use_recycle_bin"></a>2.1. Property `Rovr Config > settings > use_recycle_bin`
@@ -1730,20 +1734,34 @@ Must be one of:
 
 ### <a name="settings_openers"></a>2.6. Property `Rovr Config > settings > openers`
 
-|                           |                                                                                               |
-| ------------------------- | --------------------------------------------------------------------------------------------- |
-| **Type**                  | `object`                                                                                      |
-| **Required**              | No                                                                                            |
-| **Additional properties** | [Each additional property must conform to the schema](#settings_openers_additionalProperties) |
+|                           |             |
+| ------------------------- | ----------- |
+| **Type**                  | `object`    |
+| **Required**              | No          |
+| **Additional properties** | Not allowed |
 
-**Description:** A list of openers to open files with. These are used to open files, what were you expecting.
-Key must be a valid glob pattern, but the value has to be a list that can contain a mix of strings and objects
+**Description:** Openers to open files with, grouped by name and matched against file paths by glob pattern.
 
-| Property                                   | Type  | Title/Description |
-| ------------------------------------------ | ----- | ----------------- |
-| [](#settings_openers_additionalProperties) | array |                   |
+| Property                           | Type   | Title/Description                                                                                                                                                  |
+| ---------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [groups](#settings_openers_groups) | object | Named groups of openers. Each group is a list that can contain a mix of strings and objects, tried in order until one succeeds. Referenced by name from \`match\`. |
+| [match](#settings_openers_match)   | object | Map glob patterns (matched against the file's path) to one or more group names defined in \`groups\`. If multiple groups match, they are tried in order.           |
 
-#### <a name="settings_openers_additionalProperties"></a>2.6.1. Property `Rovr Config > settings > openers > additionalProperties`
+#### <a name="settings_openers_groups"></a>2.6.1. Property `Rovr Config > settings > openers > groups`
+
+|                           |                                                                                                      |
+| ------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **Type**                  | `object`                                                                                             |
+| **Required**              | No                                                                                                   |
+| **Additional properties** | [Each additional property must conform to the schema](#settings_openers_groups_additionalProperties) |
+
+**Description:** Named groups of openers. Each group is a list that can contain a mix of strings and objects, tried in order until one succeeds. Referenced by name from `match`.
+
+| Property                                          | Type  | Title/Description |
+| ------------------------------------------------- | ----- | ----------------- |
+| [](#settings_openers_groups_additionalProperties) | array |                   |
+
+##### <a name="settings_openers_groups_additionalProperties"></a>2.6.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties`
 
 |              |         |
 | ------------ | ------- |
@@ -1758,31 +1776,32 @@ Key must be a valid glob pattern, but the value has to be a list that can contai
 | **Additional items** | False              |
 | **Tuple validation** | See below          |
 
-| Each item of this array must be                                            | Description |
-| -------------------------------------------------------------------------- | ----------- |
-| [additionalProperties items](#settings_openers_additionalProperties_items) |             |
+| Each item of this array must be                               | Description |
+| ------------------------------------------------------------- | ----------- |
+| [opener](#settings_openers_groups_additionalProperties_items) |             |
 
-##### <a name="settings_openers_additionalProperties_items"></a>2.6.1.1. Rovr Config > settings > openers > additionalProperties > additionalProperties items
+###### <a name="settings_openers_groups_additionalProperties_items"></a>2.6.1.1.1. Rovr Config > settings > openers > groups > additionalProperties > opener
 
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `combining`      |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
+|                           |                      |
+| ------------------------- | -------------------- |
+| **Type**                  | `combining`          |
+| **Required**              | No                   |
+| **Additional properties** | Any type allowed     |
+| **Defined in**            | #/definitions/opener |
 
-| One of(Option)                                                  |
-| --------------------------------------------------------------- |
-| [item 0](#settings_openers_additionalProperties_items_oneOf_i0) |
-| [item 1](#settings_openers_additionalProperties_items_oneOf_i1) |
+| One of(Option)                                                         |
+| ---------------------------------------------------------------------- |
+| [item 0](#settings_openers_groups_additionalProperties_items_oneOf_i0) |
+| [item 1](#settings_openers_groups_additionalProperties_items_oneOf_i1) |
 
-###### <a name="settings_openers_additionalProperties_items_oneOf_i0"></a>2.6.1.1.1. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 0`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i0"></a>2.6.1.1.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 0`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="settings_openers_additionalProperties_items_oneOf_i1"></a>2.6.1.1.2. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1"></a>2.6.1.1.1.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -1790,15 +1809,15 @@ Key must be a valid glob pattern, but the value has to be a list that can contai
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                               | Type    | Title/Description                                                                                                 |
-| ---------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
-| [run](#settings_openers_additionalProperties_items_oneOf_i1_run)       | object  | The command to run to open the file. Command expansions are supported.                                            |
-| [if](#settings_openers_additionalProperties_items_oneOf_i1_if)         | object  | Only use this opener if a set criteria matches                                                                    |
-| [orphan](#settings_openers_additionalProperties_items_oneOf_i1_orphan) | boolean | Whether to open the opener as an orphan process.                                                                  |
-| [name](#settings_openers_additionalProperties_items_oneOf_i1_name)     | string  | The name of the opener to show in the menu (currently unused)                                                     |
-| [shell](#settings_openers_additionalProperties_items_oneOf_i1_shell)   | boolean | Whether the command to run is a shell command that needs to be run in a shell (required if you want to do piping) |
+| Property                                                                      | Type    | Title/Description                                                                                                 |
+| ----------------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| [run](#settings_openers_groups_additionalProperties_items_oneOf_i1_run)       | object  | The command to run to open the file. Command expansions are supported.                                            |
+| [if](#settings_openers_groups_additionalProperties_items_oneOf_i1_if)         | object  | Only use this opener if a set criteria matches                                                                    |
+| [orphan](#settings_openers_groups_additionalProperties_items_oneOf_i1_orphan) | boolean | Whether to open the opener as an orphan process.                                                                  |
+| [name](#settings_openers_groups_additionalProperties_items_oneOf_i1_name)     | string  | The name of the opener to show in the menu (currently unused)                                                     |
+| [shell](#settings_openers_groups_additionalProperties_items_oneOf_i1_shell)   | boolean | Whether the command to run is a shell command that needs to be run in a shell (required if you want to do piping) |
 
-###### <a name="settings_openers_additionalProperties_items_oneOf_i1_run"></a>2.6.1.1.2.1. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > run`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_run"></a>2.6.1.1.1.2.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > run`
 
 |                           |                                                        |
 | ------------------------- | ------------------------------------------------------ |
@@ -1809,7 +1828,7 @@ Key must be a valid glob pattern, but the value has to be a list that can contai
 
 **Description:** The command to run to open the file. Command expansions are supported.
 
-###### <a name="settings_openers_additionalProperties_items_oneOf_i1_if"></a>2.6.1.1.2.2. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if"></a>2.6.1.1.1.2.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if`
 
 |                           |                         |
 | ------------------------- | ----------------------- |
@@ -1820,13 +1839,13 @@ Key must be a valid glob pattern, but the value has to be a list that can contai
 
 **Description:** Only use this opener if a set criteria matches
 
-| Property                                                                        | Type            | Title/Description                                                                                                                                                                    |
-| ------------------------------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [cwd](#settings_openers_additionalProperties_items_oneOf_i1_if_cwd)             | array of string | Only use this opener if the current working directory matches one (or more) of the glob patterns in this list (look at https://docs.python.org/3/library/fnmatch.html for more info) |
-| [os](#settings_openers_additionalProperties_items_oneOf_i1_if_os)               | array of string | Only use this opener if the operating system is one of the following (case insensitive)                                                                                              |
-| [directory](#settings_openers_additionalProperties_items_oneOf_i1_if_directory) | boolean         | Only use this opener if the selected item is a directory (set to true) or a file (set to false) (if unspecified, matches both files and directories)                                 |
+| Property                                                                               | Type            | Title/Description                                                                                                                                                                    |
+| -------------------------------------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [cwd](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_cwd)             | array of string | Only use this opener if the current working directory matches one (or more) of the glob patterns in this list (look at https://docs.python.org/3/library/fnmatch.html for more info) |
+| [os](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os)               | array of string | Only use this opener if the operating system is one of the following (case insensitive)                                                                                              |
+| [directory](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_directory) | boolean         | Only use this opener if the selected item is a directory (set to true) or a file (set to false) (if unspecified, matches both files and directories)                                 |
 
-###### <a name="settings_openers_additionalProperties_items_oneOf_i1_if_cwd"></a>2.6.1.1.2.2.1. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_cwd"></a>2.6.1.1.1.2.2.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -1843,18 +1862,18 @@ Key must be a valid glob pattern, but the value has to be a list that can contai
 | **Additional items** | False              |
 | **Tuple validation** | See below          |
 
-| Each item of this array must be                                                 | Description |
-| ------------------------------------------------------------------------------- | ----------- |
-| [cwd items](#settings_openers_additionalProperties_items_oneOf_i1_if_cwd_items) |             |
+| Each item of this array must be                                                        | Description |
+| -------------------------------------------------------------------------------------- | ----------- |
+| [cwd items](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_cwd_items) |             |
 
-###### <a name="settings_openers_additionalProperties_items_oneOf_i1_if_cwd_items"></a>2.6.1.1.2.2.1.1. Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd > cwd items
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_cwd_items"></a>2.6.1.1.1.2.2.1.1. Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd > cwd items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="settings_openers_additionalProperties_items_oneOf_i1_if_os"></a>2.6.1.1.2.2.2. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > os`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_os"></a>2.6.1.1.1.2.2.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os`
 
 |                |                     |
 | -------------- | ------------------- |
@@ -1872,23 +1891,23 @@ Key must be a valid glob pattern, but the value has to be a list that can contai
 | **Additional items** | False              |
 | **Tuple validation** | See below          |
 
-| Each item of this array must be                                               | Description |
-| ----------------------------------------------------------------------------- | ----------- |
-| [os items](#settings_openers_additionalProperties_items_oneOf_i1_if_os_items) |             |
+| Each item of this array must be                                                      | Description |
+| ------------------------------------------------------------------------------------ | ----------- |
+| [os items](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items) |             |
 
-###### <a name="settings_openers_additionalProperties_items_oneOf_i1_if_os_items"></a>2.6.1.1.2.2.2.1. Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items"></a>2.6.1.1.1.2.2.2.1. Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items
 
 |              |             |
 | ------------ | ----------- |
 | **Type**     | `combining` |
 | **Required** | No          |
 
-| Any of(Option)                                                                       |
-| ------------------------------------------------------------------------------------ |
-| [item 0](#settings_openers_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i0) |
-| [item 1](#settings_openers_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i1) |
+| Any of(Option)                                                                              |
+| ------------------------------------------------------------------------------------------- |
+| [item 0](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i0) |
+| [item 1](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i1) |
 
-###### <a name="settings_openers_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i0"></a>2.6.1.1.2.2.2.1.1. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 0`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i0"></a>2.6.1.1.1.2.2.2.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 0`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -1901,14 +1920,14 @@ Must be one of:
 - "Linux"
 - "Darwin"
 
-###### <a name="settings_openers_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i1"></a>2.6.1.1.2.2.2.1.2. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 1`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i1"></a>2.6.1.1.1.2.2.2.1.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 1`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="settings_openers_additionalProperties_items_oneOf_i1_if_directory"></a>2.6.1.1.2.2.3. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > if > directory`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_directory"></a>2.6.1.1.1.2.2.3. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > directory`
 
 |              |           |
 | ------------ | --------- |
@@ -1917,7 +1936,7 @@ Must be one of:
 
 **Description:** Only use this opener if the selected item is a directory (set to true) or a file (set to false) (if unspecified, matches both files and directories)
 
-###### <a name="settings_openers_additionalProperties_items_oneOf_i1_orphan"></a>2.6.1.1.2.3. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > orphan`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_orphan"></a>2.6.1.1.1.2.3. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > orphan`
 
 |              |           |
 | ------------ | --------- |
@@ -1927,7 +1946,7 @@ Must be one of:
 
 **Description:** Whether to open the opener as an orphan process.
 
-###### <a name="settings_openers_additionalProperties_items_oneOf_i1_name"></a>2.6.1.1.2.4. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > name`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_name"></a>2.6.1.1.1.2.4. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > name`
 
 |              |          |
 | ------------ | -------- |
@@ -1936,7 +1955,7 @@ Must be one of:
 
 **Description:** The name of the opener to show in the menu (currently unused)
 
-###### <a name="settings_openers_additionalProperties_items_oneOf_i1_shell"></a>2.6.1.1.2.5. Property `Rovr Config > settings > openers > additionalProperties > additionalProperties items > oneOf > item 1 > shell`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_shell"></a>2.6.1.1.1.2.5. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > shell`
 
 |              |           |
 | ------------ | --------- |
@@ -1945,6 +1964,46 @@ Must be one of:
 | **Default**  | `true`    |
 
 **Description:** Whether the command to run is a shell command that needs to be run in a shell (required if you want to do piping)
+
+#### <a name="settings_openers_match"></a>2.6.2. Property `Rovr Config > settings > openers > match`
+
+|                           |                                                                                                     |
+| ------------------------- | --------------------------------------------------------------------------------------------------- |
+| **Type**                  | `object`                                                                                            |
+| **Required**              | No                                                                                                  |
+| **Additional properties** | [Each additional property must conform to the schema](#settings_openers_match_additionalProperties) |
+
+**Description:** Map glob patterns (matched against the file's path) to one or more group names defined in `groups`. If multiple groups match, they are tried in order.
+
+| Property                                         | Type            | Title/Description |
+| ------------------------------------------------ | --------------- | ----------------- |
+| [](#settings_openers_match_additionalProperties) | array of string |                   |
+
+##### <a name="settings_openers_match_additionalProperties"></a>2.6.2.1. Property `Rovr Config > settings > openers > match > additionalProperties`
+
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of string` |
+| **Required** | No                |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                                                  | Description |
+| -------------------------------------------------------------------------------- | ----------- |
+| [additionalProperties items](#settings_openers_match_additionalProperties_items) |             |
+
+###### <a name="settings_openers_match_additionalProperties_items"></a>2.6.2.1.1. Rovr Config > settings > openers > match > additionalProperties > additionalProperties items
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
 
 ### <a name="settings_drive_exclude"></a>2.7. Property `Rovr Config > settings > drive_exclude`
 

--- a/src/rovr/classes/config.pyi
+++ b/src/rovr/classes/config.pyi
@@ -18,6 +18,15 @@ class RovrConfig(TypedDict, total=False):
     keybinds: "_RovrConfigKeybinds"
     plugins: "_RovrConfigPlugins"
 
+_OPENER_ONEOF1_ORPHAN_DEFAULT = True
+r""" Default value of the field path 'opener oneof1 orphan' """
+
+_OPENER_ONEOF1_SHELL_DEFAULT = True
+r""" Default value of the field path 'opener oneof1 shell' """
+
+_Opener = Union[str, "_OpenerOneof1"]
+r""" Aggregation type: oneOf """
+
 class _OpenerIf(TypedDict, total=False):
     cwd: list[str]
     r""" Only use this opener if the current working directory matches one (or more) of the glob patterns in this list (look at https://docs.python.org/3/library/fnmatch.html for more info) """
@@ -27,6 +36,28 @@ class _OpenerIf(TypedDict, total=False):
 
     directory: bool
     r""" Only use this opener if the selected item is a directory (set to true) or a file (set to false) (if unspecified, matches both files and directories) """
+
+_OpenerOneof1 = TypedDict(
+    "_OpenerOneof1",
+    {
+        # | Aggregation type: oneOf
+        # |
+        # | Required property
+        "run": Required["_Run"],
+        "if": "_OpenerIf",
+        # | Whether to open the opener as an orphan process.
+        # |
+        # | default: True
+        "orphan": bool,
+        # | The name of the opener to show in the menu (currently unused)
+        "name": str,
+        # | Whether the command to run is a shell command that needs to be run in a shell (required if you want to do piping)
+        # |
+        # | default: True
+        "shell": bool,
+    },
+    total=False,
+)
 
 _OsIf = list["_OsIfItem"]
 r""" Only use this setting if the operating system is one of the following (case insensitive) """
@@ -268,12 +299,6 @@ r""" Default value of the field path 'Rovr Config settings editor folder run' ""
 
 _ROVR_CONFIG_SETTINGS_EDITOR_FOLDER_SHELL_DEFAULT = False
 r""" Default value of the field path 'Rovr Config settings editor folder shell' """
-
-_ROVR_CONFIG_SETTINGS_OPENERS_ADDITIONALPROPERTIES_ITEM_ONEOF1_ORPHAN_DEFAULT = True
-r""" Default value of the field path 'Rovr Config settings openers additionalProperties item oneof1 orphan' """
-
-_ROVR_CONFIG_SETTINGS_OPENERS_ADDITIONALPROPERTIES_ITEM_ONEOF1_SHELL_DEFAULT = True
-r""" Default value of the field path 'Rovr Config settings openers additionalProperties item oneof1 shell' """
 
 _ROVR_CONFIG_SETTINGS_PREVIEW_RULES_DEFAULT = {
     "text/.*": "text",
@@ -1439,11 +1464,8 @@ class _RovrConfigSettings(TypedDict, total=False):
       text/.*: text
     """
 
-    openers: dict[str, list["_RovrConfigSettingsOpenersAdditionalpropertiesItem"]]
-    r"""
-    A list of openers to open files with. These are used to open files, what were you expecting.
-    Key must be a valid glob pattern, but the value has to be a list that can contain a mix of strings and objects
-    """
+    openers: "_RovrConfigSettingsOpeners"
+    r""" Openers to open files with, grouped by name and matched against file paths by glob pattern. """
 
     drive_exclude: list[str]
     r"""
@@ -1537,32 +1559,14 @@ class _RovrConfigSettingsEditorFolder(TypedDict, total=False):
     default: False
     """
 
-_RovrConfigSettingsOpenersAdditionalpropertiesItem = Union[
-    str, "_RovrConfigSettingsOpenersAdditionalpropertiesItemOneof1"
-]
-r""" Aggregation type: oneOf """
+class _RovrConfigSettingsOpeners(TypedDict, total=False):
+    r"""Openers to open files with, grouped by name and matched against file paths by glob pattern."""
 
-_RovrConfigSettingsOpenersAdditionalpropertiesItemOneof1 = TypedDict(
-    "_RovrConfigSettingsOpenersAdditionalpropertiesItemOneof1",
-    {
-        # | Aggregation type: oneOf
-        # |
-        # | Required property
-        "run": Required["_Run"],
-        "if": "_OpenerIf",
-        # | Whether to open the opener as an orphan process.
-        # |
-        # | default: True
-        "orphan": bool,
-        # | The name of the opener to show in the menu (currently unused)
-        "name": str,
-        # | Whether the command to run is a shell command that needs to be run in a shell (required if you want to do piping)
-        # |
-        # | default: True
-        "shell": bool,
-    },
-    total=False,
-)
+    groups: dict[str, list["_Opener"]]
+    r""" Named groups of openers. Each group is a list that can contain a mix of strings and objects, tried in order until one succeeds. Referenced by name from `match`. """
+
+    match: dict[str, list[str]]
+    r""" Map glob patterns (matched against the file's path) to one or more group names defined in `groups`. If multiple groups match, they are tried in order. """
 
 _RovrConfigSettingsPreviewRulesAdditionalproperties = (
     Literal["text"]

--- a/src/rovr/config/config.toml
+++ b/src/rovr/config/config.toml
@@ -104,7 +104,10 @@ drive_exclude = ["/var/*"]
 "text/.*" = "text"
 "font/.*" = "font"
 
-[settings.openers]
+[settings.openers.groups]
+# unset for the end user
+
+[settings.openers.match]
 # unset for the end user
 
 [settings.editor.file]

--- a/src/rovr/config/migration.json
+++ b/src/rovr/config/migration.json
@@ -1,5 +1,15 @@
 [
   {
+    "keys": ["settings.openers.*"],
+    "message": [
+      "[bright_blue]settings.openers[/] has been restructured to support interactively choosing an opener.",
+      "Openers are now declared as named groups, and file patterns map to one or more group names instead of directly to an opener list.",
+      "- Move your existing pattern -> opener list entries into [bright_cyan]settings.openers.groups.<name>[/] (pick any name, e.g. `text`)",
+      "- Then map the glob pattern to that group name in [bright_cyan]settings.openers.match[/], e.g. `\"*.py\" = [\"text\"]`"
+    ],
+    "extra": "Restructured in v0.10.0"
+  },
+  {
     "keys": ["settings.editor.bulk_rename"],
     "message": [
       "The [bright_cyan]settings.editor.bulk_rename[/] has been renamed to [bright_cyan]settings.editor.bulk_[b]editor[/][/] to give way for a bulk creator"

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -89,6 +89,40 @@
         }
       }
     },
+    "opener": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "run": {
+              "$ref": "#/definitions/run",
+              "description": "The command to run to open the file. Command expansions are supported."
+            },
+            "if": {
+              "$ref": "#/definitions/opener_if",
+              "description": "Only use this opener if a set criteria matches"
+            },
+            "orphan": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether to open the opener as an orphan process."
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the opener to show in the menu (currently unused)"
+            },
+            "shell": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether the command to run is a shell command that needs to be run in a shell (required if you want to do piping)"
+            }
+          },
+          "required": ["run"]
+        }
+      ]
+    },
     "right_click_item": {
       "type": "object",
       "properties": {
@@ -491,42 +525,24 @@
         },
         "openers": {
           "type": "object",
-          "description": "A list of openers to open files with. These are used to open files, what were you expecting.\nKey must be a valid glob pattern, but the value has to be a list that can contain a mix of strings and objects",
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                { "type": "string" },
-                {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "run": {
-                      "$ref": "#/definitions/run",
-                      "description": "The command to run to open the file. Command expansions are supported."
-                    },
-                    "if": {
-                      "$ref": "#/definitions/opener_if",
-                      "description": "Only use this opener if a set criteria matches"
-                    },
-                    "orphan": {
-                      "type": "boolean",
-                      "default": true,
-                      "description": "Whether to open the opener as an orphan process."
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "The name of the opener to show in the menu (currently unused)"
-                    },
-                    "shell": {
-                      "type": "boolean",
-                      "default": true,
-                      "description": "Whether the command to run is a shell command that needs to be run in a shell (required if you want to do piping)"
-                    }
-                  },
-                  "required": ["run"]
-                }
-              ]
+          "additionalProperties": false,
+          "description": "Openers to open files with, grouped by name and matched against file paths by glob pattern.",
+          "properties": {
+            "groups": {
+              "type": "object",
+              "description": "Named groups of openers. Each group is a list that can contain a mix of strings and objects, tried in order until one succeeds. Referenced by name from `match`.",
+              "additionalProperties": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/opener" }
+              }
+            },
+            "match": {
+              "type": "object",
+              "description": "Map glob patterns (matched against the file's path) to one or more group names defined in `groups`. If multiple groups match, they are tried in order.",
+              "additionalProperties": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
             }
           }
         },

--- a/src/rovr/functions/path.py
+++ b/src/rovr/functions/path.py
@@ -686,8 +686,14 @@ def run_opener(app: App, target_path: str) -> None:
 
     from . import utils
 
-    for pattern, openers in config["settings"].get("openers", {}).items():
-        if fnmatch(target_path, pattern):
+    groups = config["settings"].get("openers", {}).get("groups", {})
+    matches = config["settings"].get("openers", {}).get("match", {})
+
+    for pattern, group_names in matches.items():
+        if not fnmatch(target_path, pattern):
+            continue
+        for group_name in group_names:
+            openers = groups.get(group_name, [])
             for opener in openers:
                 if isinstance(opener, str):
                     runner = opener

--- a/src/rovr/functions/path.py
+++ b/src/rovr/functions/path.py
@@ -693,8 +693,15 @@ def run_opener(app: App, target_path: str) -> None:
         if not fnmatch(target_path, pattern):
             continue
         for group_name in group_names:
-            openers = groups.get(group_name, [])
-            for opener in openers:
+            if group_name not in groups:
+                app.notify(
+                    f"Opener group '{group_name}' not found in configuration.",
+                    title="Opener Error",
+                    severity="warning",
+                    markup=False,
+                )
+                continue
+            for opener in groups[group_name]:
                 if isinstance(opener, str):
                     runner = opener
                 elif ifed(app, opener.get("if", {})):


### PR DESCRIPTION
splits the original `openers` implementation into two parts, a `group` and a `match` section

`[settings.openers.group]`
lets you define a group of openers
```toml
[settings.openers.groups]
text = [
  { run = "$EDITOR", orphan = true },
  { run = "code", orphan = true }
]
```
`[settings.openers.match]`
lets you provide a group for a given file extension
```toml
[settings.openers.match]
"*.py" = ["text"]  # this means you can have multiple groups
```
aims to be similar to yazi, also to add context menu support (open with) soon

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible
- [x] the documentation has been updated wherever necessary (run `poe gen-schema` and `poe gen-keys` if applicable)

## Summary by Sourcery

Refactor the custom openers configuration into named groups and glob pattern matches for file paths.

New Features:
- Introduce `settings.openers.groups` for defining reusable named groups of openers.
- Introduce `settings.openers.match` for mapping file path glob patterns to one or more opener groups.

Enhancements:
- Update the configuration schema, typings, and default config to align with the new grouped openers structure.
- Adjust the opener execution logic to resolve openers via group names matched from file path patterns.
- Improve developer documentation for custom openers to describe the new groups/match configuration model.

Documentation:
- Revise schema reference and custom openers feature docs to document the grouped openers and match-based configuration model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Openers can now be organised into named groups and matched from glob patterns, making opener configuration more flexible.
  * Unmatched files now fall back to the system default opener.

* **Bug Fixes**
  * Updated opener handling to support the new grouped configuration layout consistently across the app.

* **Documentation**
  * Refreshed the developer docs and configuration reference to explain the new opener setup and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->