### PR TITLE
fix(app): allow variable substitution for gradients

### DIFF
--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -1448,8 +1448,6 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
         import rich
         from rich.traceback import Traceback
 
-        self.on_exit_app()
-
         self.bell()
         traceback = Traceback(
             show_locals=True, width=None, locals_max_length=5, suppress=[rich]

--- a/src/rovr/config/themes/catppuccin-frappe.tcss
+++ b/src/rovr/config/themes/catppuccin-frappe.tcss
@@ -16,7 +16,6 @@ $input-cursor-background: #F2D5CF;
 $input-selection-background: #949CBB 30%;
 $border: #BABBF1;
 $border-blurred: #838BA7;
-$footer-background: #51576D;
 $block-cursor-foreground: #292C3C;
 $block-cursor-text-style: none;
 $button-color-foreground: #303446;

--- a/src/rovr/config/themes/catppuccin-macchiato.tcss
+++ b/src/rovr/config/themes/catppuccin-macchiato.tcss
@@ -16,7 +16,6 @@ $input-cursor-background: #F4DBD6;
 $input-selection-background: #838BA7 30%;
 $border: #B7BDF8;
 $border-blurred: #737994;
-$footer-background: #494D64;
 $block-cursor-foreground: #1E2030;
 $block-cursor-text-style: none;
 $button-color-foreground: #24273A;

--- a/src/rovr/config/themes/catppuccin-mocha.tcss
+++ b/src/rovr/config/themes/catppuccin-mocha.tcss
@@ -16,7 +16,6 @@ $input-cursor-background: #f5e0dc;
 $input-selection-background: #9399b2 30%;
 $border: #b4befe;
 $border-blurred: #585b70;
-$footer-background: #45475a;
 $block-cursor-foreground: #1e1e2e;
 $block-cursor-text-style: none;
 $button-color-foreground: #181825;

--- a/src/rovr/config/themes/nord.tcss
+++ b/src/rovr/config/themes/nord.tcss
@@ -11,8 +11,8 @@ $panel: #434C5E;
 $dark: true;
 
 /* progress bar gradients */
-$bar-gradient-default: #88c0d0 #5e81ac;
-$bar-gradient-error: #bf616a #d08770;
+$bar-gradient-default: $secondary $primary;
+$bar-gradient-error: $warning $error;
 
 /* other vars */
 $block-cursor-background: #88C0D0;

--- a/src/rovr/config/themes/rose-pine-dawn.tcss
+++ b/src/rovr/config/themes/rose-pine-dawn.tcss
@@ -15,7 +15,6 @@ $input-cursor-background: #575279;
 $input-selection-background: #dfdad9;
 $border: #cecacd;
 $border-blurred: #9893a5;
-$footer-background: #f2e9e1;
 $block-cursor-foreground: #faf4ed;
 $block-cursor-text-style: none;
 $block-cursor-background: #575279;

--- a/src/rovr/config/themes/rose-pine-moon.tcss
+++ b/src/rovr/config/themes/rose-pine-moon.tcss
@@ -15,7 +15,6 @@ $input-cursor-background: #f4ede8;
 $input-selection-background: #44415a;
 $border: #56526e;
 $border-blurred: #6e6a86;
-$footer-background: #393552;
 $block-cursor-foreground: #232136;
 $block-cursor-text-style: none;
 $block-cursor-background: #c4a7e7;

--- a/src/rovr/config/themes/rose-pine.tcss
+++ b/src/rovr/config/themes/rose-pine.tcss
@@ -15,7 +15,6 @@ $input-cursor-background: #f4ede8;
 $input-selection-background: #403d52;
 $border: #524f67;
 $border-blurred: #6e6a86;
-$footer-background: #26233a;
 $block-cursor-foreground: #191724;
 $block-cursor-text-style: none;
 $block-cursor-background: #c4a7e7;

--- a/src/rovr/config/themes/solarized-dark.tcss
+++ b/src/rovr/config/themes/solarized-dark.tcss
@@ -12,7 +12,6 @@ $dark: true;
 
 /* other vars */
 $button-color-foreground: #fdf6e3;
-$footer-background: #268bd2;
 $footer-key-foreground: #fdf6e3;
 $footer-description-foreground: #fdf6e3;
 $input-selection-background: #073642;

--- a/src/rovr/config/themes/solarized-light.tcss
+++ b/src/rovr/config/themes/solarized-light.tcss
@@ -12,6 +12,5 @@ $dark: false;
 
 /* other vars */
 $button-color-foreground: #fdf6e3;
-$footer-background: #268bd2;
 $footer-key-foreground: #fdf6e3;
 $footer-description-foreground: #fdf6e3;

--- a/src/rovr/footer/process_container.py
+++ b/src/rovr/footer/process_container.py
@@ -57,7 +57,11 @@ class ProgressBarContainer(VerticalGroup, inherit_bindings=False):
         gradient_colors = getattr(
             self.app.get_theme(self.app.theme), "bar_gradient", {}
         ).get("default")
-        gradient = Gradient.from_colors(*gradient_colors) if gradient_colors else None
+        gradient = (
+            Gradient.from_colors(*reversed(gradient_colors))
+            if gradient_colors
+            else None
+        )
         self.progress_bar = ProgressBar(
             total=total,
             show_percentage=config["interface"]["show_progress_percentage"],

--- a/src/rovr/functions/themes.py
+++ b/src/rovr/functions/themes.py
@@ -199,19 +199,28 @@ def parse_theme_file(theme_file: Path) -> Theme:
             f"missing required color fields: {', '.join(sorted(not_exist))}"
         )
 
-    bar_gradient: dict[str, list[str]] = {}
-    for name, kind in BAR_GRADIENT_FIELDS.items():
+    gradient_declarations: dict[str, str] = {}
+    for name in BAR_GRADIENT_FIELDS:
         if name not in declared:
             continue
-        colors = declared.pop(name).split()
-        for color in colors:
-            Color.parse(color)
-        bar_gradient[kind] = colors
+        gradient_declarations[name] = declared.pop(name)
     theme = Theme(
         name=theme_file.stem,
         variables=declared,
         **fields,  # ty: ignore[invalid-argument-type]
     )
+    resolved = resolve_variable_references(
+        {**declared, **gradient_declarations},
+        theme.to_color_system().generate(),
+    )
+    bar_gradient: dict[str, list[str]] = {}
+    for name, kind in BAR_GRADIENT_FIELDS.items():
+        if name not in gradient_declarations:
+            continue
+        colors = resolved[name].split()
+        for color in colors:
+            Color.parse(color)
+        bar_gradient[kind] = colors
     # Theme.ansi defaults to false, so retain whether a file actually declared
     # it. Undeclared themes must defer to the user's transparent-mode setting.
     theme.ansi_explicit = "ansi" in fields  # ty: ignore[unresolved-attribute]

--- a/tests/test_functions_themes.py
+++ b/tests/test_functions_themes.py
@@ -264,6 +264,25 @@ def test_parse_theme_file_bar_gradient(tmp_path: Path) -> None:
     assert "bar-gradient-default" not in theme.variables
 
 
+def test_bar_gradient_mixed_literals_and_variables(tmp_path: Path) -> None:
+    """Gradients can mix literal colors and variables, exercising mixed Color.parse resolution."""
+
+    from textual.color import Color
+
+    theme_file = tmp_path / "gradients-mixed.tcss"
+    theme_file.write_text(
+        NORD_PLACEHOLDER + "\n$bar-gradient-default: #111111 $primary;\n"
+    )
+    theme = theme_utils.parse_theme_file(theme_file)
+    variables = theme.to_color_system().generate()
+
+    assert theme.bar_gradient == {
+        "default": [Color.parse("#111111").hex, variables["primary"]],
+    }
+    # bar-gradient declarations don't leak into the theme's plain variables
+    assert "bar-gradient-default" not in theme.variables
+
+
 def test_parse_theme_file_invalid_bar_gradient_color_raises(tmp_path: Path) -> None:
     theme_file = tmp_path / "bad-gradient.tcss"
     theme_file.write_text(NORD_PLACEHOLDER + "\n$bar-gradient-default: not-a-color;\n")

--- a/tests/test_functions_themes.py
+++ b/tests/test_functions_themes.py
@@ -251,13 +251,14 @@ def test_parse_theme_file_bar_gradient(tmp_path: Path) -> None:
     theme_file = tmp_path / "gradients.tcss"
     theme_file.write_text(
         NORD_PLACEHOLDER + "\n"
-        "$bar-gradient-default: #111111 #222222;\n"
-        "$bar-gradient-error: #ff0000 #990000;\n"
+        "$bar-gradient-default: $secondary $primary;\n"
+        "$bar-gradient-error: $warning $error;\n"
     )
     theme = theme_utils.parse_theme_file(theme_file)
+    variables = theme.to_color_system().generate()
     assert theme.bar_gradient == {
-        "default": ["#111111", "#222222"],
-        "error": ["#ff0000", "#990000"],
+        "default": [variables["secondary"], variables["primary"]],
+        "error": [variables["warning"], variables["error"]],
     }
     # bar-gradient declarations don't leak into the theme's plain variables
     assert "bar-gradient-default" not in theme.variables


### PR DESCRIPTION
first stacked pr :o 

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Allow theme bar gradients to use variable-based color declarations and adjust progress bar rendering accordingly.

New Features:
- Support variable substitution in bar gradient theme declarations so gradients can reference existing theme color variables.

Bug Fixes:
- Ensure bar gradient declarations are resolved through the theme color system before validation and use in the UI.
- Reverse the order of bar gradient colors when constructing the footer progress bar gradient to match the expected visual direction.
- Avoid invoking the generic app exit handler in the fatal error path to prevent side effects during crash handling.

Tests:
- Update bar gradient parsing tests to cover variable-based gradient declarations and ensure they do not leak into plain theme variables.