### PR TITLE
fix: prevent `Process`-es from importing from cwd

### DIFF
--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -77,7 +77,7 @@ from rovr.core import (
     PreviewContainer,
 )
 from rovr.footer import Clipboard, MetadataContainer, ProcessContainer
-from rovr.functions import drive_workers
+from rovr.functions import drive_workers, multiprocessing_utils
 from rovr.functions.path import (
     dump_exc,
     ensure_existing_directory,
@@ -915,7 +915,7 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
                             target=drive_workers.get_mounted_drives_worker,
                             args=(result_queue, os_type, config),
                         )
-                        process.start()
+                        multiprocessing_utils.start_process(process)
                         process.join(timeout=2.0)
 
                         if process.is_alive():

--- a/src/rovr/core/pinned_sidebar.py
+++ b/src/rovr/core/pinned_sidebar.py
@@ -12,6 +12,7 @@ from rovr.classes.mixins import Action, Actionable
 from rovr.classes.textual_options import PinnedSidebarOption
 from rovr.functions import drive_workers as drive_utils
 from rovr.functions import icons as icon_utils
+from rovr.functions import multiprocessing_utils
 from rovr.functions import path as path_utils
 from rovr.functions import pins as pin_utils
 from rovr.functions.utils import multiprocessing_process_error_checker
@@ -165,7 +166,7 @@ class PinnedSidebar(Actionable, OptionList, inherit_bindings=False):
                     target=drive_utils.get_mounted_drives_worker,
                     args=(result_queue, os_type, config),
                 )
-                process.start()
+                multiprocessing_utils.start_process(process)
                 process.join(timeout=2.0)
 
                 if process.is_alive():

--- a/src/rovr/functions/multiprocessing_utils.py
+++ b/src/rovr/functions/multiprocessing_utils.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import os
 import threading
+from collections.abc import Iterator
 from concurrent.futures import ProcessPoolExecutor
+from contextlib import contextmanager
 from multiprocessing.process import BaseProcess
 
 _safe_path_lock = threading.Lock()
@@ -67,3 +69,15 @@ class SafePathProcessPoolExecutor(ProcessPoolExecutor):
             super().shutdown(wait=wait, cancel_futures=cancel_futures)
         finally:
             self._disable_safe_path()
+
+
+@contextmanager
+def safe_path_process_pool(max_workers: int) -> Iterator[SafePathProcessPoolExecutor]:
+    executor = SafePathProcessPoolExecutor(max_workers=max_workers)
+    try:
+        yield executor
+    except BaseException:
+        executor.shutdown(wait=False, cancel_futures=True)
+        raise
+    else:
+        executor.shutdown(wait=True)

--- a/src/rovr/functions/multiprocessing_utils.py
+++ b/src/rovr/functions/multiprocessing_utils.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import os
+import threading
+from concurrent.futures import ProcessPoolExecutor
+from multiprocessing.process import BaseProcess
+
+_safe_path_lock = threading.Lock()
+_safe_path_users = 0
+_previous_safe_path: str | None = None
+
+
+def _enable_safe_path() -> None:
+    global _previous_safe_path, _safe_path_users
+
+    with _safe_path_lock:
+        if _safe_path_users == 0:
+            _previous_safe_path = os.environ.get("PYTHONSAFEPATH")
+            os.environ["PYTHONSAFEPATH"] = "1"
+        _safe_path_users += 1
+
+
+def _disable_safe_path() -> None:
+    global _previous_safe_path, _safe_path_users
+
+    with _safe_path_lock:
+        _safe_path_users -= 1
+        if _safe_path_users != 0:
+            return
+        if _previous_safe_path is None:
+            os.environ.pop("PYTHONSAFEPATH", None)
+        else:
+            os.environ["PYTHONSAFEPATH"] = _previous_safe_path
+        _previous_safe_path = None
+
+
+def start_process(process: BaseProcess) -> None:
+    _enable_safe_path()
+    try:
+        process.start()
+    finally:
+        _disable_safe_path()
+
+
+class SafePathProcessPoolExecutor(ProcessPoolExecutor):
+    def __init__(self, max_workers: int) -> None:
+        _enable_safe_path()
+        self._safe_path_enabled = True
+        try:
+            super().__init__(max_workers=max_workers)
+        except Exception:
+            self._disable_safe_path()
+            raise
+
+    def _disable_safe_path(self) -> None:
+        if self._safe_path_enabled:
+            self._safe_path_enabled = False
+            _disable_safe_path()
+
+    def shutdown(
+        self,
+        wait: bool = True,
+        *,
+        cancel_futures: bool = False,
+    ) -> None:
+        try:
+            super().shutdown(wait=wait, cancel_futures=cancel_futures)
+        finally:
+            self._disable_safe_path()

