### PR TITLE
feat: allow multiple paths in cli

### DIFF
--- a/src/rovr/__main__.py
+++ b/src/rovr/__main__.py
@@ -58,7 +58,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = RichArgumentParser(
         prog="rovr",
         description="a stylish, batteries-included terminal file manager.",
-        usage="rovr [OPTIONS] [PATH]",
+        usage="rovr [OPTIONS] [PATH ...]",
         formatter_class=formatter_class,
         add_help=False,
     )
@@ -205,7 +205,7 @@ def _build_parser() -> argparse.ArgumentParser:
         else argparse.SUPPRESS,
     )
 
-    parser.add_argument("path", nargs="?", default="", type=str, metavar="PATH")
+    parser.add_argument("paths", nargs="*", default=[], type=str, metavar="PATH")
 
     return parser
 
@@ -388,7 +388,7 @@ example_function(10)"""
 
     if args.ignore_missing_tty or sys.stdout.isatty():
         app = Application(
-            startup_path=args.path,
+            startup_path=args.paths,
             cwd_file=cwd_file if cwd_file else None,
             chooser_file=chooser_file if chooser_file else None,
             show_keys=args.show_keys,
@@ -421,7 +421,7 @@ example_function(10)"""
 
                     constants.COLOR_SYSTEM = "truecolor"
                 app = Application(
-                    startup_path=args.path,
+                    startup_path=args.paths,
                     cwd_file=cwd_file if cwd_file else None,
                     chooser_file=chooser_file if chooser_file else None,
                     show_keys=args.show_keys,

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -214,7 +214,7 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
 
     def __init__(
         self,
-        startup_path: str = "",
+        startup_path: str | Iterable[str] = "",
         *,
         cwd_file: str | TextIOWrapper | None = None,
         chooser_file: str | TextIOWrapper | None = None,
@@ -247,8 +247,20 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
         self._background_processes: set[Popen] = set()
         # cannot use self.clipboard, reserved for Textual's clipboard
         self.Clipboard = Clipboard()
-        if startup_path:
-            chdir(ensure_existing_directory(startup_path))
+        startup_paths = (
+            [startup_path] if isinstance(startup_path, str) else startup_path
+        )
+        self._startup_locations: list[tuple[str, str | None]] = []
+        for startup_item in startup_paths:
+            resolved_path = path.abspath(path.expanduser(startup_item))
+            directory = normalise(ensure_existing_directory(resolved_path))
+            focus_on = (
+                path.basename(resolved_path) if path.isfile(resolved_path) else None
+            )
+            self._startup_locations.append((directory, focus_on))
+        if not self._startup_locations:
+            self._startup_locations.append((normalise(getcwd()), None))
+        chdir(self._startup_locations[0][0])
 
         self._p_timer: Timer | None = None
         self._dnd_invoked_tab: str | None = None
@@ -284,7 +296,7 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
             else " comfy-panels"
         )
         with Vertical(id="root", classes=root_classes.strip()):
-            header = HeaderArea()
+            header = HeaderArea(self._startup_locations)
             self.tabWidget = header.tabline
             yield header
             with VerticalGroup(id="menu_wrapper"):

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -214,7 +214,7 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
 
     def __init__(
         self,
-        startup_path: str | Iterable[str] = "",
+        startup_path: str | Iterable[str] | None = None,
         *,
         cwd_file: str | TextIOWrapper | None = None,
         chooser_file: str | TextIOWrapper | None = None,
@@ -247,9 +247,12 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
         self._background_processes: set[Popen] = set()
         # cannot use self.clipboard, reserved for Textual's clipboard
         self.Clipboard = Clipboard()
-        startup_paths = (
-            [startup_path] if isinstance(startup_path, str) else startup_path
-        )
+        if startup_path is None:
+            startup_paths = []
+        elif isinstance(startup_path, str):
+            startup_paths = [startup_path]
+        else:
+            startup_paths = list(startup_path)
         self._startup_locations: list[tuple[str, str | None]] = []
         for startup_item in startup_paths:
             resolved_path = path.abspath(path.expanduser(startup_item))

--- a/src/rovr/header/header.py
+++ b/src/rovr/header/header.py
@@ -1,5 +1,3 @@
-from os import getcwd
-
 from textual import events
 from textual.app import ComposeResult
 from textual.containers import HorizontalGroup
@@ -13,9 +11,14 @@ from .tabs import NewTabButton, Tabline, TablineTab
 
 
 class HeaderArea(HorizontalGroup):
-    def __init__(self) -> None:
+    def __init__(self, startup_locations: list[tuple[str, str | None]]) -> None:
         super().__init__(id="headerArea")
-        self.tabline = Tabline(TablineTab(directory=getcwd()))
+        self.tabline = Tabline(
+            *(
+                TablineTab(directory=directory, focus_on=focus_on)
+                for directory, focus_on in startup_locations
+            )
+        )
 
     def compose(self) -> ComposeResult:
         if (

--- a/src/rovr/header/tabs.py
+++ b/src/rovr/header/tabs.py
@@ -38,12 +38,18 @@ class BetterUnderline(Underline):
 class TablineTab(Tab):
     ALLOW_SELECT = False
 
-    def __init__(self, directory: str | bytes = "", label: str = "") -> None:
+    def __init__(
+        self,
+        directory: str | bytes = "",
+        label: str = "",
+        focus_on: str | None = None,
+    ) -> None:
         """Initialise a Tab.
 
         Args:
             directory (str): The directory to set the tab as.
             label (ContentText): The label to use in the tab.
+            focus_on: The item to highlight when the tab is first loaded.
         """
         if directory == "":
             directory = getcwd()
@@ -56,6 +62,7 @@ class TablineTab(Tab):
             )
         super().__init__(label=label, id=f"id_{id(self)}")
         self.directory = directory
+        self.focus_on = focus_on
         self.session = SessionManager()
 
 
@@ -152,10 +159,12 @@ class Tabline(Tabs):
         worker = self.app.cd(
             event.tab.directory,
             add_to_history=False,
+            focus_on=event.tab.focus_on,
             has_selected=event.tab.session.selectMode,
             callback=callback,
             clear_search=False,
         )
+        event.tab.focus_on = None
         if worker is not None:
             with suppress(WorkerCancelled):
                 await worker.wait()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,7 @@
+from rovr.__main__ import _build_parser
+
+
+def test_parser_accepts_multiple_paths() -> None:
+    args = _build_parser().parse_args([".", ".."])
+
+    assert args.paths == [".", ".."]

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -6,6 +6,7 @@ from textual import events
 
 from rovr.app import Application
 from rovr.components import SearchInput
+from rovr.header.tabs import TablineTab
 from rovr.navigation_widgets import BackButton
 
 from .conftest import iter_until, workers_finished
@@ -33,6 +34,42 @@ async def test_nav(tmp_path: Path) -> None:
         await iter_until(
             pilot, lambda: app.file_list.get_option_at_index(0).dir_entry.is_dir()
         )
+
+
+@pytest.mark.asyncio
+async def test_multiple_startup_paths_open_tabs(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+
+    app = Application(startup_path=[first.as_posix(), second.as_posix()])
+    async with app.run_test(size=(143, 37)) as pilot:
+        await iter_until(pilot, lambda: app.tabWidget.active_tab is not None)
+
+        assert len(app.tabWidget.query(TablineTab)) == 2
+        assert isinstance(app.tabWidget.active_tab, TablineTab)
+        assert app.tabWidget.active_tab.directory == first.as_posix()
+        assert Path.cwd() == first
+
+
+@pytest.mark.asyncio
+async def test_startup_file_is_highlighted(tmp_path: Path) -> None:
+    target = tmp_path / "target.txt"
+    target.touch()
+    (tmp_path / "another.txt").touch()
+
+    app = Application(startup_path=target.as_posix())
+    async with app.run_test(size=(143, 37)) as pilot:
+        await iter_until(
+            pilot,
+            lambda: (
+                app.file_list.highlighted_option is not None
+                and app.file_list.highlighted_option.dir_entry.name == target.name
+            ),
+        )
+
+        assert Path.cwd() == tmp_path
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
long standing issue ig

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Support multiple startup paths in the CLI and propagate them through the application to open multiple tabs and optionally highlight a specific file on startup.

New Features:
- Allow passing multiple PATH arguments to the rovr CLI and initialize the application with all of them.
- Open a tab per startup location and optionally highlight a specific file when its tab is first loaded.

Enhancements:
- Refactor application startup to normalise and track one or more startup locations, including the current working directory fallback.
- Update the header/tabline construction to accept a list of startup locations and create corresponding tabs with optional initial focus items.

Tests:
- Add navigation tests covering multiple startup paths opening separate tabs and highlighting a startup file.
- Add a CLI parser test to ensure multiple paths are accepted and wired into the application startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launch the application with multiple file or directory paths.
  * Open each startup location in a separate tab.
  * Automatically focus on a specified startup file in the file list.
  * Use the first startup directory as the initial working location.

* **Tests**
  * Added coverage for multiple startup paths, tab activation, directory selection, and file focusing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->