### PR TITLE
refactor: use asyncio's shell as far as possible

### DIFF
--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -10,7 +10,6 @@ from dataclasses import replace
 from importlib import resources
 from io import TextIOWrapper
 from os import chdir, getcwd, path
-from subprocess import Popen, TimeoutExpired
 from time import perf_counter
 from typing import Callable, ClassVar, Iterable
 
@@ -78,6 +77,7 @@ from rovr.core import (
 )
 from rovr.footer import Clipboard, MetadataContainer, ProcessContainer
 from rovr.functions import drive_workers
+from rovr.functions.command import run_command_async
 from rovr.functions.path import (
     dump_exc,
     ensure_existing_directory,
@@ -96,7 +96,6 @@ from rovr.functions.themes import (
 from rovr.functions.utils import (
     multiprocessing_process_error_checker,
     run_command,
-    should_cancel,
 )
 from rovr.header import HeaderArea
 from rovr.header.tabs import TablineTab
@@ -241,7 +240,6 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
         self._file_list_container = FileListContainer()
         # shutdown event for bg thread
         self._shutdown_event = threading.Event()
-        self._background_processes: set[Popen] = set()
         # cannot use self.clipboard, reserved for Textual's clipboard
         self.Clipboard = Clipboard()
         if startup_path:
@@ -534,18 +532,6 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
 
     def on_unmount(self) -> None:
         self._shutdown_event.set()
-        for proc in tuple(self._background_processes):
-            self._stop_background_process(proc)
-
-    @staticmethod
-    def _stop_background_process(proc: Popen) -> None:
-        if proc.poll() is not None:
-            return
-        proc.terminate()
-        try:
-            proc.wait(timeout=0.5)
-        except TimeoutExpired:
-            proc.kill()
 
     def action_focus_next(self) -> None:
         if config["interface"]["allow_tab_nav"]:
@@ -611,28 +597,18 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
         if response is None or response.command == "":
             return
 
-        proc = run_command(self, response.command, run_type=response.run_type)
         if response.run_type == "background":
-            self.shell_thread(proc, "Shell Exec")
+            self.shell_command(response.command, "Shell Exec")
+        else:
+            run_command(self, response.command, run_type=response.run_type)
 
-    @work(thread=True)
-    def shell_thread(self, proc: Popen, title: str = "") -> None:
-        self._background_processes.add(proc)
-        try:
-            while True:
-                try:
-                    stdout_bytes, stderr_bytes = proc.communicate(timeout=0.2)
-                    break
-                except TimeoutExpired:
-                    if should_cancel() or self._shutdown_event.is_set():
-                        self._stop_background_process(proc)
-                        return
-        finally:
-            self._background_processes.discard(proc)
-        if should_cancel() or self._shutdown_event.is_set():
-            return
-        stdout = stdout_bytes.decode().strip()
-        stderr = stderr_bytes.decode().strip()
+    @work
+    async def shell_command(
+        self, command: str | list[str], title: str = "", shell: bool = True
+    ) -> None:
+        result = await run_command_async(command, shell=shell)
+        stdout = result.stdout.decode().strip()
+        stderr = result.stderr.decode().strip()
         if stdout and stderr:
             msg = f"stdout = {stdout}\nstderr = {stderr}\n"
         elif stdout and not stderr:
@@ -640,12 +616,11 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
         elif not stdout and stderr:
             msg = str(stderr)
         else:
-            msg = f"Process completed with code {proc.returncode}"
-        self.call_from_thread(
-            self.notify,
+            msg = f"Process completed with code {result.returncode}"
+        self.notify(
             msg.strip(),
             title=title,
-            severity="information" if proc.returncode == 0 else "error",
+            severity="information" if result.returncode == 0 else "error",
         )
 
     def on_app_blur(self, event: events.AppBlur) -> None:

--- a/src/rovr/core/file_list_right_click_menu.py
+++ b/src/rovr/core/file_list_right_click_menu.py
@@ -1,5 +1,4 @@
 from functools import partial
-from subprocess import Popen
 from typing import ClassVar, Literal
 
 from textual import events, work
@@ -247,14 +246,19 @@ class FileListRightClickMenu(PopupOptionList, inherit_bindings=False):
             command: str | list[str] = await expand_command(
                 self.app, event.option.action["run"]
             )
-            proc = run_command(
-                self.app,
-                command,
-                event.option.action["run_type"],
-                shell=event.option.action["shell"],
-            )
-            if isinstance(proc, Popen) and event.option.action["run_type"] != "orphan":
-                self.app.shell_thread(proc, "Context Menu")
+            if event.option.action["run_type"] == "background":
+                self.app.shell_command(
+                    command,
+                    "Context Menu",
+                    shell=event.option.action["shell"],
+                )
+            else:
+                run_command(
+                    self.app,
+                    command,
+                    event.option.action["run_type"],
+                    shell=event.option.action["shell"],
+                )
 
     def on_blur(self, event: events.Blur) -> None:  # ty: ignore[invalid-method-override]
         event.prevent_default().stop()

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import subprocess
 from dataclasses import dataclass
 from functools import partial
 from io import BytesIO
 from os import path
-from time import monotonic, time
+from time import time
 from typing import cast
 
 import textual_image.renderable
@@ -34,6 +33,7 @@ from rovr.core import FileList
 from rovr.functions import icons as icon_utils
 from rovr.functions import path as path_utils
 from rovr.functions import preview_utils
+from rovr.functions.command import run_command_async
 from rovr.functions.pdf import get_pdf_images, get_pdf_info
 from rovr.functions.utils import multiprocessing_process_error_checker, should_cancel
 from rovr.variables.constants import PreviewContainerTitles, config, file_one
@@ -508,9 +508,9 @@ class PreviewContainer(Actionable, Container):
             "border_subtitle",
             f"Page {self.pdf.current_page + 1}/{self.pdf.total_pages}",
         )
-        self.run_worker(self.show_pdf_preview, thread=True, exclusive=True)
+        self.show_pdf_preview()
 
-    def load_pdf_pages(self, first_page: int, last_page: int) -> list[PILImage]:
+    async def load_pdf_pages(self, first_page: int, last_page: int) -> list[PILImage]:
         """
         Returns:
             List of images, one per pages fetched
@@ -523,7 +523,7 @@ class PreviewContainer(Actionable, Container):
                 f"Invalid args, first_page={first_page} > last_page={last_page}"
             )
 
-        result = get_pdf_images(
+        result = await get_pdf_images(
             str(self._current_file_path),
             first_page=first_page,
             last_page=last_page,
@@ -541,17 +541,20 @@ class PreviewContainer(Actionable, Container):
                 return preview_utils.resample_batch(result)
             except ValueError as exc:
                 if multiprocessing_process_error_checker(self.app, exc):
-                    return preview_utils.resample_batch_sync(result)
+                    return await asyncio.to_thread(
+                        preview_utils.resample_batch_sync, result
+                    )
                 raise
-        return preview_utils.resample_batch_sync(result)
+        return await asyncio.to_thread(preview_utils.resample_batch_sync, result)
 
-    def show_pdf_preview(self) -> None:
+    @work(exclusive=True, group="pdf_preview")
+    async def show_pdf_preview(self) -> None:
         """
-        Show PDF preview. Runs in a thread.
+        Show a PDF preview.
         The job of this function is to load the pdf file for the first time.
         Or ensure the batched loading
         """
-        self.app.call_from_thread(setattr, self, "border_title", titles.pdf)
+        self.border_title = titles.pdf
 
         if should_cancel() or self._current_file_path is None:
             return
@@ -559,21 +562,19 @@ class PreviewContainer(Actionable, Container):
         # Convert PDF to images if not already done
         if self.pdf.images is None:
             try:
-                self.pdf.total_pages = int(
-                    get_pdf_info(
-                        str(self._current_file_path),
-                        poppler_path=PDFHandler.get_poppler_folder(),
-                    )["Pages"]
+                pdf_info = await get_pdf_info(
+                    str(self._current_file_path),
+                    poppler_path=PDFHandler.get_poppler_folder(),
                 )
-                result = self.load_pdf_pages(
+                self.pdf.total_pages = int(pdf_info["Pages"])
+                result = await self.load_pdf_pages(
                     first_page=1, last_page=self.pdf.get_last_page_to_load()
                 )
             except Exception as exc:
                 if should_cancel():
                     return
-                self.app.call_from_thread(self.remove_children)
-                self.app.call_from_thread(
-                    self.mount,
+                await self.remove_children()
+                await self.mount(
                     Static(f"{type(exc).__name__}: {str(exc)}", classes="special"),
                 )
                 return
@@ -582,23 +583,20 @@ class PreviewContainer(Actionable, Container):
             # The only one case when current page and border subtitles
             # should be manually adjusted. Not the best design though.
             self.pdf.current_page = 0
-            self.app.call_from_thread(
-                setattr,
-                self,
-                "border_subtitle",
-                f"Page {self.pdf.current_page + 1}/{self.pdf.total_pages}",
+            self.border_subtitle = (
+                f"Page {self.pdf.current_page + 1}/{self.pdf.total_pages}"
             )
 
         elif self.pdf.should_load_next_batch():
-            # Saving the value per thread instead of recalculating after the load
-            # Even if something changes in between, we want the threads that set the status to
+            # Save the value instead of recalculating after the load.
+            # Even if something changes in between, workers that set the status to
             # loading, to always unset it
             toggle_loading = self.pdf.must_load_next_batch()
 
             if toggle_loading:
                 self.post_message(self.SetLoading(True))
             try:
-                result = self.load_pdf_pages(
+                result = await self.load_pdf_pages(
                     first_page=self.pdf.count_loaded() + 1,
                     last_page=self.pdf.get_last_page_to_load(),
                 )
@@ -607,27 +605,25 @@ class PreviewContainer(Actionable, Container):
                     return
                 if toggle_loading:
                     self.call_later(lambda: self.post_message(self.SetLoading(False)))
-                self.app.call_from_thread(self.remove_children)
-                self.app.call_from_thread(
-                    self.mount,
+                await self.remove_children()
+                await self.mount(
                     Static(f"{type(exc).__name__}: {str(exc)}", classes="special"),
                 )
                 return
             if toggle_loading:
                 self.call_later(lambda: self.post_message(self.SetLoading(False)))
             # Note - This should_cancel must be kept here, not before the `load_pdf_pages` call
-            # That, somehow doesn't prevents multiple threads executing the load
-            # even though, we successful prevent multiple threads
+            # That prevents multiple workers executing the load
             # appending the results via this one
             # Also we must ensure to cancel only after you reset the SetLoading(false)
             # We don't want threads to Set the screen in Loading state, and never turn it back
             if should_cancel():
                 return
 
-            # This mutation on the `images` object should be done by one one thread
+            # This mutation on the `images` object should be done by one worker
             # and the entire flow of checking `should_load_next_batch` to loading
             # to appending the pages should be atomic.
-            # At this point, we are using `should_cancel` to allow only one thread
+            # At this point, we are using `should_cancel` to allow only one worker
             # to reach here
             self.pdf.images += result
 
@@ -639,32 +635,26 @@ class PreviewContainer(Actionable, Container):
         if image_widget := self.get_child(".image_preview"):
             if should_cancel():
                 return
-            self.app.call_from_thread(setattr, image_widget, "image", current_image)
+            setattr(image_widget, "image", current_image)
         else:
-            self.app.call_from_thread(self.remove_children)
-            self.app.call_from_thread(self.remove_class, "bat", "full", "clip")
+            await self.remove_children()
+            self.remove_class("bat", "full", "clip")
 
             if should_cancel():
                 return
 
             image_widget = NewImage(current_image)
             image_widget.can_focus = True
-            self.app.call_from_thread(self.mount, image_widget)
+            await self.mount(image_widget)
 
         if should_cancel():
             return
 
     # ------------ PDF related functions end ------------
 
-    def show_bat_file_preview(self) -> bool:
-        """Show bat file preview. Runs in a thread.
-
-        Returns:
-            bool: True if successful, False otherwise.
-
-        Raises:
-            subprocess.TimeoutExpired: If bat does not finish within five seconds.
-        """
+    @work(exclusive=True, group="bat_preview")
+    async def show_bat_file_preview(self) -> None:
+        """Show a bat-powered file preview."""
         bat_executable = config["plugins"]["bat"]["executable"]
         command = [
             bat_executable,
@@ -674,89 +664,71 @@ class PreviewContainer(Actionable, Container):
             if config["interface"]["show_line_numbers"]
             else "--style=plain",
         ]
-        max_lines = self.app.call_from_thread(lambda: self.region.height)
+        max_lines = self.region.height
         if max_lines > 0:
             command.append(f"--line-range=:{max_lines}")
         assert self._current_file_path is not None
         command.extend(["--", self._current_file_path])
 
         if should_cancel():
-            return False
+            return
 
         from rich.text import Text
 
-        self.app.call_from_thread(setattr, self, "border_title", titles.bat)
+        self.border_title = titles.bat
 
         try:
-            process = subprocess.Popen(
-                command,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            deadline = monotonic() + 5
-            while True:
-                try:
-                    stdout, stderr = process.communicate(timeout=1)
-                    break
-                except subprocess.TimeoutExpired:
-                    if should_cancel() or monotonic() >= deadline:
-                        process.kill()
-                        stdout, stderr = process.communicate()
-                        if should_cancel():
-                            return False
-                        raise subprocess.TimeoutExpired(command, 5, stdout, stderr)
+            completed = await run_command_async(command, timeout=5)
+            stdout, stderr = completed.stdout, completed.stderr
 
             if should_cancel():
-                return False
+                return
 
-            if process.returncode == 0:
+            if completed.returncode == 0:
                 bat_output = stdout.decode("utf-8", errors="ignore")
                 new_content = Text.from_ansi(bat_output)
 
                 if should_cancel():
-                    return False
+                    return
 
                 if static_widget := self.get_child("Static"):
                     self.log("Using existing Static")
-                    self.app.call_from_thread(static_widget.update, new_content)
-                    self.app.call_from_thread(static_widget.set_classes, "bat_preview")
+                    static_widget.update(new_content)
+                    static_widget.set_classes("bat_preview")
                 else:
                     self.log("Mounting new Static")
-                    self.app.call_from_thread(self.remove_children)
+                    await self.remove_children()
 
                     if should_cancel():
-                        return False
+                        return
 
                     static_widget = Static(new_content, classes="bat_preview")
-                    self.app.call_from_thread(self.mount, static_widget)
+                    await self.mount(static_widget)
                     if should_cancel():
-                        return False
+                        return
                     static_widget.can_focus = True
-                return True
+                return
             else:
                 error_message = stderr.decode("utf-8", errors="ignore")
                 if should_cancel():
-                    return False
-                self.app.call_from_thread(self.remove_children)
-                self.app.call_from_thread(
-                    self.notify,
+                    return
+                await self.remove_children()
+                self.notify(
                     error_message,
                     title="Plugins: Bat",
                     severity="warning",
                 )
-                return False
-        except Exception as exc:
+        except (OSError, TimeoutError) as exc:
             if should_cancel():
-                return False
-            self.app.call_from_thread(
-                self.notify,
+                return
+            self.notify(
                 str(exc),
                 title="Plugins: Bat",
                 severity="error",
                 markup=False,
             )
             path_utils.dump_exc(self, exc)
-            return False
+        self.run_worker(self.show_normal_file_preview, thread=True, exclusive=True)
 
     def show_normal_file_preview(self) -> None:
         """Show normal file preview with syntax highlighting. Runs in a thread."""
@@ -1195,7 +1167,7 @@ class PreviewContainer(Actionable, Container):
         elif file_type == "pdf":
             self.log("Showing pdf preview")
             self.app.call_from_thread(self.add_class, "pdf")
-            self.show_pdf_preview()
+            self.app.call_from_thread(self.show_pdf_preview)
         elif file_type == "resvg":
             self.log("Showing resvg preview")
             self.show_resvg_preview()
@@ -1209,9 +1181,9 @@ class PreviewContainer(Actionable, Container):
             else:
                 if config["plugins"]["bat"]["enabled"]:
                     self.log("Showing bat preview")
-                    if self.show_bat_file_preview():
-                        return
-                self.show_normal_file_preview()
+                    self.app.call_from_thread(self.show_bat_file_preview)
+                else:
+                    self.show_normal_file_preview()
 
     def mount_special_messages(self) -> None:
         """Mount special messages. Runs in a thread."""
@@ -1228,21 +1200,11 @@ class PreviewContainer(Actionable, Container):
                 config["plugins"]["file_one"]["enabled"]
                 and config["plugins"]["file_one"]["get_description"]
             ):
-                try:
-                    executable = file_one()
-                    if executable:
-                        process = subprocess.run(
-                            [executable, "--brief", "--", self._current_file_path],
-                            capture_output=True,
-                            text=True,
-                            check=True,
-                            timeout=1,
-                        )
-                        display_content += f"\n{process.stdout.strip()}"
-                except subprocess.TimeoutExpired:
-                    pass
-                except (subprocess.SubprocessError, FileNotFoundError) as exc:
-                    path_utils.dump_exc(self, exc)
+                self.app.call_from_thread(
+                    self.show_file_description,
+                    self._current_file_path,
+                    display_content,
+                )
 
         if static_widget := self.get_child("Static"):
             self.app.call_from_thread(static_widget.update, display_content)
@@ -1255,6 +1217,27 @@ class PreviewContainer(Actionable, Container):
             self.app.call_from_thread(self.mount, static_widget)
         # not wasting an isinstance on this
         cast(Static, static_widget).can_focus = True
+
+    @work(exclusive=True, group="file_description")
+    async def show_file_description(self, file_path: str, display_content: str) -> None:
+        executable = file_one()
+        if not executable:
+            return
+        try:
+            completed = await run_command_async(
+                [executable, "--brief", "--", file_path],
+                timeout=1,
+            )
+        except (OSError, TimeoutError) as exc:
+            path_utils.dump_exc(self, exc)
+            return
+        if (
+            completed.returncode == 0
+            and self._current_file_path == file_path
+            and (static_widget := self.get_child("Static"))
+        ):
+            description = completed.stdout.decode(errors="ignore").strip()
+            static_widget.update(f"{display_content}\n{description}")
 
     def on_mouse_scroll_up(self, event: events.MouseScrollUp) -> None:
         """Handle mouse scroll up for PDF navigation."""
@@ -1274,18 +1257,23 @@ class PreviewContainer(Actionable, Container):
             return self._render_widget.region
         return super().region
 
-    @work(thread=True)
+    @work(exclusive=True, group="preview_resize")
     @on(events.Resize)
-    def _trigger_resize_update(self) -> None:
-        """Trigger resize update from a thread."""
+    async def _trigger_resize_update(self) -> None:
+        """Update command-backed previews after a resize."""
         try:
             if self.border_title in (
                 PreviewContainerTitles.file,
                 PreviewContainerTitles.bat,
             ):
-                if config["plugins"]["bat"]["enabled"] and self.show_bat_file_preview():
-                    return
-                self.show_normal_file_preview()
+                if config["plugins"]["bat"]["enabled"]:
+                    self.show_bat_file_preview()
+                else:
+                    self.run_worker(
+                        self.show_normal_file_preview,
+                        thread=True,
+                        exclusive=True,
+                    )
         except Exception:
             pass
 

--- a/src/rovr/functions/command.py
+++ b/src/rovr/functions/command.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
+from os import PathLike
+from shlex import join as shell_join
+from shlex import split as shell_split
+from typing import Any
+
+
+async def _stop_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        return
+    with suppress(ProcessLookupError):
+        process.terminate()
+    try:
+        await asyncio.wait_for(process.wait(), timeout=0.5)
+    except TimeoutError:
+        with suppress(ProcessLookupError):
+            process.kill()
+        await process.wait()
+
+
+async def run_command_async(
+    command: str | Sequence[str | PathLike[str]],
+    *,
+    shell: bool = False,
+    timeout: float | None = None,
+    stdin: int | None = subprocess.DEVNULL,
+    env: Mapping[str, str] | None = None,
+    startupinfo: subprocess.STARTUPINFO | None = None,
+    **kwargs: Any,
+) -> subprocess.CompletedProcess[bytes]:
+    if shell:
+        if not isinstance(command, str):
+            command = shell_join([str(part) for part in command])
+        process = await asyncio.create_subprocess_shell(
+            command,
+            stdin=stdin,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+            startupinfo=startupinfo,
+            **kwargs,
+        )
+    else:
+        if isinstance(command, str):
+            command = shell_split(command)
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            stdin=stdin,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+            startupinfo=startupinfo,
+            **kwargs,
+        )
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            process.communicate(),
+            timeout=timeout,
+        )
+    except BaseException:
+        await _stop_process(process)
+        raise
+    return subprocess.CompletedProcess(command, process.returncode or 0, stdout, stderr)

--- a/src/rovr/functions/pdf.py
+++ b/src/rovr/functions/pdf.py
@@ -1,18 +1,41 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import platform
 import shutil
 import subprocess
 import tempfile
 from io import BytesIO
-from subprocess import PIPE, Popen, TimeoutExpired
 
 from PIL import Image
 from PIL.Image import Image as PILImage
 
+from rovr.functions.command import run_command_async
+
 # Keys whose values should be parsed as integers from pdfinfo output
 pdfinfo_turn_to_int = {"Pages"}
+
+
+async def _run_commands(
+    commands: list[list[str]],
+    env: dict[str, str],
+    startupinfo: subprocess.STARTUPINFO | None,
+) -> list[subprocess.CompletedProcess[bytes]]:
+    tasks: list[asyncio.Task[subprocess.CompletedProcess[bytes]]] = []
+    async with asyncio.TaskGroup() as group:
+        tasks.extend(
+            group.create_task(
+                run_command_async(
+                    command,
+                    env=env,
+                    startupinfo=startupinfo,
+                    timeout=15,
+                )
+            )
+            for command in commands
+        )
+    return [task.result() for task in tasks]
 
 
 def _get_command_path(command: str, poppler_path: str | None = None) -> str:
@@ -117,7 +140,7 @@ def _load_images_from_folder(
     return images
 
 
-def get_pdf_info(
+async def get_pdf_info(
     pdf_path: str,
     poppler_path: str | None = None,
 ) -> dict[str, str | int]:
@@ -131,27 +154,20 @@ def get_pdf_info(
 
     Raises:
         ValueError: Page count cannot be determined from output.
-        TimeoutExpired: If the pdfinfo command takes too long to execute.
     """
     command = [_get_command_path("pdfinfo", poppler_path), pdf_path]
 
-    proc = Popen(
+    completed = await run_command_async(
         command,
         env=_get_env(poppler_path),
-        stdout=PIPE,
-        stderr=PIPE,
         startupinfo=_get_startupinfo(),
+        timeout=5,
     )
-    try:
-        out, err = proc.communicate(timeout=5)
-    except TimeoutExpired:
-        proc.kill()
-        proc.communicate()
-        raise
+    out, err = completed.stdout, completed.stderr
 
-    if proc.returncode != 0:
+    if completed.returncode != 0:
         raise ValueError(
-            f"pdfinfo failed with error code {proc.returncode}.\n{err.decode('utf8', 'ignore')}"
+            f"pdfinfo failed with error code {completed.returncode}.\n{err.decode('utf8', 'ignore')}"
         )
 
     result: dict[str, str | int] = {}
@@ -170,7 +186,7 @@ def get_pdf_info(
     return result
 
 
-def get_pdf_images(
+async def get_pdf_images(
     pdf_path: str,
     first_page: int = 1,
     last_page: int | None = None,
@@ -206,7 +222,7 @@ def get_pdf_images(
     startupinfo = _get_startupinfo()
 
     if use_pdftocairo:
-        return _render_with_pdftocairo(
+        return await _render_with_pdftocairo(
             pdf_path=pdf_path,
             first_page=first_page,
             last_page=last_page,
@@ -217,7 +233,7 @@ def get_pdf_images(
             startupinfo=startupinfo,
         )
     else:
-        return _render_with_pdftoppm(
+        return await _render_with_pdftoppm(
             pdf_path=pdf_path,
             first_page=first_page,
             last_page=last_page,
@@ -229,7 +245,7 @@ def get_pdf_images(
         )
 
 
-def _render_with_pdftoppm(
+async def _render_with_pdftoppm(
     pdf_path: str,
     first_page: int,
     last_page: int | None,
@@ -254,8 +270,6 @@ def _render_with_pdftoppm(
     Returns:
         List of PIL images
 
-    Raises:
-        TimeoutExpired: If any pdftoppm command takes too long to execute
     """
     command_base = _get_command_path("pdftoppm", poppler_path)
 
@@ -267,21 +281,15 @@ def _render_with_pdftoppm(
             args.extend(["-l", str(last_page)])
         args.append(pdf_path)
 
-        try:
-            proc = Popen(
-                args, env=env, stdout=PIPE, stderr=PIPE, startupinfo=startupinfo
-            )
-            data, _ = proc.communicate(timeout=15)
-        except TimeoutExpired:
-            proc.kill()
-            proc.communicate()
-            raise
-        return _parse_ppm_buffer(data)
+        completed = await run_command_async(
+            args, env=env, startupinfo=startupinfo, timeout=15
+        )
+        return await asyncio.to_thread(_parse_ppm_buffer, completed.stdout)
 
     # Multi-process: split page ranges across subprocesses
     remainder = page_count % thread_count
     current_page = first_page
-    processes: list[Popen] = []
+    commands: list[list[str]] = []
 
     for _ in range(thread_count):
         chunk = page_count // thread_count + int(remainder > 0)
@@ -292,36 +300,22 @@ def _render_with_pdftoppm(
         args.extend(["-l", str(chunk_last)])
         args.append(pdf_path)
 
-        processes.append(
-            Popen(args, env=env, stdout=PIPE, stderr=PIPE, startupinfo=startupinfo)
-        )
+        commands.append(args)
 
         current_page += chunk
         remainder -= int(remainder > 0)
 
-    images: list[PILImage] = []
-    saved_exception: TimeoutExpired | None = None
-    for proc in processes:
-        if saved_exception is not None:
-            proc.kill()
-            proc.communicate()
-            continue
-        try:
-            data, _ = proc.communicate(timeout=15)
-        except TimeoutExpired as exc:
-            proc.kill()
-            proc.communicate()
-            if not saved_exception:
-                saved_exception = exc
-                continue
-        images += _parse_ppm_buffer(data)
-    if saved_exception is not None:
-        raise saved_exception
-
-    return images
+    completed_commands = await _run_commands(commands, env, startupinfo)
+    chunks = await asyncio.gather(
+        *(
+            asyncio.to_thread(_parse_ppm_buffer, completed.stdout)
+            for completed in completed_commands
+        )
+    )
+    return [image for chunk in chunks for image in chunk]
 
 
-def _render_with_pdftocairo(
+async def _render_with_pdftocairo(
     pdf_path: str,
     first_page: int,
     last_page: int | None,
@@ -346,8 +340,6 @@ def _render_with_pdftocairo(
     Returns:
         List of PIL images
 
-    Raises:
-        TimeoutExpired: If any pdftocairo command takes too long to execute
     """
     command_base = _get_command_path("pdftocairo", poppler_path)
     output_folder = tempfile.mkdtemp()
@@ -361,21 +353,15 @@ def _render_with_pdftocairo(
                 args.extend(["-l", str(last_page)])
             args.extend([pdf_path, os.path.join(output_folder, prefix)])
 
-            proc = Popen(
-                args, env=env, stdout=PIPE, stderr=PIPE, startupinfo=startupinfo
+            await run_command_async(args, env=env, startupinfo=startupinfo, timeout=15)
+            return await asyncio.to_thread(
+                _load_images_from_folder, output_folder, prefix, "png"
             )
-            try:
-                proc.communicate(timeout=15)
-            except TimeoutExpired:
-                proc.kill()
-                proc.communicate()
-                raise
-            return _load_images_from_folder(output_folder, prefix, "png")
 
         # multi proc stuff
         remainder = page_count % thread_count
         current_page = first_page
-        processes: list[tuple[str, Popen]] = []
+        commands: list[tuple[str, list[str]]] = []
 
         for i in range(thread_count):
             chunk = page_count // thread_count + int(remainder > 0)
@@ -387,33 +373,20 @@ def _render_with_pdftocairo(
             args.extend(["-l", str(chunk_last)])
             args.extend([pdf_path, os.path.join(output_folder, prefix)])
 
-            processes.append((
-                prefix,
-                Popen(args, env=env, stdout=PIPE, stderr=PIPE, startupinfo=startupinfo),
-            ))
+            commands.append((prefix, args))
 
             current_page += chunk
             remainder -= int(remainder > 0)
 
-        images: list[PILImage] = []
-        saved_exception: TimeoutExpired | None = None
-        for prefix, proc in processes:
-            if saved_exception is not None:
-                proc.kill()
-                proc.communicate()
-                continue
-            try:
-                proc.communicate(timeout=15)
-            except TimeoutExpired as exc:
-                proc.kill()
-                proc.communicate()
-                if not saved_exception:
-                    saved_exception = exc
-                    continue
-            images += _load_images_from_folder(output_folder, prefix, "png")
-        if saved_exception is not None:
-            raise saved_exception
-
-        return images
+        await _run_commands([args for _, args in commands], env, startupinfo)
+        chunks = await asyncio.gather(
+            *(
+                asyncio.to_thread(
+                    _load_images_from_folder, output_folder, prefix, "png"
+                )
+                for prefix, _ in commands
+            )
+        )
+        return [image for chunk in chunks for image in chunk]
     finally:
         shutil.rmtree(output_folder, ignore_errors=True)

--- a/src/rovr/screens/zd_to_directory.py
+++ b/src/rovr/screens/zd_to_directory.py
@@ -1,4 +1,3 @@
-import asyncio
 import contextlib
 import subprocess
 from typing import cast
@@ -11,6 +10,7 @@ from textual.worker import WorkerCancelled
 
 from rovr.classes.textual_options import OptionWithValue
 from rovr.components import DoubleClickableOptionList, ModalSearchScreen
+from rovr.functions.command import run_command_async
 from rovr.functions.utils import dismiss, should_cancel
 from rovr.variables.constants import config
 
@@ -64,19 +64,6 @@ class ZDToDirectory(ModalSearchScreen):
             self.log(f"Problems while parsing zoxide line - '{line}'")
             return line, None
 
-    async def _run_subprocess(
-        self, command: list[str], timeout: float
-    ) -> subprocess.CompletedProcess[bytes]:
-        result = await asyncio.to_thread(
-            subprocess.run,
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            timeout=timeout,
-            check=False,
-        )
-        return cast(subprocess.CompletedProcess[bytes], result)
-
     @work(exclusive=True)
     async def zoxide_updater(self, event: Input.Changed) -> None:
         """Update the list"""
@@ -93,9 +80,9 @@ class ZDToDirectory(ModalSearchScreen):
 
         zoxide_cmd += search_term.split()
         try:
-            result = await self._run_subprocess(zoxide_cmd, 3)
+            result = await run_command_async(zoxide_cmd, timeout=3)
             stdout = result.stdout
-        except (OSError, subprocess.TimeoutExpired) as exc:
+        except (OSError, TimeoutError) as exc:
             # zoxide not installed
             self.search_options.clear_options()
             self.search_options.add_option(


### PR DESCRIPTION
---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Refactor external command and preview handling to use asyncio-based subprocess utilities and structured Textual workers.

Bug Fixes:
- Ensure fallbacks to normal file preview when bat or external tools fail while preserving user notifications.
- Prevent concurrent preview workers from racing by using exclusive worker groups for PDF, bat, file descriptions, and resize-triggered updates.

Enhancements:
- Replace direct subprocess usage with a shared async run_command_async helper for PDFs, bat previews, shell commands, and zoxide integration.
- Convert PDF, bat, file description, and resize-related preview flows to async Textual workers instead of thread-based workers.
- Run PDF rendering commands concurrently using asyncio TaskGroup to improve parallelism and simplify timeout/error handling.
- Simplify shell/background process lifecycle management by removing manual process tracking and leveraging async subprocess execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved responsiveness when running shell commands, including background commands from context menus.
  - PDF previews now load and render more smoothly, including multi-page documents.
  - File previews update more reliably when resizing the preview area.
  - BAT file previews and file descriptions now load more consistently.
  - Improved handling of command timeouts and failures, with clearer status notifications.
  - Directory navigation using zoxide is more reliable when commands take too long or fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->