--- a/src/rovr/functions/preview_utils.py
+++ b/src/rovr/functions/preview_utils.py
@@ -2,7 +2,7 @@ import multiprocessing
 import multiprocessing.connection
 import stat
 import subprocess
-from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
+from concurrent.futures import FIRST_COMPLETED, Future, wait
 from functools import lru_cache
 from os import path
 from os import stat as os_stat
@@ -11,6 +11,10 @@ from typing import Literal, NamedTuple, TypeAlias
 from PIL import Image
 from PIL.Image import Image as PILImage
 
+from rovr.functions.multiprocessing_utils import (
+    SafePathProcessPoolExecutor,
+    start_process,
+)
 from rovr.functions.preview_workers import (
     _depalette,
     resample_bytes_worker,
@@ -83,7 +87,7 @@ def _get_resample_pool_size(batch_size: int) -> int:
 
 
 def _await_resample_futures(
-    executor: ProcessPoolExecutor,
+    executor: SafePathProcessPoolExecutor,
     futures: dict[Future[tuple[bytes, str, tuple[int, int]]], int],
 ) -> list[tuple[bytes, str, tuple[int, int]]]:
     pending: set[Future[tuple[bytes, str, tuple[int, int]]]] = set(futures)
@@ -133,7 +137,9 @@ def resample_batch(images: list[PILImage]) -> list[PILImage]:
             MAX_IMAGE_SIZE,
             RESAMPLING_METHOD(),
         ))
-    executor = ProcessPoolExecutor(max_workers=_get_resample_pool_size(len(payloads)))
+    executor = SafePathProcessPoolExecutor(
+        max_workers=_get_resample_pool_size(len(payloads))
+    )
     try:
         futures = {
             executor.submit(resample_worker, payload): index
@@ -165,7 +171,7 @@ def resample(image: Image.Image) -> Image.Image:
             RESAMPLING_METHOD(),
         ),
     )
-    proc.start()
+    start_process(proc)
     child_conn.close()
 
     result = _await_resample_process(proc, parent_conn)
@@ -189,7 +195,7 @@ def resample_file(file_path: str) -> Image.Image | None:
         target=resample_file_worker,
         args=(child_conn, file_path, MAX_IMAGE_SIZE, RESAMPLING_METHOD()),
     )
-    proc.start()
+    start_process(proc)
     child_conn.close()
 
     result = _await_resample_process(proc, parent_conn)
@@ -204,7 +210,7 @@ def load_svg(file_path: str) -> bytes | None:
     proc = multiprocessing.Process(
         target=svg_image_worker, args=(child_conn, file_path)
     )
-    proc.start()
+    start_process(proc)
     child_conn.close()
 
     # wait for it to complete

