### PR TITLE
feat: allow themeing checked options

### DIFF
--- a/docs/src/content/docs/dev/configuration/theming.mdx
+++ b/docs/src/content/docs/dev/configuration/theming.mdx
@@ -101,6 +101,16 @@ you may notice that class inheritance is not shown, `FileListContainer` inherits
 
 rovr includes some extra classes that can be used to narrow down the elements, or style them based on certain scenarios.
 
+<h4 class="no-lower">Checkbox selection lists</h4>
+
+Lists using rovr's checkbox renderer, including `FileList` and `Clipboard`, expose a component class for styling the entire checked option.
+
+| Component Classes              | Description                                 | Example                                                   |
+| ------------------------------ | ------------------------------------------- | --------------------------------------------------------- |
+| selection-list--option-checked | applied on options that are checked         | `Clipboard > .selection-list--option-checked`             |
+| \*--hovered                    | used when the checked option is hovered     | `FileList > .selection-list--option-checked--hovered`     |
+| \*--highlighted                | used when the checked option is highlighted | `FileList > .selection-list--option-checked--highlighted` |
+
 <h4 class="no-lower">FileList</h4>
 
 This is the main file list that you will be navigating
@@ -117,6 +127,7 @@ This is the main file list that you will be navigating
 | filelist--hidden      | applied on files/folders that are hidden       | `FileList > .filelist--hidden`      |
 
 These component classes also come with their own sub classes due to textual limitations.
+When multiple classes apply, checked styling is used as the base and file-specific styling takes precedence for properties it defines.
 
 | Component Classes | Description                                   | Example                                   |
 | ----------------- | --------------------------------------------- | ----------------------------------------- |

--- a/docs/src/content/docs/dev/configuration/theming.mdx
+++ b/docs/src/content/docs/dev/configuration/theming.mdx
@@ -103,7 +103,7 @@ rovr includes some extra classes that can be used to narrow down the elements, o
 
 <h4 class="no-lower">Checkbox selection lists</h4>
 
-Lists using rovr's checkbox renderer, including `FileList` and `Clipboard`, expose a component class for styling the entire checked option.
+Lists using rovr's checkbox renderer, including `FileList`, `Clipboard` and the `TrashSelectionList`, expose a component class for styling the entire checked option.
 
 | Component Classes              | Description                                 | Example                                                   |
 | ------------------------------ | ------------------------------------------- | --------------------------------------------------------- |

--- a/src/rovr/classes/mixins.py
+++ b/src/rovr/classes/mixins.py
@@ -1,5 +1,5 @@
 from inspect import isawaitable
-from typing import Any, Awaitable, Callable, Iterable, NamedTuple, Self
+from typing import Any, Awaitable, Callable, ClassVar, Iterable, NamedTuple, Self
 
 from rich.cells import cell_len
 from rich.segment import Segment
@@ -9,7 +9,7 @@ from textual.content import ContentText
 from textual.events import Key
 from textual.geometry import Region, Size
 from textual.strip import Strip
-from textual.widgets import OptionList
+from textual.widgets import OptionList, SelectionList
 from textual.widgets.option_list import Option, OptionDoesNotExist
 from textual.widgets.selection_list import Selection, SelectionType
 
@@ -151,12 +151,22 @@ class SingleLineOptionLayoutMixin:
 
 
 class CheckboxRenderingMixin:
+    CHECKED_COMPONENT_CLASS: ClassVar[str] = "selection-list--option-checked"
+    COMPONENT_CLASSES: ClassVar[set[str]] = SelectionList.COMPONENT_CLASSES | {
+        CHECKED_COMPONENT_CLASS,
+        f"{CHECKED_COMPONENT_CLASS}--highlighted",
+        f"{CHECKED_COMPONENT_CLASS}--hovered",
+    }
+
     def _get_option_component_classes(self, option: Option) -> list[str]:
+        classes: list[str] = []
+        if isinstance(option, Selection) and option.value in self._selected:
+            classes.append(self.CHECKED_COMPONENT_CLASS)
         if hasattr(option, "get_component_classes") and callable(
             option.get_component_classes
         ):
-            return list(option.get_component_classes())  # ty: ignore
-        return []
+            classes.extend(option.get_component_classes())  # ty: ignore
+        return classes
 
     def _get_left_gutter_width(self) -> int:
         """

--- a/src/rovr/classes/mixins.py
+++ b/src/rovr/classes/mixins.py
@@ -160,7 +160,11 @@ class CheckboxRenderingMixin:
 
     def _get_option_component_classes(self, option: Option) -> list[str]:
         classes: list[str] = []
-        if isinstance(option, Selection) and option.value in self._selected:
+        if (
+            isinstance(option, Selection)
+            and option.value in self._selected
+            and not option.disabled
+        ):
             classes.append(self.CHECKED_COMPONENT_CLASS)
         if hasattr(option, "get_component_classes") and callable(
             option.get_component_classes

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -54,7 +54,7 @@ class FileList(
     OptionList but can multi-select files and folders.
     """
 
