### PR TITLE
Add auto select mode config

### DIFF
--- a/src/rovr/classes/config.pyi
+++ b/src/rovr/classes/config.pyi
@@ -138,6 +138,9 @@ r""" Default value of the field path 'Rovr Config interface preview_text start' 
 _ROVR_CONFIG_INTERFACE_SCROLLOFF_DEFAULT = 3
 r""" Default value of the field path 'Rovr Config interface scrolloff' """
 
+_ROVR_CONFIG_INTERFACE_AUTO_SELECT_MODE_DEFAULT = False
+r""" Default value of the field path 'Rovr Config interface auto_select_mode' """
+
 _ROVR_CONFIG_INTERFACE_SHOW_HIDDEN_FILES_DEFAULT = False
 r""" Default value of the field path 'Rovr Config interface show_hidden_files' """
 
@@ -692,6 +695,13 @@ class _RovrConfigInterface(TypedDict, total=False):
     show_line_numbers: bool
     r"""
     Add line numbers to the left gutter if you are viewing a text file.
+
+    default: False
+    """
+
+    auto_select_mode: bool
+    r"""
+    Start new file-list sessions in select mode.
 
     default: False
     """

--- a/src/rovr/classes/session_manager.py
+++ b/src/rovr/classes/session_manager.py
@@ -1,5 +1,7 @@
 from typing import TypedDict
 
+from rovr.variables.constants import config
+
 
 class SessionOptionDict(TypedDict):
     name: str
@@ -32,6 +34,6 @@ class SessionManager:
         self.directories: list[str] = []
         self.historyIndex: int = 0
         self.lastHighlighted: dict[str, SessionOptionDict] = {}
-        self.selectMode: bool = False
+        self.selectMode: bool = config["interface"]["auto_select_mode"]
         self.selectedItems: list[SessionOptionDict] = []
         self.search: str = ""

--- a/src/rovr/config/config.toml
+++ b/src/rovr/config/config.toml
@@ -9,6 +9,7 @@ show_progress_eta = false
 show_progress_percentage = true
 truncate_progress_file_path = false
 show_line_numbers = true
+auto_select_mode = false
 show_hidden_files = false
 allow_tab_nav = true
 append_new_tabs = true

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -243,6 +243,11 @@
           "default": false,
           "description": "Add line numbers to the left gutter if you are viewing a text file."
         },
+        "auto_select_mode": {
+          "type": "boolean",
+          "default": false,
+          "description": "Start new file-list sessions in select mode."
+        },
         "scrolloff": {
           "type": "integer",
           "minimum": 0,

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -125,6 +125,7 @@ class FileList(
         self._options: list[FileListSelectionWidget] = []
         self.dummy = dummy
         self.enter_into = enter_into
+        self._select_mode_enabled = False
         self.select_mode_enabled = select or (
             not dummy and config["interface"]["auto_select_mode"]
         )
@@ -132,13 +133,23 @@ class FileList(
             self.items_in_cwd: set[str] = set()
         self.file_list_pause_check = False
         self._ignore_next_click: bool = False
-        if self.select_mode_enabled:
-            self.add_class("select-mode")
 
     def on_mount(self) -> None:
         if not self.dummy and self.parent:
             self.input: Input = self.parent.query_one(Input)
             self.focus()
+
+    @property
+    def select_mode_enabled(self) -> bool:
+        return self._select_mode_enabled
+
+    @select_mode_enabled.setter
+    def select_mode_enabled(self, enabled: bool) -> None:
+        self._select_mode_enabled = enabled
+        if enabled:
+            self.add_class("select-mode")
+        else:
+            self.remove_class("select-mode")
 
     @property
     def highlighted_option(self) -> FileListSelectionWidget | None:
@@ -564,10 +575,6 @@ class FileList(
         with self.prevent(SelectionList.SelectedChanged):
             self.deselect_all()
         self.update_border_subtitle()
-        if self.select_mode_enabled:
-            self.add_class("select-mode")
-        else:
-            self.remove_class("select-mode")
 
     async def get_selected_objects(self) -> list[str] | None:
         """Get the selected objects in the file list.

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -125,11 +125,15 @@ class FileList(
         self._options: list[FileListSelectionWidget] = []
         self.dummy = dummy
         self.enter_into = enter_into
-        self.select_mode_enabled = select
+        self.select_mode_enabled = select or (
+            not dummy and config["interface"]["auto_select_mode"]
+        )
         if not self.dummy:
             self.items_in_cwd: set[str] = set()
         self.file_list_pause_check = False
         self._ignore_next_click: bool = False
+        if self.select_mode_enabled:
+            self.add_class("select-mode")
 
     def on_mount(self) -> None:
         if not self.dummy and self.parent:

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -7,6 +7,7 @@ from textual import events
 from rovr.app import Application
 from rovr.components import SearchInput
 from rovr.navigation_widgets import BackButton
+from rovr.variables.constants import config
 
 from .conftest import iter_until, workers_finished
 
@@ -197,6 +198,32 @@ async def test_tab_multiselection(tmp_path: Path) -> None:
         for selected_id in app.file_list.selected:
             assert app.file_list.get_option_index(selected_id) in indexes
             indexes.remove(app.file_list.get_option_index(selected_id))
+
+
+@pytest.mark.asyncio
+async def test_auto_select_mode_starts_file_lists_in_select_mode(
+    tmp_path: Path,
+) -> None:
+    for i in range(3):
+        open(tmp_path / f"file{i}", "w").close()
+
+    original_auto_select_mode = config["interface"]["auto_select_mode"]
+    config["interface"]["auto_select_mode"] = True
+    try:
+        app = Application(startup_path=tmp_path.as_posix())
+        async with app.run_test(size=(143, 37)) as pilot:
+            await iter_until(pilot, lambda: bool(app.file_list.options))
+
+            assert app.file_list.select_mode_enabled
+            assert app.tabWidget.active_tab.session.selectMode
+
+            await app.tabWidget.add_tab("")
+            await workers_finished(pilot, app.file_list)
+
+            assert app.file_list.select_mode_enabled
+            assert app.tabWidget.active_tab.session.selectMode
+    finally:
+        config["interface"]["auto_select_mode"] = original_auto_select_mode
 
 
 @pytest.mark.asyncio

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -203,27 +203,29 @@ async def test_tab_multiselection(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_auto_select_mode_starts_file_lists_in_select_mode(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     for i in range(3):
         open(tmp_path / f"file{i}", "w").close()
 
-    original_auto_select_mode = config["interface"]["auto_select_mode"]
-    config["interface"]["auto_select_mode"] = True
-    try:
-        app = Application(startup_path=tmp_path.as_posix())
-        async with app.run_test(size=(143, 37)) as pilot:
-            await iter_until(pilot, lambda: bool(app.file_list.options))
+    monkeypatch.setitem(config["interface"], "auto_select_mode", True)
+    app = Application(startup_path=tmp_path.as_posix())
+    async with app.run_test(size=(143, 37)) as pilot:
+        await iter_until(pilot, lambda: bool(app.file_list.options))
 
-            assert app.file_list.select_mode_enabled
-            assert app.tabWidget.active_tab.session.selectMode
+        assert app.file_list.select_mode_enabled
+        assert app.file_list.has_class("select-mode")
+        assert app.tabWidget.active_tab.session.selectMode
 
-            await app.tabWidget.add_tab("")
-            await workers_finished(pilot, app.file_list)
+        await app.tabWidget.add_tab("")
+        await workers_finished(pilot, app.file_list)
 
-            assert app.file_list.select_mode_enabled
-            assert app.tabWidget.active_tab.session.selectMode
-    finally:
-        config["interface"]["auto_select_mode"] = original_auto_select_mode
+        assert app.file_list.select_mode_enabled
+        assert app.file_list.has_class("select-mode")
+        assert app.tabWidget.active_tab.session.selectMode
+
+        app.file_list.select_mode_enabled = False
+        assert not app.file_list.has_class("select-mode")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #254.

Adds `interface.auto_select_mode` so new file-list sessions can start in select mode when configured. Existing per-tab select mode behavior is preserved.

Tests:
- `poe check`
- `poe test -n 4`

## Summary by Sourcery

Introduce configurable auto-select mode to start new file-list sessions in selection mode by default.

New Features:
- Add interface.auto_select_mode configuration option to control whether new file-list sessions start in select mode.
- Honor auto_select_mode when initializing file lists and session select state so tabs can default to selection mode.

Tests:
- Add navigation test verifying that enabling auto_select_mode starts initial and newly opened file-list sessions in select mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interface setting to automatically start new file-list sessions in select mode.
  * New sessions now default to select mode when enabled in settings.
* **Bug Fixes**
  * Select mode now remains consistent when opening additional tabs or file lists.
  * The initial session state now more reliably follows the configured default.
* **Tests**
  * Added coverage to verify auto select mode behaviour and the corresponding UI state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->