### PR TITLE
fix(app): follow a better variable resolution order

### DIFF
--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -510,30 +510,40 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
 
     def get_css_variables(self) -> dict[str, str]:
         # RovrStylesheet strips `$name:` declarations from the CSS files, so
-        # every file's declarations are resolved here instead: bundled first,
-        # then the user's style.tcss so it wins on name clashes.
-        declared: dict[str, str] = {}
-        style_paths: list[str] = [str(self.CSS_PATH[0])]
+        # every source's declarations are resolved here instead: bundled style,
+        # active theme, then the user's style.tcss in ascending priority.
+        bundled_declarations: dict[str, str] = {}
+        custom_declarations: dict[str, str] = {}
+        with (
+            suppress(OSError),
+            open(self.CSS_PATH[0], "rt", encoding="utf-8") as css_file,
+        ):
+            bundled_declarations = extract_variable_declarations(css_file.read())
         if self.CUSTOM_STYLE_AVAILABLE:
-            style_paths.append(path.join(RovrVars.ROVRCONFIG, "style.tcss"))
-        for style_path in style_paths:
             with (
                 suppress(OSError),
-                open(style_path, "rt", encoding="utf-8") as css_file,
+                open(
+                    path.join(RovrVars.ROVRCONFIG, "style.tcss"),
+                    "rt",
+                    encoding="utf-8",
+                ) as css_file,
             ):
-                declared.update(extract_variable_declarations(css_file.read()))
+                custom_declarations = extract_variable_declarations(css_file.read())
         # declarations that map onto Theme fields go through the color system,
         # so an overridden $primary regenerates $primary-lighten-3 and friends
         theme = self.current_theme
-        field_overrides = pop_theme_field_overrides(declared)
+        style_declarations = {**bundled_declarations, **custom_declarations}
+        field_overrides = pop_theme_field_overrides(style_declarations)
         if field_overrides:
             theme = replace(theme, **field_overrides)  # ty: ignore[invalid-argument-type]
         variables = theme.to_color_system().generate()
-        variables.update(resolve_variable_references(theme.variables, variables))
         variables = {**self.get_theme_variable_defaults(), **variables}
-        # everything else resolves only after all files are merged, so
+        declared = {**bundled_declarations, **theme.variables, **custom_declarations}
+        for field_name in field_overrides:
+            declared.pop(field_name.replace("_", "-"), None)
+        # Everything else resolves only after all sources are merged, so
         # `$border-focused: $primary-lighten-3;` in the bundled file picks up
-        # a user or theme override of either name
+        # a theme or user override of either name.
         variables.update(resolve_variable_references(declared, variables))
         self.theme_variables = variables
         return variables

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -532,8 +532,8 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
         # declarations that map onto Theme fields go through the color system,
         # so an overridden $primary regenerates $primary-lighten-3 and friends
         theme = self.current_theme
-        style_declarations = {**bundled_declarations, **custom_declarations}
-        field_overrides = pop_theme_field_overrides(style_declarations)
+        pop_theme_field_overrides(bundled_declarations)
+        field_overrides = pop_theme_field_overrides(custom_declarations)
         if field_overrides:
             theme = replace(theme, **field_overrides)  # ty: ignore[invalid-argument-type]
         variables = theme.to_color_system().generate()

--- a/tests/test_functions_themes.py
+++ b/tests/test_functions_themes.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from textual.app import App
@@ -127,6 +129,40 @@ def test_resolve_variable_references_cycle_leaves_refs_in_place() -> None:
     # a cycle can never settle; it must not raise or infinite-loop
     assert resolved["a"].startswith("$")
     assert resolved["b"].startswith("$")
+
+
+def test_get_css_variables_uses_theme_before_custom_style_precedence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from rovr.app import Application
+    from rovr.variables.maps import RovrVars
+
+    bundled_style = tmp_path / "bundled.tcss"
+    bundled_style.write_text(
+        "$border-blurred: $primary-background-lighten-3;\n$override-order: $primary;\n"
+    )
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "style.tcss").write_text("$override-order: $accent;\n")
+    monkeypatch.setattr(RovrVars, "ROVRCONFIG", config_dir.as_posix())
+
+    theme_file = tmp_path / "test.tcss"
+    theme_file.write_text(
+        NORD_PLACEHOLDER
+        + "$border-blurred: $primary;\n"
+        + "$override-order: $secondary;\n"
+    )
+    app = SimpleNamespace(
+        CSS_PATH=[bundled_style],
+        CUSTOM_STYLE_AVAILABLE=True,
+        current_theme=theme_utils.parse_theme_file(theme_file),
+        get_theme_variable_defaults=lambda: {},
+    )
+
+    variables = Application.get_css_variables(cast(Application, app))
+
+    assert variables["border-blurred"] == variables["primary"]
+    assert variables["override-order"] == variables["accent"]
 
 
 def test_pop_theme_field_overrides_extracts_known_fields() -> None:

--- a/tests/test_functions_themes.py
+++ b/tests/test_functions_themes.py
@@ -139,7 +139,9 @@ def test_get_css_variables_uses_theme_before_custom_style_precedence(
 
     bundled_style = tmp_path / "bundled.tcss"
     bundled_style.write_text(
-        "$border-blurred: $primary-background-lighten-3;\n$override-order: $primary;\n"
+        "$primary: #ff0000;\n"
+        "$border-blurred: $primary-background-lighten-3;\n"
+        "$override-order: $primary;\n"
     )
     config_dir = tmp_path / "config"
     config_dir.mkdir()
@@ -152,15 +154,17 @@ def test_get_css_variables_uses_theme_before_custom_style_precedence(
         + "$border-blurred: $primary;\n"
         + "$override-order: $secondary;\n"
     )
+    active_theme = theme_utils.parse_theme_file(theme_file)
     app = SimpleNamespace(
         CSS_PATH=[bundled_style],
         CUSTOM_STYLE_AVAILABLE=True,
-        current_theme=theme_utils.parse_theme_file(theme_file),
+        current_theme=active_theme,
         get_theme_variable_defaults=lambda: {},
     )
 
     variables = Application.get_css_variables(cast(Application, app))
 
+    assert variables["primary"] == active_theme.to_color_system().generate()["primary"]
     assert variables["border-blurred"] == variables["primary"]
     assert variables["override-order"] == variables["accent"]
 


### PR DESCRIPTION
resolves the problem raised in https://github.com/NSPC911/rovr/discussions/249#discussioncomment-17901612

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Adjust CSS variable resolution order to respect theme and user style precedence and add coverage for the new behavior.

Bug Fixes:
- Ensure CSS variables resolve using bundled defaults, then active theme overrides, and finally user style.tcss values so overrides behave as expected.

Tests:
- Add regression test verifying CSS variable resolution uses theme variables before user custom style declarations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme styling so theme settings consistently take precedence over bundled styles.
  * Custom styles can now override both theme settings and bundled variables where intended.
  * CSS variable references are resolved more reliably, producing a more consistent application appearance across themes.

* **Tests**
  * Added coverage to verify styling precedence and customisation behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->