-    COMPONENT_CLASSES: ClassVar[set[str]] = {
+    COMPONENT_CLASSES: ClassVar[set[str]] = CheckboxRenderingMixin.COMPONENT_CLASSES | {
         "filelist--cut",
         "filelist--cut--highlighted",
         "filelist--cut--hovered",

--- a/src/rovr/screens/trash.py
+++ b/src/rovr/screens/trash.py
@@ -94,7 +94,7 @@ class TrashSelectionList(
 ):
     BINDINGS: ClassVar[list[BindingType]] = list(bindings)
 
-    COMPONENT_CLASSES: ClassVar[set[str]] = {
+    COMPONENT_CLASSES: ClassVar[set[str]] = CheckboxRenderingMixin.COMPONENT_CLASSES | {
         "trash--detail-size",
         "trash--detail-mtime",
     }

--- a/src/rovr/style.tcss
+++ b/src/rovr/style.tcss
@@ -530,6 +530,18 @@ CommandList:ansi {
 }
 
 FileList {
+  .selection-list--option-checked,
+  .selection-list--option-checked--hovered {
+    color: $primary;
+  }
+  &:focus .selection-list--option-checked--highlighted,
+  &.-popup-shown .selection-list--option-checked--highlighted {
+    color: $block-cursor-foreground;
+  }
+  &:blur .selection-list--option-checked--highlighted {
+    color: $primary;
+  }
+
   .filelist--hidden,
   .filelist--hidden--hovered,
   .filelist--hidden--highlighted {

--- a/tests/test_filelist_component_classes.py
+++ b/tests/test_filelist_component_classes.py
@@ -9,6 +9,7 @@ from textual.worker import Worker
 
 from rovr.app import Application
 from rovr.classes.textual_options import FileListSelectionWidget
+from rovr.footer.clipboard_container import Clipboard
 from rovr.variables.constants import config, os_type
 
 
@@ -83,3 +84,43 @@ async def test_working_symlink_adds_component_class(tmp_path: Path) -> None:
         )
         classes = option.get_component_classes()
         assert "filelist--link" in classes
+
+
+@pytest.mark.asyncio
+async def test_checked_component_style_preserves_file_style(tmp_path: Path) -> None:
+    file_path = tmp_path / "checked.txt"
+    file_path.touch()
+
+    app = Application(tmp_path.as_posix())
+    async with app.run_test(size=(143, 37)) as pilot:
+        await pilot.pause()
+        worker = cast(Worker, app.file_list.update_file_list(add_to_session=False))
+        await worker.wait()
+        await app.file_list.toggle_mode()
+
+        option = next(
+            option for option in app.file_list.options if option.label == file_path.name
+        )
+        app.file_list.select(option)
+
+        classes = app.file_list._get_option_component_classes(option)
+        assert classes[0] == "selection-list--option-checked"
+        assert (
+            "background"
+            not in app.file_list.get_component_styles(
+                "selection-list--option-checked"
+            ).get_rules()
+        )
+        assert "selection-list--option-checked" in Clipboard.COMPONENT_CLASSES
+
+        combined_style = app.file_list.get_visual_style(
+            "option-list--option", *classes, "filelist--cut--highlighted"
+        )
+        checked_style = app.file_list.get_visual_style(
+            "option-list--option", "selection-list--option-checked"
+        )
+        file_style = app.file_list.get_visual_style(
+            "option-list--option", "filelist--cut--highlighted"
+        )
+        assert combined_style.foreground == checked_style.foreground
+        assert combined_style.background == file_style.background


### PR DESCRIPTION
Lets you theme the selected options; this was gone due to #284, it's back again yay

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Restore and standardize theming support for checked options in checkbox selection lists, ensuring consistent component classes, styling behavior, and documentation across FileList, Clipboard, and TrashSelectionList.

New Features:
- Expose a dedicated component class for styling checked options in checkbox-based selection lists such as FileList and Clipboard.

Enhancements:
- Unify and extend checkbox rendering component classes via CheckboxRenderingMixin and apply them to FileList and TrashSelectionList.

Documentation:
- Document theming support for checked options in checkbox selection lists and clarify precedence when combining checked and file-specific styles.

Tests:
- Add tests to ensure checked option styles preserve file-specific styles and integrate with clipboard component classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added visual states for checked, hovered, highlighted and focused file options.
  - Checked options now support distinct styling across focused, popup-highlighted and blurred states.

- **Bug Fixes**
  - Preserved file-specific colours and styling when options are checked, hovered or highlighted.
  - Ensured checked styling integrates consistently across file lists, clipboard selections and trash selections.

- **Documentation**
  - Documented selection-list classes and how checked, hovered and highlighted styles interact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->