### PR TITLE
perf(filelist)?: evict history after a given limit

### DIFF
--- a/docs/src/content/docs/dev/reference/schema.mdx
+++ b/docs/src/content/docs/dev/reference/schema.mdx
@@ -85,53 +85,55 @@ description: config schema humanified
               - [2.2.1.6.1.3.3.1. Rovr Config > settings > right_click > right_click items > if > cwd > cwd items](#settings_right_click_items_if_cwd_items)
             - [2.2.1.6.1.3.4. Property `Rovr Config > settings > right_click > right_click items > if > directory`](#settings_right_click_items_if_directory)
   - [2.3. Property `Rovr Config > settings > copy_includes_metadata`](#settings_copy_includes_metadata)
-  - [2.4. Property `Rovr Config > settings > editor`](#settings_editor)
-    - [2.4.1. Property `Rovr Config > settings > editor > file`](#settings_editor_file)
-      - [2.4.1.1. Property `Rovr Config > settings > editor > file > run`](#settings_editor_file_run)
-        - [2.4.1.1.1. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 0`](#settings_right_click_items_action_oneOf_i1_run_oneOf_i0)
-        - [2.4.1.1.2. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1`](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1)
-          - [2.4.1.1.2.1. Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1 > item 1 items](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1_items)
-      - [2.4.1.2. Property `Rovr Config > settings > editor > file > orphan`](#settings_editor_file_orphan)
-      - [2.4.1.3. Property `Rovr Config > settings > editor > file > shell`](#settings_editor_file_shell)
-    - [2.4.2. Property `Rovr Config > settings > editor > folder`](#settings_editor_folder)
-      - [2.4.2.1. Property `Rovr Config > settings > editor > folder > run`](#settings_editor_folder_run)
-        - [2.4.2.1.1. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 0`](#settings_right_click_items_action_oneOf_i1_run_oneOf_i0)
-        - [2.4.2.1.2. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1`](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1)
-          - [2.4.2.1.2.1. Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1 > item 1 items](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1_items)
-      - [2.4.2.2. Property `Rovr Config > settings > editor > folder > orphan`](#settings_editor_folder_orphan)
-      - [2.4.2.3. Property `Rovr Config > settings > editor > folder > shell`](#settings_editor_folder_shell)
-    - [2.4.3. Property `Rovr Config > settings > editor > bulk_editor`](#settings_editor_bulk_editor)
-      - [2.4.3.1. Property `Rovr Config > settings > editor > bulk_editor > run`](#settings_editor_bulk_editor_run)
-        - [2.4.3.1.1. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 0`](#settings_right_click_items_action_oneOf_i1_run_oneOf_i0)
-        - [2.4.3.1.2. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1`](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1)
-          - [2.4.3.1.2.1. Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1 > item 1 items](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1_items)
-      - [2.4.3.2. Property `Rovr Config > settings > editor > bulk_editor > rename_show_as_mapping`](#settings_editor_bulk_editor_rename_show_as_mapping)
-      - [2.4.3.3. Property `Rovr Config > settings > editor > bulk_editor > shell`](#settings_editor_bulk_editor_shell)
-  - [2.5. Property `Rovr Config > settings > preview_rules`](#settings_preview_rules)
-    - [2.5.1. Property `Rovr Config > settings > preview_rules > additionalProperties`](#settings_preview_rules_additionalProperties)
-  - [2.6. Property `Rovr Config > settings > openers`](#settings_openers)
-    - [2.6.1. Property `Rovr Config > settings > openers > groups`](#settings_openers_groups)
-      - [2.6.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties`](#settings_openers_groups_additionalProperties)
-        - [2.6.1.1.1. Rovr Config > settings > openers > groups > additionalProperties > opener](#settings_openers_groups_additionalProperties_items)
-          - [2.6.1.1.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 0`](#settings_openers_groups_additionalProperties_items_oneOf_i0)
-          - [2.6.1.1.1.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1`](#settings_openers_groups_additionalProperties_items_oneOf_i1)
-            - [2.6.1.1.1.2.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > run`](#settings_openers_groups_additionalProperties_items_oneOf_i1_run)
-            - [2.6.1.1.1.2.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if)
-              - [2.6.1.1.1.2.2.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_cwd)
-                - [2.6.1.1.1.2.2.1.1. Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd > cwd items](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_cwd_items)
-              - [2.6.1.1.1.2.2.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os)
-                - [2.6.1.1.1.2.2.2.1. Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items)
-                  - [2.6.1.1.1.2.2.2.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 0`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i0)
-                  - [2.6.1.1.1.2.2.2.1.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 1`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i1)
-              - [2.6.1.1.1.2.2.3. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > directory`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_directory)
-            - [2.6.1.1.1.2.3. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > orphan`](#settings_openers_groups_additionalProperties_items_oneOf_i1_orphan)
-            - [2.6.1.1.1.2.4. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > name`](#settings_openers_groups_additionalProperties_items_oneOf_i1_name)
-            - [2.6.1.1.1.2.5. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > shell`](#settings_openers_groups_additionalProperties_items_oneOf_i1_shell)
-    - [2.6.2. Property `Rovr Config > settings > openers > match`](#settings_openers_match)
-      - [2.6.2.1. Property `Rovr Config > settings > openers > match > additionalProperties`](#settings_openers_match_additionalProperties)
-        - [2.6.2.1.1. Rovr Config > settings > openers > match > additionalProperties > additionalProperties items](#settings_openers_match_additionalProperties_items)
-  - [2.7. Property `Rovr Config > settings > drive_exclude`](#settings_drive_exclude)
-    - [2.7.1. Rovr Config > settings > drive_exclude > drive_exclude items](#settings_drive_exclude_items)
+  - [2.4. Property `Rovr Config > settings > history_size`](#settings_history_size)
+  - [2.5. Property `Rovr Config > settings > last_highlighted_size`](#settings_last_highlighted_size)
+  - [2.6. Property `Rovr Config > settings > editor`](#settings_editor)
+    - [2.6.1. Property `Rovr Config > settings > editor > file`](#settings_editor_file)
+      - [2.6.1.1. Property `Rovr Config > settings > editor > file > run`](#settings_editor_file_run)
+        - [2.6.1.1.1. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 0`](#settings_right_click_items_action_oneOf_i1_run_oneOf_i0)
+        - [2.6.1.1.2. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1`](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1)
+          - [2.6.1.1.2.1. Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1 > item 1 items](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1_items)
+      - [2.6.1.2. Property `Rovr Config > settings > editor > file > orphan`](#settings_editor_file_orphan)
+      - [2.6.1.3. Property `Rovr Config > settings > editor > file > shell`](#settings_editor_file_shell)
+    - [2.6.2. Property `Rovr Config > settings > editor > folder`](#settings_editor_folder)
+      - [2.6.2.1. Property `Rovr Config > settings > editor > folder > run`](#settings_editor_folder_run)
+        - [2.6.2.1.1. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 0`](#settings_right_click_items_action_oneOf_i1_run_oneOf_i0)
+        - [2.6.2.1.2. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1`](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1)
+          - [2.6.2.1.2.1. Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1 > item 1 items](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1_items)
+      - [2.6.2.2. Property `Rovr Config > settings > editor > folder > orphan`](#settings_editor_folder_orphan)
+      - [2.6.2.3. Property `Rovr Config > settings > editor > folder > shell`](#settings_editor_folder_shell)
+    - [2.6.3. Property `Rovr Config > settings > editor > bulk_editor`](#settings_editor_bulk_editor)
+      - [2.6.3.1. Property `Rovr Config > settings > editor > bulk_editor > run`](#settings_editor_bulk_editor_run)
+        - [2.6.3.1.1. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 0`](#settings_right_click_items_action_oneOf_i1_run_oneOf_i0)
+        - [2.6.3.1.2. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1`](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1)
+          - [2.6.3.1.2.1. Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1 > item 1 items](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1_items)
+      - [2.6.3.2. Property `Rovr Config > settings > editor > bulk_editor > rename_show_as_mapping`](#settings_editor_bulk_editor_rename_show_as_mapping)
+      - [2.6.3.3. Property `Rovr Config > settings > editor > bulk_editor > shell`](#settings_editor_bulk_editor_shell)
+  - [2.7. Property `Rovr Config > settings > preview_rules`](#settings_preview_rules)
+    - [2.7.1. Property `Rovr Config > settings > preview_rules > additionalProperties`](#settings_preview_rules_additionalProperties)
+  - [2.8. Property `Rovr Config > settings > openers`](#settings_openers)
+    - [2.8.1. Property `Rovr Config > settings > openers > groups`](#settings_openers_groups)
+      - [2.8.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties`](#settings_openers_groups_additionalProperties)
+        - [2.8.1.1.1. Rovr Config > settings > openers > groups > additionalProperties > opener](#settings_openers_groups_additionalProperties_items)
+          - [2.8.1.1.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 0`](#settings_openers_groups_additionalProperties_items_oneOf_i0)
+          - [2.8.1.1.1.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1`](#settings_openers_groups_additionalProperties_items_oneOf_i1)
+            - [2.8.1.1.1.2.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > run`](#settings_openers_groups_additionalProperties_items_oneOf_i1_run)
+            - [2.8.1.1.1.2.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if)
+              - [2.8.1.1.1.2.2.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_cwd)
+                - [2.8.1.1.1.2.2.1.1. Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd > cwd items](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_cwd_items)
+              - [2.8.1.1.1.2.2.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os)
+                - [2.8.1.1.1.2.2.2.1. Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items)
+                  - [2.8.1.1.1.2.2.2.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 0`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i0)
+                  - [2.8.1.1.1.2.2.2.1.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 1`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i1)
+              - [2.8.1.1.1.2.2.3. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > directory`](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_directory)
+            - [2.8.1.1.1.2.3. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > orphan`](#settings_openers_groups_additionalProperties_items_oneOf_i1_orphan)
+            - [2.8.1.1.1.2.4. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > name`](#settings_openers_groups_additionalProperties_items_oneOf_i1_name)
+            - [2.8.1.1.1.2.5. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > shell`](#settings_openers_groups_additionalProperties_items_oneOf_i1_shell)
+    - [2.8.2. Property `Rovr Config > settings > openers > match`](#settings_openers_match)
+      - [2.8.2.1. Property `Rovr Config > settings > openers > match > additionalProperties`](#settings_openers_match_additionalProperties)
+        - [2.8.2.1.1. Rovr Config > settings > openers > match > additionalProperties > additionalProperties items](#settings_openers_match_additionalProperties_items)
+  - [2.9. Property `Rovr Config > settings > drive_exclude`](#settings_drive_exclude)
+    - [2.9.1. Rovr Config > settings > drive_exclude > drive_exclude items](#settings_drive_exclude_items)
 - [3. Property `Rovr Config > metadata`](#metadata)
   - [3.1. Property `Rovr Config > metadata > fields`](#metadata_fields)
     - [3.1.1. Rovr Config > metadata > fields > fields items](#metadata_fields_items)
@@ -978,6 +980,8 @@ Must be one of:
 | [use_recycle_bin](#settings_use_recycle_bin)               | boolean         | When deleting a file, allow moving the file to the recycle bin.                                                                                                                                                         |
 | [right_click](#settings_right_click)                       | array           | Configuration for the right-click context menu. Fully replaces the default list.                                                                                                                                        |
 | [copy_includes_metadata](#settings_copy_includes_metadata) | boolean         | When copying over a file, preserve metadata from the original file, such as creation and modification times.                                                                                                            |
+| [history_size](#settings_history_size)                     | integer         | The maximum number of directories to keep in the back/forward navigation history, per tab. Oldest entries are evicted once this is exceeded.                                                                            |
+| [last_highlighted_size](#settings_last_highlighted_size)   | integer         | The maximum number of directories to remember the last-highlighted item for, per tab. Least-recently-used entries are evicted once this is exceeded.                                                                    |
 | [editor](#settings_editor)                                 | object          | Settings related to the editor used for different operations                                                                                                                                                            |
 | [preview_rules](#settings_preview_rules)                   | object          | Map MIME type patterns to preview types. Uses regex patterns. Valid preview types: text, image, pdf, archive, folder, resvg, font, remime.<br />-&gt; Use 'remime' if you want a more accurate description from file(1) |
 | [openers](#settings_openers)                               | object          | Openers to open files with, grouped by name and matched against file paths by glob pattern.                                                                                                                             |
@@ -1534,7 +1538,35 @@ Must be one of:
 
 **Description:** When copying over a file, preserve metadata from the original file, such as creation and modification times.
 
-### <a name="settings_editor"></a>2.4. Property `Rovr Config > settings > editor`
+### <a name="settings_history_size"></a>2.4. Property `Rovr Config > settings > history_size`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `integer` |
+| **Required** | No        |
+| **Default**  | `100`     |
+
+**Description:** The maximum number of directories to keep in the back/forward navigation history, per tab. Oldest entries are evicted once this is exceeded.
+
+| Restrictions |        |
+| ------------ | ------ |
+| **Minimum**  | &ge; 1 |
+
+### <a name="settings_last_highlighted_size"></a>2.5. Property `Rovr Config > settings > last_highlighted_size`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `integer` |
+| **Required** | No        |
+| **Default**  | `200`     |
+
+**Description:** The maximum number of directories to remember the last-highlighted item for, per tab. Least-recently-used entries are evicted once this is exceeded.
+
+| Restrictions |        |
+| ------------ | ------ |
+| **Minimum**  | &ge; 1 |
+
+### <a name="settings_editor"></a>2.6. Property `Rovr Config > settings > editor`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -1550,7 +1582,7 @@ Must be one of:
 | [folder](#settings_editor_folder)           | object | Editor to use when opening a folder |
 | [bulk_editor](#settings_editor_bulk_editor) | object | Editor to use for bulk editing      |
 
-#### <a name="settings_editor_file"></a>2.4.1. Property `Rovr Config > settings > editor > file`
+#### <a name="settings_editor_file"></a>2.6.1. Property `Rovr Config > settings > editor > file`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -1566,7 +1598,7 @@ Must be one of:
 | [orphan](#settings_editor_file_orphan) | boolean | Whether to open the editor as an orphan process.                                                                                                                 |
 | [shell](#settings_editor_file_shell)   | boolean | Whether the command to run is a shell command that needs to be run in a shell (required if you want to do complicated things like piping in your editor command) |
 
-##### <a name="settings_editor_file_run"></a>2.4.1.1. Property `Rovr Config > settings > editor > file > run`
+##### <a name="settings_editor_file_run"></a>2.6.1.1. Property `Rovr Config > settings > editor > file > run`
 
 |                           |                   |
 | ------------------------- | ----------------- |
@@ -1583,14 +1615,14 @@ Must be one of:
 | [item 0](#settings_right_click_items_action_oneOf_i1_run_oneOf_i0) |
 | [item 1](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1) |
 
-###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i0"></a>2.4.1.1.1. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 0`
+###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i0"></a>2.6.1.1.1. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 0`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i1"></a>2.4.1.1.2. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1`
+###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i1"></a>2.6.1.1.2. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -1609,14 +1641,14 @@ Must be one of:
 | ------------------------------------------------------------------------------ | ----------- |
 | [item 1 items](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1_items) |             |
 
-###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i1_items"></a>2.4.1.1.2.1. Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1 > item 1 items
+###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i1_items"></a>2.6.1.1.2.1. Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1 > item 1 items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="settings_editor_file_orphan"></a>2.4.1.2. Property `Rovr Config > settings > editor > file > orphan`
+##### <a name="settings_editor_file_orphan"></a>2.6.1.2. Property `Rovr Config > settings > editor > file > orphan`
 
 |              |           |
 | ------------ | --------- |
@@ -1626,7 +1658,7 @@ Must be one of:
 
 **Description:** Whether to open the editor as an orphan process.
 
-##### <a name="settings_editor_file_shell"></a>2.4.1.3. Property `Rovr Config > settings > editor > file > shell`
+##### <a name="settings_editor_file_shell"></a>2.6.1.3. Property `Rovr Config > settings > editor > file > shell`
 
 |              |           |
 | ------------ | --------- |
@@ -1636,7 +1668,7 @@ Must be one of:
 
 **Description:** Whether the command to run is a shell command that needs to be run in a shell (required if you want to do complicated things like piping in your editor command)
 
-#### <a name="settings_editor_folder"></a>2.4.2. Property `Rovr Config > settings > editor > folder`
+#### <a name="settings_editor_folder"></a>2.6.2. Property `Rovr Config > settings > editor > folder`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -1652,7 +1684,7 @@ Must be one of:
 | [orphan](#settings_editor_folder_orphan) | boolean | Whether to open the editor as an orphan process.                                                                                                                 |
 | [shell](#settings_editor_folder_shell)   | boolean | Whether the command to run is a shell command that needs to be run in a shell (required if you want to do complicated things like piping in your editor command) |
 
-##### <a name="settings_editor_folder_run"></a>2.4.2.1. Property `Rovr Config > settings > editor > folder > run`
+##### <a name="settings_editor_folder_run"></a>2.6.2.1. Property `Rovr Config > settings > editor > folder > run`
 
 |                           |                   |
 | ------------------------- | ----------------- |
@@ -1669,14 +1701,14 @@ Must be one of:
 | [item 0](#settings_right_click_items_action_oneOf_i1_run_oneOf_i0) |
 | [item 1](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1) |
 
-###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i0"></a>2.4.2.1.1. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 0`
+###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i0"></a>2.6.2.1.1. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 0`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i1"></a>2.4.2.1.2. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1`
+###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i1"></a>2.6.2.1.2. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -1695,14 +1727,14 @@ Must be one of:
 | ------------------------------------------------------------------------------ | ----------- |
 | [item 1 items](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1_items) |             |
 
-###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i1_items"></a>2.4.2.1.2.1. Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1 > item 1 items
+###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i1_items"></a>2.6.2.1.2.1. Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1 > item 1 items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="settings_editor_folder_orphan"></a>2.4.2.2. Property `Rovr Config > settings > editor > folder > orphan`
+##### <a name="settings_editor_folder_orphan"></a>2.6.2.2. Property `Rovr Config > settings > editor > folder > orphan`
 
 |              |           |
 | ------------ | --------- |
@@ -1712,7 +1744,7 @@ Must be one of:
 
 **Description:** Whether to open the editor as an orphan process.
 
-##### <a name="settings_editor_folder_shell"></a>2.4.2.3. Property `Rovr Config > settings > editor > folder > shell`
+##### <a name="settings_editor_folder_shell"></a>2.6.2.3. Property `Rovr Config > settings > editor > folder > shell`
 
 |              |           |
 | ------------ | --------- |
@@ -1722,7 +1754,7 @@ Must be one of:
 
 **Description:** Whether the command to run is a shell command that needs to be run in a shell (required if you want to do complicated things like piping in your editor command)
 
-#### <a name="settings_editor_bulk_editor"></a>2.4.3. Property `Rovr Config > settings > editor > bulk_editor`
+#### <a name="settings_editor_bulk_editor"></a>2.6.3. Property `Rovr Config > settings > editor > bulk_editor`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -1738,7 +1770,7 @@ Must be one of:
 | [rename_show_as_mapping](#settings_editor_bulk_editor_rename_show_as_mapping) | boolean | When doing a bulk rename, show as a mapping of \`&lt;old&gt; ➔ &lt;new&gt;\` instead of just showing only the new names                                          |
 | [shell](#settings_editor_bulk_editor_shell)                                   | boolean | Whether the command to run is a shell command that needs to be run in a shell (required if you want to do complicated things like piping in your editor command) |
 
-##### <a name="settings_editor_bulk_editor_run"></a>2.4.3.1. Property `Rovr Config > settings > editor > bulk_editor > run`
+##### <a name="settings_editor_bulk_editor_run"></a>2.6.3.1. Property `Rovr Config > settings > editor > bulk_editor > run`
 
 |                           |                   |
 | ------------------------- | ----------------- |
@@ -1755,14 +1787,14 @@ Must be one of:
 | [item 0](#settings_right_click_items_action_oneOf_i1_run_oneOf_i0) |
 | [item 1](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1) |
 
-###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i0"></a>2.4.3.1.1. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 0`
+###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i0"></a>2.6.3.1.1. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 0`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i1"></a>2.4.3.1.2. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1`
+###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i1"></a>2.6.3.1.2. Property `Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -1781,14 +1813,14 @@ Must be one of:
 | ------------------------------------------------------------------------------ | ----------- |
 | [item 1 items](#settings_right_click_items_action_oneOf_i1_run_oneOf_i1_items) |             |
 
-###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i1_items"></a>2.4.3.1.2.1. Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1 > item 1 items
+###### <a name="settings_right_click_items_action_oneOf_i1_run_oneOf_i1_items"></a>2.6.3.1.2.1. Rovr Config > settings > right_click > right_click items > action > oneOf > item 1 > run > oneOf > item 1 > item 1 items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-##### <a name="settings_editor_bulk_editor_rename_show_as_mapping"></a>2.4.3.2. Property `Rovr Config > settings > editor > bulk_editor > rename_show_as_mapping`
+##### <a name="settings_editor_bulk_editor_rename_show_as_mapping"></a>2.6.3.2. Property `Rovr Config > settings > editor > bulk_editor > rename_show_as_mapping`
 
 |              |           |
 | ------------ | --------- |
@@ -1798,7 +1830,7 @@ Must be one of:
 
 **Description:** When doing a bulk rename, show as a mapping of `&lt;old&gt; ➔ &lt;new&gt;` instead of just showing only the new names
 
-##### <a name="settings_editor_bulk_editor_shell"></a>2.4.3.3. Property `Rovr Config > settings > editor > bulk_editor > shell`
+##### <a name="settings_editor_bulk_editor_shell"></a>2.6.3.3. Property `Rovr Config > settings > editor > bulk_editor > shell`
 
 |              |           |
 | ------------ | --------- |
@@ -1808,7 +1840,7 @@ Must be one of:
 
 **Description:** Whether the command to run is a shell command that needs to be run in a shell (required if you want to do complicated things like piping in your editor command)
 
-### <a name="settings_preview_rules"></a>2.5. Property `Rovr Config > settings > preview_rules`
+### <a name="settings_preview_rules"></a>2.7. Property `Rovr Config > settings > preview_rules`
 
 |                           |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -1824,7 +1856,7 @@ Must be one of:
 | ------------------------------------------------ | ---------------- | ----------------- |
 | [](#settings_preview_rules_additionalProperties) | enum (of string) |                   |
 
-#### <a name="settings_preview_rules_additionalProperties"></a>2.5.1. Property `Rovr Config > settings > preview_rules > additionalProperties`
+#### <a name="settings_preview_rules_additionalProperties"></a>2.7.1. Property `Rovr Config > settings > preview_rules > additionalProperties`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -1842,7 +1874,7 @@ Must be one of:
 - "resvg"
 - "font"
 
-### <a name="settings_openers"></a>2.6. Property `Rovr Config > settings > openers`
+### <a name="settings_openers"></a>2.8. Property `Rovr Config > settings > openers`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -1857,7 +1889,7 @@ Must be one of:
 | [groups](#settings_openers_groups) | object | Named groups of openers. Each group is a list that can contain a mix of strings and objects, tried in order until one succeeds. Referenced by name from \`match\`. |
 | [match](#settings_openers_match)   | object | Map glob patterns (matched against the file's path) to one or more group names defined in \`groups\`. If multiple groups match, they are tried in order.           |
 
-#### <a name="settings_openers_groups"></a>2.6.1. Property `Rovr Config > settings > openers > groups`
+#### <a name="settings_openers_groups"></a>2.8.1. Property `Rovr Config > settings > openers > groups`
 
 |                           |                                                                                                      |
 | ------------------------- | ---------------------------------------------------------------------------------------------------- |
@@ -1871,7 +1903,7 @@ Must be one of:
 | ------------------------------------------------- | ----- | ----------------- |
 | [](#settings_openers_groups_additionalProperties) | array |                   |
 
-##### <a name="settings_openers_groups_additionalProperties"></a>2.6.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties`
+##### <a name="settings_openers_groups_additionalProperties"></a>2.8.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties`
 
 |              |         |
 | ------------ | ------- |
@@ -1890,7 +1922,7 @@ Must be one of:
 | ------------------------------------------------------------- | ----------- |
 | [opener](#settings_openers_groups_additionalProperties_items) |             |
 
-###### <a name="settings_openers_groups_additionalProperties_items"></a>2.6.1.1.1. Rovr Config > settings > openers > groups > additionalProperties > opener
+###### <a name="settings_openers_groups_additionalProperties_items"></a>2.8.1.1.1. Rovr Config > settings > openers > groups > additionalProperties > opener
 
 |                           |                      |
 | ------------------------- | -------------------- |
@@ -1904,14 +1936,14 @@ Must be one of:
 | [item 0](#settings_openers_groups_additionalProperties_items_oneOf_i0) |
 | [item 1](#settings_openers_groups_additionalProperties_items_oneOf_i1) |
 
-###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i0"></a>2.6.1.1.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 0`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i0"></a>2.8.1.1.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 0`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1"></a>2.6.1.1.1.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1"></a>2.8.1.1.1.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -1927,7 +1959,7 @@ Must be one of:
 | [name](#settings_openers_groups_additionalProperties_items_oneOf_i1_name)     | string  | The name of the opener to show in the menu (currently unused)                                                     |
 | [shell](#settings_openers_groups_additionalProperties_items_oneOf_i1_shell)   | boolean | Whether the command to run is a shell command that needs to be run in a shell (required if you want to do piping) |
 
-###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_run"></a>2.6.1.1.1.2.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > run`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_run"></a>2.8.1.1.1.2.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > run`
 
 |                           |                                                        |
 | ------------------------- | ------------------------------------------------------ |
@@ -1938,7 +1970,7 @@ Must be one of:
 
 **Description:** The command to run to open the file. Command expansions are supported.
 
-###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if"></a>2.6.1.1.1.2.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if"></a>2.8.1.1.1.2.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if`
 
 |                           |                         |
 | ------------------------- | ----------------------- |
@@ -1955,7 +1987,7 @@ Must be one of:
 | [os](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os)               | array of string | Only use this opener if the operating system is one of the following (case insensitive)                                                                                              |
 | [directory](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_directory) | boolean         | Only use this opener if the selected item is a directory (set to true) or a file (set to false) (if unspecified, matches both files and directories)                                 |
 
-###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_cwd"></a>2.6.1.1.1.2.2.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_cwd"></a>2.8.1.1.1.2.2.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -1976,14 +2008,14 @@ Must be one of:
 | -------------------------------------------------------------------------------------- | ----------- |
 | [cwd items](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_cwd_items) |             |
 
-###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_cwd_items"></a>2.6.1.1.1.2.2.1.1. Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd > cwd items
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_cwd_items"></a>2.8.1.1.1.2.2.1.1. Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > cwd > cwd items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_os"></a>2.6.1.1.1.2.2.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_os"></a>2.8.1.1.1.2.2.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os`
 
 |                |                     |
 | -------------- | ------------------- |
@@ -2005,7 +2037,7 @@ Must be one of:
 | ------------------------------------------------------------------------------------ | ----------- |
 | [os items](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items) |             |
 
-###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items"></a>2.6.1.1.1.2.2.2.1. Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items"></a>2.8.1.1.1.2.2.2.1. Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items
 
 |              |             |
 | ------------ | ----------- |
@@ -2017,7 +2049,7 @@ Must be one of:
 | [item 0](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i0) |
 | [item 1](#settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i1) |
 
-###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i0"></a>2.6.1.1.1.2.2.2.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 0`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i0"></a>2.8.1.1.1.2.2.2.1.1. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 0`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -2030,14 +2062,14 @@ Must be one of:
 - "Linux"
 - "Darwin"
 
-###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i1"></a>2.6.1.1.1.2.2.2.1.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 1`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_os_items_anyOf_i1"></a>2.8.1.1.1.2.2.2.1.2. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > os > os items > anyOf > item 1`
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_directory"></a>2.6.1.1.1.2.2.3. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > directory`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_if_directory"></a>2.8.1.1.1.2.2.3. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > if > directory`
 
 |              |           |
 | ------------ | --------- |
@@ -2046,7 +2078,7 @@ Must be one of:
 
 **Description:** Only use this opener if the selected item is a directory (set to true) or a file (set to false) (if unspecified, matches both files and directories)
 
-###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_orphan"></a>2.6.1.1.1.2.3. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > orphan`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_orphan"></a>2.8.1.1.1.2.3. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > orphan`
 
 |              |           |
 | ------------ | --------- |
@@ -2056,7 +2088,7 @@ Must be one of:
 
 **Description:** Whether to open the opener as an orphan process.
 
-###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_name"></a>2.6.1.1.1.2.4. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > name`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_name"></a>2.8.1.1.1.2.4. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > name`
 
 |              |          |
 | ------------ | -------- |
@@ -2065,7 +2097,7 @@ Must be one of:
 
 **Description:** The name of the opener to show in the menu (currently unused)
 
-###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_shell"></a>2.6.1.1.1.2.5. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > shell`
+###### <a name="settings_openers_groups_additionalProperties_items_oneOf_i1_shell"></a>2.8.1.1.1.2.5. Property `Rovr Config > settings > openers > groups > additionalProperties > additionalProperties items > oneOf > item 1 > shell`
 
 |              |           |
 | ------------ | --------- |
@@ -2075,7 +2107,7 @@ Must be one of:
 
 **Description:** Whether the command to run is a shell command that needs to be run in a shell (required if you want to do piping)
 
-#### <a name="settings_openers_match"></a>2.6.2. Property `Rovr Config > settings > openers > match`
+#### <a name="settings_openers_match"></a>2.8.2. Property `Rovr Config > settings > openers > match`
 
 |                           |                                                                                                     |
 | ------------------------- | --------------------------------------------------------------------------------------------------- |
@@ -2089,7 +2121,7 @@ Must be one of:
 | ------------------------------------------------ | --------------- | ----------------- |
 | [](#settings_openers_match_additionalProperties) | array of string |                   |
 
-##### <a name="settings_openers_match_additionalProperties"></a>2.6.2.1. Property `Rovr Config > settings > openers > match > additionalProperties`
+##### <a name="settings_openers_match_additionalProperties"></a>2.8.2.1. Property `Rovr Config > settings > openers > match > additionalProperties`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -2108,14 +2140,14 @@ Must be one of:
 | -------------------------------------------------------------------------------- | ----------- |
 | [additionalProperties items](#settings_openers_match_additionalProperties_items) |             |
 
-###### <a name="settings_openers_match_additionalProperties_items"></a>2.6.2.1.1. Rovr Config > settings > openers > match > additionalProperties > additionalProperties items
+###### <a name="settings_openers_match_additionalProperties_items"></a>2.8.2.1.1. Rovr Config > settings > openers > match > additionalProperties > additionalProperties items
 
 |              |          |
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="settings_drive_exclude"></a>2.7. Property `Rovr Config > settings > drive_exclude`
+### <a name="settings_drive_exclude"></a>2.9. Property `Rovr Config > settings > drive_exclude`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -2137,7 +2169,7 @@ Must be one of:
 | ---------------------------------------------------- | ----------- |
 | [drive_exclude items](#settings_drive_exclude_items) |             |
 
-#### <a name="settings_drive_exclude_items"></a>2.7.1. Rovr Config > settings > drive_exclude > drive_exclude items
+#### <a name="settings_drive_exclude_items"></a>2.9.1. Rovr Config > settings > drive_exclude > drive_exclude items
 
 |              |          |
 | ------------ | -------- |

--- a/src/rovr/action_buttons/unzip_button.py
+++ b/src/rovr/action_buttons/unzip_button.py
@@ -4,6 +4,7 @@ from textual import work
 from textual.widgets import Button
 
 from rovr.classes.textual_validators import IsValidFilePath
+from rovr.functions import utils
 from rovr.functions.icons import get_icon
 from rovr.functions.path import normalise
 from rovr.screens import ModalInput
@@ -17,6 +18,18 @@ class UnzipButton(Button):
         super().__init__(get_icon("general", "open")[0], classes="option", id="unzip")
         if config["interface"]["tooltips"]:
             self.tooltip = "Extract selected archive"
+
+    @work(thread=True, exclusive=True, group="unzip_check")
+    def update_state(self, file_path: str) -> None:
+        """Determine whether the highlighted file is an archive, off the main thread.
+
+        Args:
+            file_path (str): The path of the highlighted file.
+        """
+        is_archive = utils.is_archive(file_path)
+        if utils.should_cancel():
+            return
+        self.app.call_from_thread(setattr, self, "disabled", not is_archive)
 
     @work
     async def on_button_pressed(self, event: Button.Pressed) -> None:

--- a/src/rovr/classes/config.pyi
+++ b/src/rovr/classes/config.pyi
@@ -303,6 +303,12 @@ r""" Default value of the field path 'Rovr Config settings editor folder run' ""
 _ROVR_CONFIG_SETTINGS_EDITOR_FOLDER_SHELL_DEFAULT = False
 r""" Default value of the field path 'Rovr Config settings editor folder shell' """
 
+_ROVR_CONFIG_SETTINGS_HISTORY_SIZE_DEFAULT = 100
+r""" Default value of the field path 'Rovr Config settings history_size' """
+
+_ROVR_CONFIG_SETTINGS_LAST_HIGHLIGHTED_SIZE_DEFAULT = 200
+r""" Default value of the field path 'Rovr Config settings last_highlighted_size' """
+
 _ROVR_CONFIG_SETTINGS_PREVIEW_RULES_DEFAULT = {
     "text/.*": "text",
     "application/(json|javascript|xml|raml\\+yaml)": "text",
@@ -1517,6 +1523,22 @@ class _RovrConfigSettings(TypedDict, total=False):
     When copying over a file, preserve metadata from the original file, such as creation and modification times.
 
     default: True
+    """
+
+    history_size: int
+    r"""
+    The maximum number of directories to keep in the back/forward navigation history, per tab. Oldest entries are evicted once this is exceeded.
+
+    minimum: 1
+    default: 100
+    """
+
+    last_highlighted_size: int
+    r"""
+    The maximum number of directories to remember the last-highlighted item for, per tab. Least-recently-used entries are evicted once this is exceeded.
+
+    minimum: 1
+    default: 200
     """
 
     editor: "_RovrConfigSettingsEditor"

--- a/src/rovr/classes/session_manager.py
+++ b/src/rovr/classes/session_manager.py
@@ -1,4 +1,7 @@
+from collections import OrderedDict, deque
 from typing import TypedDict
+
+from rovr.variables.constants import config
 
 
 class SessionOptionDict(TypedDict):
@@ -13,15 +16,17 @@ class SessionManager:
     """Manages session-related variables.
 
     Attributes:
-        directories (list[str]): A list of dictionaries that contain a
-            directory's name within. The closer it is to index 0, the
-            older it is.
+        directories (deque[str]): The visited directories, capped at
+            `settings.history_size` entries. The closer it is to index 0, the
+            older it is; once full, appending evicts the oldest entry.
         historyIndex (int): The index of the session in the directories.
             This can be a number between 0 and the length of the list - 1,
             inclusive.
-        lastHighlighted (dict[str, SessionOptionDict]): A dictionary mapping directory
-                                 paths to the index of the last highlighted item. If a
-                                 directory is not in the dictionary, the default is 0.
+        lastHighlighted (OrderedDict[str, SessionOptionDict]): A mapping of directory
+                                 paths to the index of the last highlighted item, capped at
+                                 `settings.last_highlighted_size` entries (least-recently-used
+                                 eviction). If a directory is not in the dictionary, the
+                                 default is 0. Use `remember_highlight` to write to it.
         selectMode (bool): Whether select mode is enabled for that directory.
         selectedItems (list[SessionOptionDict]): A list of selected items within the
                                                                       current directory
@@ -29,9 +34,23 @@ class SessionManager:
     """
 
     def __init__(self) -> None:
-        self.directories: list[str] = []
+        self.directories: deque[str] = deque(maxlen=config["settings"]["history_size"])
         self.historyIndex: int = 0
-        self.lastHighlighted: dict[str, SessionOptionDict] = {}
+        self.lastHighlighted: OrderedDict[str, SessionOptionDict] = OrderedDict()
         self.selectMode: bool = False
         self.selectedItems: list[SessionOptionDict] = []
         self.search: str = ""
+
+    def remember_highlight(self, cwd: str, value: SessionOptionDict) -> None:
+        """Record the last-highlighted item for a directory, evicting the
+        least-recently-used entry once `settings.last_highlighted_size` is exceeded.
+
+        Args:
+            cwd (str): The directory the highlight belongs to.
+            value (SessionOptionDict): The highlighted item's name/index.
+        """
+        self.lastHighlighted[cwd] = value
+        self.lastHighlighted.move_to_end(cwd)
+        max_size = config["settings"]["last_highlighted_size"]
+        while len(self.lastHighlighted) > max_size:
+            self.lastHighlighted.popitem(last=False)

--- a/src/rovr/config/config.toml
+++ b/src/rovr/config/config.toml
@@ -54,6 +54,8 @@ panels = false
 [settings]
 copy_includes_metadata = true
 use_recycle_bin = true
+history_size = 100
+last_highlighted_size = 200
 # comments are just how shell config would look like, it will never be
 # set as default options in the menu, it can be used as reference
 right_click = [

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -440,6 +440,18 @@
           "default": true,
           "description": "When copying over a file, preserve metadata from the original file, such as creation and modification times."
         },
+        "history_size": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 100,
+          "description": "The maximum number of directories to keep in the back/forward navigation history, per tab. Oldest entries are evicted once this is exceeded."
+        },
+        "last_highlighted_size": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 200,
+          "description": "The maximum number of directories to remember the last-highlighted item for, per tab. Least-recently-used entries are evicted once this is exceeded."
+        },
         "editor": {
           "type": "object",
           "description": "Settings related to the editor used for different operations",

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -401,7 +401,8 @@ class FileList(
         name_to_index: dict[str, int] = {}
         if add_to_session:
             if session.historyIndex != len(session.directories) - 1:
-                session.directories = session.directories[: session.historyIndex + 1]
+                while len(session.directories) > session.historyIndex + 1:
+                    session.directories.pop()
             session.directories.append(cwd)
             session.historyIndex = len(session.directories) - 1
         try:
@@ -514,12 +515,15 @@ class FileList(
                     self.list_of_options[0], FileListSelectionWidget
                 ):
                     # Hard coding is my passion (referring to the id)
-                    session.lastHighlighted[cwd] = {
-                        "name": self.list_of_options[0].dir_entry.name,
-                        "index": 0,
-                    }
-            elif session.directories == []:
-                session.directories = [path_utils.normalise(getcwd())]
+                    session.remember_highlight(
+                        cwd,
+                        {
+                            "name": self.list_of_options[0].dir_entry.name,
+                            "index": 0,
+                        },
+                    )
+            elif not session.directories:
+                session.directories.append(path_utils.normalise(getcwd()))
             self.app.query_one("Button#back").disabled = session.historyIndex <= 0
             self.app.query_one("Button#forward").disabled = (
                 session.historyIndex == len(session.directories) - 1
@@ -539,10 +543,13 @@ class FileList(
             except (OptionDoesNotExist, KeyError):
                 self.highlighted = 0
             if isinstance(self.highlighted_option, FileListSelectionWidget):
-                session.lastHighlighted[cwd] = SessionOptionDict({
-                    "name": self.highlighted_option.dir_entry.name,
-                    "index": self.highlighted or 0,  # weird ty behaviour on 0.0.33
-                })
+                session.remember_highlight(
+                    cwd,
+                    SessionOptionDict({
+                        "name": self.highlighted_option.dir_entry.name,
+                        "index": self.highlighted or 0,  # weird ty behaviour on 0.0.33
+                    }),
+                )
 
             self.scroll_to_highlight()
             self.app.tabWidget.active_tab.label = (
@@ -689,26 +696,26 @@ class FileList(
             self.call_after_refresh(self.update_border_subtitle)
         # Get the highlighted option
         highlighted_option = event.option
-        self.app.tabWidget.active_tab.session.lastHighlighted[
-            path_utils.normalise(getcwd())
-        ] = {"name": highlighted_option.dir_entry.name, "index": self.highlighted}
+        self.app.tabWidget.active_tab.session.remember_highlight(
+            path_utils.normalise(getcwd()),
+            {"name": highlighted_option.dir_entry.name, "index": self.highlighted},
+        )
         # Get the filename from the option id
         # total files as footer
         if self.highlighted is None:
             self.highlighted = 0
         # update tracked mtime for the watcher
-        highlighted_path = highlighted_option.dir_entry.path
-        if path.exists(highlighted_path) and not path.isdir(highlighted_path):
-            from contextlib import suppress
-
+        try:
+            is_file = highlighted_option.dir_entry.is_file()
+        except OSError:
+            is_file = False
+        if is_file:
             with suppress(OSError):
-                setattr(
-                    self.app,
-                    "_highlighted_file_mtime",
-                    highlighted_option.dir_entry.stat().st_mtime,
+                self.app._highlighted_file_mtime = (
+                    highlighted_option.dir_entry.stat().st_mtime
                 )
         else:
-            setattr(self.app, "_highlighted_file_mtime", None)
+            self.app._highlighted_file_mtime = None
         # preview
         self.app.query_one("MetadataContainer").update_metadata(
             event.option.dir_entry, event.option
@@ -724,9 +731,23 @@ class FileList(
                 highlighted_option.dir_entry.path, highlighted_option
             )
             return
-        self.app.query_one("#unzip").disabled = not utils.is_archive(
-            highlighted_option.dir_entry.path
-        )
+        self.update_unzip_state(highlighted_option.dir_entry.path)
+
+    @work(thread=True, exclusive=True, group="unzip_check")
+    def update_unzip_state(self, file_path: str) -> None:
+        """Determine whether the highlighted file is an archive, off the main thread.
+
+        Args:
+            file_path (str): The path of the highlighted file.
+        """
+        is_archive = utils.is_archive(file_path)
+        if utils.should_cancel():
+            return
+        try:
+            button = self.app.query_one("#unzip", Button)
+        except NoMatches:
+            return
+        self.app.call_from_thread(setattr, button, "disabled", not is_archive)
 
     @property
     def options(self) -> Sequence[FileListSelectionWidget]:

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -731,23 +731,9 @@ class FileList(
                 highlighted_option.dir_entry.path, highlighted_option
             )
             return
-        self.update_unzip_state(highlighted_option.dir_entry.path)
-
-    @work(thread=True, exclusive=True, group="unzip_check")
-    def update_unzip_state(self, file_path: str) -> None:
-        """Determine whether the highlighted file is an archive, off the main thread.
-
-        Args:
-            file_path (str): The path of the highlighted file.
-        """
-        is_archive = utils.is_archive(file_path)
-        if utils.should_cancel():
-            return
-        try:
-            button = self.app.query_one("#unzip", Button)
-        except NoMatches:
-            return
-        self.app.call_from_thread(setattr, button, "disabled", not is_archive)
+        self.app.query_one("#unzip").update_unzip_state(
+            highlighted_option.dir_entry.path
+        )
 
     @property
     def options(self) -> Sequence[FileListSelectionWidget]:

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -194,6 +194,8 @@ class PreviewContainer(Actionable, Container):
         self, location: str, highlighted_option: FileListSelectionWidget | None = None
     ) -> None:
         # prevent short circuit from occurring later on
+        if should_cancel():
+            return
         self._current_file_path = None
         self._file_mtime = None
         self._file_type = "none"

--- a/src/rovr/functions/drive_workers.py
+++ b/src/rovr/functions/drive_workers.py
@@ -35,7 +35,7 @@ def normalise(*location: str | bytes) -> str:
 def _get_windows_drives() -> list[str]:
     import ctypes
 
-    bitmask = ctypes.windll.kernel32.GetLogicalDrives()  # type: ignore[attr-defined]
+    bitmask = ctypes.windll.kernel32.GetLogicalDrives()
     return [f"{chr(ord('A') + i)}:/" for i in range(26) if bitmask & (1 << i)]
 
 


### PR DESCRIPTION
as title says. evict history after it becomes too big. most users wouldn't face this problem, but it exists as a just-in-case measure if it grows too big. also configurable because it runs in my blood

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible
- [x] the documentation has been updated wherever necessary (run `poe gen-schema` and `poe gen-keys` if applicable)

## Summary by Sourcery

Introduce configurable limits for per-tab navigation history and last-highlighted directories, and update session tracking and UI behavior to respect these caps while improving responsiveness and robustness.

New Features:
- Add `settings.history_size` and `settings.last_highlighted_size` configuration options to cap navigation history length and last-highlighted-per-directory tracking per tab.

Enhancements:
- Change session directory history to use a bounded deque and last-highlighted tracking to use an ordered mapping with least-recently-used eviction.
- Centralize last-highlighted item updates through a `remember_highlight` helper on the session manager.
- Move archive detection for the unzip button to a background worker to avoid blocking the main thread.
- Improve highlighted-file mtime tracking and preview container behavior to better handle cancellations and filesystem edge cases.
- Update config schema, defaults, and developer docs to document the new settings and reflect updated indices in the schema reference.
- Remove an unnecessary type ignore around Windows drive enumeration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable limits for per-tab navigation history and remembered highlighted items (defaults: 100 and 200).
  - Navigation and “last highlighted” tracking are now bounded with least-recently-used eviction.
- **Bug Fixes**
  - Archive/unzip button state updates correctly when a highlighted item changes.
  - Prevented outdated preview/UI work after cancellation requests.
  - Improved robustness when highlight targets are unavailable or filesystem checks fail.
- **Documentation**
  - Updated the configuration reference and JSON schema to include the new settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->