--- a/src/rovr/functions/preview_utils.py
+++ b/src/rovr/functions/preview_utils.py
@@ -12,7 +12,7 @@ from PIL import Image
 from PIL.Image import Image as PILImage
 
 from rovr.functions.multiprocessing_utils import (
-    SafePathProcessPoolExecutor,
+    safe_path_process_pool,
     start_process,
 )
 from rovr.functions.preview_workers import (
@@ -87,7 +87,6 @@ def _get_resample_pool_size(batch_size: int) -> int:
 
 
 def _await_resample_futures(
-    executor: SafePathProcessPoolExecutor,
     futures: dict[Future[tuple[bytes, str, tuple[int, int]]], int],
 ) -> list[tuple[bytes, str, tuple[int, int]]]:
     pending: set[Future[tuple[bytes, str, tuple[int, int]]]] = set(futures)
@@ -109,10 +108,8 @@ def _await_resample_futures(
     except Exception:
         for future in pending:
             future.cancel()
-        executor.shutdown(wait=False, cancel_futures=True)
         raise
 
-    executor.shutdown(wait=True)
     results: list[tuple[bytes, str, tuple[int, int]]] = []
     for result in ordered_results:
         if result is None:
@@ -137,18 +134,14 @@ def resample_batch(images: list[PILImage]) -> list[PILImage]:
             MAX_IMAGE_SIZE,
             RESAMPLING_METHOD(),
         ))
-    executor = SafePathProcessPoolExecutor(
+    with safe_path_process_pool(
         max_workers=_get_resample_pool_size(len(payloads))
-    )
-    try:
+    ) as executor:
         futures = {
             executor.submit(resample_worker, payload): index
             for index, payload in enumerate(payloads)
         }
-    except Exception:
-        executor.shutdown(wait=False, cancel_futures=True)
-        raise
-    results = _await_resample_futures(executor, futures)
+        results = _await_resample_futures(futures)
     return [Image.frombytes(mode, size, data) for data, mode, size in results]
 
 

--- a/tests/test_multiprocessing_utils.py
+++ b/tests/test_multiprocessing_utils.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rovr.functions.multiprocessing_utils import safe_path_process_pool
+
+
+def test_safe_path_process_pool_waits_on_success() -> None:
+    executor = MagicMock()
+    with (
+        patch(
+            "rovr.functions.multiprocessing_utils.SafePathProcessPoolExecutor",
+            return_value=executor,
+        ) as executor_type,
+        safe_path_process_pool(max_workers=2) as active_executor,
+    ):
+        assert active_executor is executor
+
+    executor_type.assert_called_once_with(max_workers=2)
+    executor.shutdown.assert_called_once_with(wait=True)
+
+
+def test_safe_path_process_pool_cancels_on_error() -> None:
+    executor = MagicMock()
+    with (
+        patch(
+            "rovr.functions.multiprocessing_utils.SafePathProcessPoolExecutor",
+            return_value=executor,
+        ),
+        pytest.raises(RuntimeError, match="cancelled"),
+        safe_path_process_pool(max_workers=1),
+    ):
+        raise RuntimeError("cancelled")
+
+    executor.shutdown.assert_called_once_with(wait=False, cancel_futures=True)


### PR DESCRIPTION
resolves a long-standing issue where python's multiprocessing import `signal`, so if you were in a directory with a folder/file named `signal(.py)`, it imports that, then fails because import shadowing

## Summary by Sourcery

Ensure all multiprocessing-based workers run with PYTHONSAFEPATH enabled to prevent imports from the current working directory being shadowed.

Enhancements:
- Introduce a multiprocessing_utils helper module that manages PYTHONSAFEPATH for processes and process pools.
- Wrap process startup calls with a start_process helper to safely toggle PYTHONSAFEPATH around process creation.
- Replace direct use of ProcessPoolExecutor in image resampling with SafePathProcessPoolExecutor to enforce safe import paths across the pool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of background drive refresh and preview/resampling processing.
  * Added safer lifecycle handling for the process pool to ensure clean shutdown on both success and errors.
  * Updated subprocess start behaviour to use a shared, consistent startup helper while preserving existing timeouts and fallback handling.
* **Refactor**
  * Switched preview/resampling code to use a context-managed process-pool pattern.
* **Tests**
  * Added unit tests covering normal and exceptional shutdown behaviour for the process-pool context manager.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->