### PR TITLE
feat: add transparent halfcell

### DIFF
--- a/src/rovr/monkey_patches/_classes.py
+++ b/src/rovr/monkey_patches/_classes.py
@@ -1,8 +1,18 @@
-from typing import Iterable
+from typing import IO, Iterable, cast
 
+from PIL import Image as PILImage
 from rich.ansi import AnsiDecoder
+from rich.color import Color
+from rich.color_triplet import ColorTriplet
+from rich.console import Console, ConsoleOptions, RenderResult
+from rich.segment import Segment
+from rich.style import Style
 from rich.text import Text
 from textual_image import _pixeldata
+from textual_image._geometry import ImageSize
+from textual_image._terminal import get_cell_size
+from textual_image._utils import StrOrBytesPath, grouped
+from textual_image.renderable import halfcell
 
 from rovr.variables.constants import RESAMPLING_METHOD
 
@@ -13,6 +23,52 @@ def scaled(self: _pixeldata.PixelData, width: int, height: int) -> _pixeldata.Pi
 
 
 _pixeldata.PixelData.scaled = scaled  # ty: ignore[invalid-assignment]
+
+
+def _map_pixel(pixel: tuple[int, int, int, int]) -> Color:
+    return Color.from_triplet(ColorTriplet(*pixel[:3]))
+
+
+def halfcell_init(
+    self: halfcell.Image,
+    image: StrOrBytesPath | IO[bytes] | PILImage.Image,
+    width: int | str | None = None,
+    height: int | str | None = None,
+) -> None:
+    image_data = _pixeldata.PixelData(image)
+    self._image_data = _pixeldata.PixelData(image_data.pil_image.convert("RGBA"))
+    self._render_size = ImageSize(
+        self._image_data.width, self._image_data.height, width, height
+    )
+
+
+def halfcell_rich_console(
+    self: halfcell.Image, console: Console, options: ConsoleOptions
+) -> RenderResult:
+    terminal_sizes = get_cell_size()
+    width, height = self._render_size.get_cell_size(
+        options.max_width, options.max_height, terminal_sizes
+    )
+
+    for upper_row, lower_row in grouped(self._image_data.scaled(width, height * 2), 2):
+        for upper_pixel, lower_pixel in zip(upper_row, lower_row, strict=True):
+            upper = cast(tuple[int, int, int, int], upper_pixel)
+            lower = cast(tuple[int, int, int, int], lower_pixel)
+            if upper[3] == lower[3] == 0:
+                yield Segment(" ")
+            elif upper[3] == 0:
+                yield Segment("▄", style=Style(color=_map_pixel(lower)))
+            elif lower[3] == 0:
+                yield Segment("▀", style=Style(color=_map_pixel(upper)))
+            else:
+                yield Segment(
+                    "▀", style=Style(color=_map_pixel(upper), bgcolor=_map_pixel(lower))
+                )
+        yield Segment("\n")
+
+
+halfcell.Image.__init__ = halfcell_init  # ty: ignore[invalid-assignment]
+halfcell.Image.__rich_console__ = halfcell_rich_console  # ty: ignore[invalid-assignment]
 
 
 # https://github.com/Textualize/rich/issues/4090

--- a/tests/test_transparent_halfcell_image.py
+++ b/tests/test_transparent_halfcell_image.py
@@ -34,3 +34,11 @@ def test_render_single_transparent_halfcell_without_background() -> None:
     assert segments[0].text == "▄"
     assert segments[0].style is not None
     assert segments[0].style.bgcolor is None
+
+
+def test_render_single_transparent_halfcell_with_background() -> None:
+    segments = _render_pixels([(255, 0, 0, 255), (0, 0, 0, 0)])
+
+    assert segments[0].text == "▀"
+    assert segments[0].style is not None
+    assert segments[0].style.bgcolor is None

--- a/tests/test_transparent_halfcell_image.py
+++ b/tests/test_transparent_halfcell_image.py
@@ -1,0 +1,36 @@
+from typing import cast
+
+from PIL import Image
+from rich.console import Console
+from rich.segment import Segment
+from textual_image.renderable.halfcell import Image as HalfcellImage
+
+import rovr.monkey_patches._classes  # noqa: F401
+
+
+def _render_pixels(pixels: list[tuple[int, int, int, int]]) -> list[Segment]:
+    image = Image.new("RGBA", (1, 2))
+    image.putdata(pixels)
+    console = Console()
+    renderable = HalfcellImage(image, width=1, height=1)
+    return [
+        cast(Segment, segment)
+        for segment in renderable.__rich_console__(
+            console, console.options.update(width=1, height=1)
+        )
+    ]
+
+
+def test_render_fully_transparent_pixels_as_spaces() -> None:
+    segments = _render_pixels([(0, 0, 0, 0), (0, 0, 0, 0)])
+
+    assert segments[0].text == " "
+    assert segments[0].style is None
+
+
+def test_render_single_transparent_halfcell_without_background() -> None:
+    segments = _render_pixels([(0, 0, 0, 0), (255, 0, 0, 255)])
+
+    assert segments[0].text == "▄"
+    assert segments[0].style is not None
+    assert segments[0].style.bgcolor is None


### PR DESCRIPTION
monkey patching with reference to my other pr https://github.com/lnqs/textual-image/pull/101

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Add monkey patches to support transparent halfcell image rendering and cover the behavior with tests.

New Features:
- Enable halfcell image rendering that correctly handles transparent pixels by mapping them to spaces or partial block characters.

Tests:
- Add tests verifying transparent and semi-transparent halfcell pixels render as spaces or blocks without unintended background colors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved half-cell image rendering for RGBA inputs, including correct scaling to terminal cell size.
  * Enhanced colour and styling handling for richer output.
  * Fully transparent halves now render as clean blank spaces, while partially opaque halves use the appropriate half-block glyphs.
* **Tests**
  * Added automated coverage for transparent and partially transparent half-cell image rendering, verifying glyph selection and styling/background behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->