### PR TITLE
feat: exclude hidden subfolders by default in path-input autocomplete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ rovr.onefile-build
 rovr.exe
 rovr.bin
 /rovr
+
+# Code editors
+.helix
+.zed

--- a/src/rovr/navigation_widgets/path_input.py
+++ b/src/rovr/navigation_widgets/path_input.py
@@ -68,7 +68,6 @@ def should_exclude_hidden(path_str: str) -> bool:
     The special component ``..`` always results in filtering because it
     represents navigation rather than prefix matching.  Single ``.`` does
     **not** filter — it acts as an explicit invitation to see dotfiles.
-    Double-dot prefixes such as ``..`` also yield ``False`` (unfiltered).
 
     Args:
         path_str: The raw value inside the path input widget.

--- a/src/rovr/navigation_widgets/path_input.py
+++ b/src/rovr/navigation_widgets/path_input.py
@@ -78,7 +78,10 @@ def should_exclude_hidden(path_str: str) -> bool:
     if path_str.endswith(".."):
         return True
 
-    # User typed something that starts with a dot → show hidden files.
+    if config["interface"]["show_hidden_files"]:
+        return False
+
+    # User typed something that starts with a dot -> show hidden files.
     head, tail = os.path.split(path_str)
     if not tail:
         return True
@@ -106,7 +109,8 @@ def _unix_get_candidates(path_str: str) -> list[DropdownItem]:
     # Case 2: exact directory match
     # User typed path of a particular folder already (but without the trailing "/")
     if (
-        not path_str.endswith(".") and not path_str.endswith(os.path.sep)
+        not path_str.endswith(".")
+        and not path_str.endswith("/")
         and ppath.exists()
         and ppath.is_dir()
     ):
@@ -169,9 +173,10 @@ def _win_get_candidates(path_str: str) -> list[DropdownItem]:
         return []
 
     # Case 3: exact directory match
-    # User typed path of a particular folder already (but without the trailing "/")
+    # User typed path of a particular folder already (but without the trailing "\")
     if (
-        not path_str.endswith(".") and not path_str.endswith(os.path.sep)
+        not path_str.endswith(".")
+        and not path_str.endswith(("\\", "/"))
         and ppath.exists()
         and ppath.is_dir()
     ):

--- a/src/rovr/navigation_widgets/path_input.py
+++ b/src/rovr/navigation_widgets/path_input.py
@@ -1,5 +1,8 @@
-from os import getcwd, listdir, path
-from typing import ClassVar, cast
+import os
+import stat
+from os import getcwd, path
+from pathlib import Path
+from typing import ClassVar, Generator, cast
 
 from rich.text import Text
 from textual import events
@@ -11,23 +14,82 @@ from textual_autocomplete import DropdownItem, PathAutoComplete, TargetState
 
 from rovr.classes.mixins import Action, Actionable
 from rovr.classes.textual_options import PathDropdownItem
+from rovr.classes.type_aliases import DirEntryType
 from rovr.functions.icons import get_icon
 from rovr.functions.utils import check_key
 from rovr.variables.constants import config, os_type
 
 
-def listdir_or(path: str | None = None) -> list[str]:
-    """Wrapper around os.listdir that returns an empty list if the path doesn't exist.
+def get_subdirectories(parent: str | os.PathLike) -> Generator[DirEntryType, None, None]:
+    try:
+        with os.scandir(parent) as it:
+            for entry in it:
+                if entry.is_dir():
+                    yield entry
+    except (FileNotFoundError, OSError):
+        return
+
+
+def is_dir_entry_hidden(entry: os.DirEntry) -> bool:
+    """Check whether a ``DirEntry`` represents a hidden item.
+
+    Apart from normal rule, we also treat dot prefix as hidden on all OSes,
+    because many cross-platform apps only use dot prefix for they internal folder,
+    like ".git", ".helix".
+
     Args:
-        path: The path to list. If None, lists the current directory.
+        entry: A ``DirEntry`` from ``os.scandir``.
 
     Returns:
-        A list of directory entries in the given path, or an empty list if the path doesn't exist.
+        ``True`` if the entry is hidden, ``False`` otherwise.
     """
+    if entry.name.startswith("."):
+        return True
     try:
-        return listdir(path)
+        file_stat = entry.stat(follow_symlinks=False)
     except OSError:
-        return []
+        return False
+
+    if os_type == "Darwin":
+        return file_stat.st_flags & stat.UF_HIDDEN
+    # Windows
+    if os_type == "Windows":
+        return file_stat.st_file_attributes & stat.FILE_ATTRIBUTE_HIDDEN
+    return False
+
+
+def should_exclude_hidden(path_str: str) -> bool:
+    """Decide whether hidden entries must be excluded from autocomplete results.
+
+    When the user explicitly types something that starts with ``.`` we let
+    the dropdown show hidden entries so they can reach ``.config``, ``.local``,
+    etc.  Otherwise hidden entries are filtered out.
+
+    The special component ``..`` always results in filtering because it
+    represents navigation rather than prefix matching.  Single ``.`` does
+    **not** filter — it acts as an explicit invitation to see dotfiles.
+    Double-dot prefixes such as ``..`` also yield ``False`` (unfiltered).
+
+    Args:
+        path_str: The raw value inside the path input widget.
+
+    Returns:
+        ``True`` when hidden entries should be filtered, ``False`` when they
+        should be listed.
+    """
+    # Never filter when the raw input is empty
+    if not path_str:
+        return False
+
+    # Navigation tokens never reveal hidden files.
+    if path_str.endswith(".."):
+        return True
+
+    # User typed something that starts with a dot → show hidden files.
+    head, tail = os.path.split(path_str)
+    if not tail:
+        return True
+    return not tail.startswith(".")
 
 
 def _unix_get_candidates(path_str: str) -> list[DropdownItem]:
@@ -39,26 +101,53 @@ def _unix_get_candidates(path_str: str) -> list[DropdownItem]:
     if not path.isabs(path_str):
         return []
 
-    # Case 2: list directories
-    if (not path_str.endswith("/")) and path.exists(path_str) and path.isdir(path_str):
-        # Case 3: exact directory match
-        target = path.realpath(path.expanduser(path_str))
-        return [PathDropdownItem(path.basename(target) + "/", target)]
+    # User is going up, no need to provide autocomplete.
+    if path_str.endswith(".."):
+        return []
+
+    # We treat differently for "/path/to/folder" and "/path/to/folder/",
+    # but `Path.resolve` will strip the trailing "/",
+    # so sometimes we have to check against the original `path_str`.
+    ppath = Path(path_str).expanduser().resolve()
+
+    # Case 2: exact directory match
+    # User typed path of a particular folder already (but without the trailing "/")
+    if (
+        not path_str.endswith(".") and not path_str.endswith(os.path.sep)
+        and ppath.exists()
+        and ppath.is_dir()
+    ):
+        return [PathDropdownItem(f"{ppath.name}/", str(ppath))]
 
     # Case 3: list contents of parent
-    parent = path.dirname(path_str)
-    if path.exists(parent) and path.isdir(parent):
-        items = []
-        for item in listdir_or(parent):
-            full_item_path = path.join(parent, item)
-            if path.isdir(full_item_path):
-                items.append(PathDropdownItem(item + "/", full_item_path))
-        items.sort(key=lambda x: x.path.lower())
-        return items
-    return []
+    # - User typed a directory path with trailing "/" -> show subdirectories
+    # - User typed a partial directory path (like "/home/user/.local/sh")
+    #   -> we determine the parent ("~/.local") then show subdirectories ("share")
+    parent = ppath if ppath.is_dir() else ppath.parent
+    items: list[DropdownItem] = []
+    should_filter = should_exclude_hidden(path_str)
+    for entry in get_subdirectories(parent):
+        if should_filter and is_dir_entry_hidden(entry):
+            continue
+        items.append(PathDropdownItem(f"{entry.name}/", entry.path))
+    items.sort(key=lambda x: x.path.lower())
+    return items
 
 
 def _win_get_candidates(path_str: str) -> list[DropdownItem]:
+    """Windows-specific path autocomplete using ``scandir`` and ``DirEntry``.
+
+    Handles drive-letter discovery, bare/drive inputs (``C``, ``C:``), and
+    directory traversal on Windows.  Hidden directories are filtered unless
+    the terminal component starts with a dot.
+
+    Args:
+        path_str: The raw value inside the Windows path input widget.
+
+    Returns:
+        A list of ``DropdownItem`` suggestions, or an empty list when no
+        candidates are available.
+    """
     # Case 1: Empty string - return available drives
     if not path_str:
         drives = []
@@ -82,28 +171,31 @@ def _win_get_candidates(path_str: str) -> list[DropdownItem]:
     if not path.isabs(path_str):
         return []
 
-    # Case 3: Check if it's an exact directory match
-    # Skip this case if the path ends with "." or ".." to avoid returning "./" or "../"
-    if (
-        (not path_str.endswith(("/", "\\")))
-        and (path.split(path_str)[-1] not in (".", ".."))
-        and path.exists(path_str)
-        and path.isdir(path_str)
-    ):
-        target = path.realpath(path_str)
-        return [PathDropdownItem(path.basename(target) + "/", target)]
+    ppath = Path(path_str).expanduser().resolve()
+    if path_str.endswith(".."):
+        return []
 
-    parent = path.dirname(path_str)
-    if path.exists(parent) and path.isdir(parent):
-        # Case 4: Path ends with "/" - list contents of that directory (directories only)
-        items = []
-        for item in listdir_or(parent):
-            full_item_path = path.join(parent, item)
-            if path.isdir(full_item_path):
-                items.append(PathDropdownItem(item + "/", full_item_path))
-        items.sort(key=lambda x: x.path.lower())
-        return items
-    return []
+    # Case 3: exact directory match
+    # User typed path of a particular folder already (but without the trailing "/")
+    if (
+        not path_str.endswith(".") and not path_str.endswith(os.path.sep)
+        and ppath.exists()
+        and ppath.is_dir()
+    ):
+        return [PathDropdownItem(f"{ppath.name}{os.path.sep}", str(ppath))]
+
+    # Case 4: list contents of parent
+    # - Path ends with "/" → show subdirectories
+    # - Partial path like "C:\Users\Admin\Doc" → parent is "C:\Users\Admin"
+    parent = ppath if ppath.exists() else ppath.parent
+    items: list[DropdownItem] = []
+    should_filter = should_exclude_hidden(path_str)
+    for entry in get_subdirectories(parent):
+        if should_filter and is_dir_entry_hidden(entry):
+            continue
+        items.append(PathDropdownItem(f"{entry.name}\\", entry.path))
+    items.sort(key=lambda x: x.path.lower())
+    return items
 
 
 class PathAutoCompleteInput(PathAutoComplete):

--- a/src/rovr/navigation_widgets/path_input.py
+++ b/src/rovr/navigation_widgets/path_input.py
@@ -184,8 +184,8 @@ def _win_get_candidates(path_str: str) -> list[DropdownItem]:
         return [PathDropdownItem(f"{ppath.name}{os.path.sep}", str(ppath))]
 
     # Case 4: list contents of parent
-    # - Path ends with "/" → show subdirectories
-    # - Partial path like "C:\Users\Admin\Doc" → parent is "C:\Users\Admin"
+    # - Path ends with "/" -> show subdirectories
+    # - Partial path like "C:\Users\Admin\Doc" -> parent is "C:\Users\Admin"
     parent = ppath if ppath.exists() else ppath.parent
     items: list[DropdownItem] = []
     should_filter = should_exclude_hidden(path_str)

--- a/src/rovr/navigation_widgets/path_input.py
+++ b/src/rovr/navigation_widgets/path_input.py
@@ -14,13 +14,12 @@ from textual_autocomplete import DropdownItem, PathAutoComplete, TargetState
 
 from rovr.classes.mixins import Action, Actionable
 from rovr.classes.textual_options import PathDropdownItem
-from rovr.classes.type_aliases import DirEntryType
 from rovr.functions.icons import get_icon
 from rovr.functions.utils import check_key
 from rovr.variables.constants import config, os_type
 
 
-def get_subdirectories(parent: str | os.PathLike) -> Generator[DirEntryType, None, None]:
+def get_subdirectories(parent: str | os.PathLike) -> Generator[os.DirEntry, None, None]:
     try:
         with os.scandir(parent) as it:
             for entry in it:
@@ -33,17 +32,13 @@ def get_subdirectories(parent: str | os.PathLike) -> Generator[DirEntryType, Non
 def is_dir_entry_hidden(entry: os.DirEntry) -> bool:
     """Check whether a ``DirEntry`` represents a hidden item.
 
-    Apart from normal rule, we also treat dot prefix as hidden on all OSes,
-    because many cross-platform apps only use dot prefix for they internal folder,
-    like ".git", ".helix".
-
     Args:
         entry: A ``DirEntry`` from ``os.scandir``.
 
     Returns:
         ``True`` if the entry is hidden, ``False`` otherwise.
     """
-    if entry.name.startswith("."):
+    if entry.name.startswith(".") and os_type != "Windows":
         return True
     try:
         file_stat = entry.stat(follow_symlinks=False)
@@ -52,7 +47,6 @@ def is_dir_entry_hidden(entry: os.DirEntry) -> bool:
 
     if os_type == "Darwin":
         return file_stat.st_flags & stat.UF_HIDDEN
-    # Windows
     if os_type == "Windows":
         return file_stat.st_file_attributes & stat.FILE_ATTRIBUTE_HIDDEN
     return False

--- a/tests/test_path_input.py
+++ b/tests/test_path_input.py
@@ -1,0 +1,47 @@
+import sys
+
+import pytest
+
+from rovr.navigation_widgets.path_input import should_exclude_hidden
+
+
+def test_should_exclude_hidden_empty() -> None:
+    assert not should_exclude_hidden("")
+
+
+def test_should_exclude_hidden_dot_terminal() -> None:
+    """User typed '.' alone or as last component → show dotfiles."""
+    assert not should_exclude_hidden(".")
+    assert not should_exclude_hidden("/home/.")
+
+
+def test_should_exclude_hidden_double_dot_filters() -> None:
+    """.. represents navigation, so it MUST filter."""
+    assert should_exclude_hidden("..")
+    assert should_exclude_hidden("/home/..")
+    assert should_exclude_hidden("C:\\Windows\\..")
+
+
+def test_should_exclude_hidden_dotfile_no_filter() -> None:
+    assert not should_exclude_hidden("/foo/.config")
+    assert should_exclude_hidden("/foo/.hidden_dir/")
+    assert not should_exclude_hidden("/home/...cache")
+
+
+def test_should_exclude_hidden_visible_filters() -> None:
+    assert should_exclude_hidden("/home")
+    assert should_exclude_hidden("/home/")
+    assert should_exclude_hidden("/home/projects")
+    assert should_exclude_hidden("C:/Users/Me/Documents")
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Need to be on Windows")
+def test_should_exclude_hidden_backslash_separator() -> None:
+    """Backslashes should work as separators too."""
+    assert not should_exclude_hidden("C:\\foo\\.git")
+
+
+def test_should_exclude_hidden_trailing_slashes_no_separator() -> None:
+    """Path with trailing slashes but no final component still filters
+    (same behaviour as the original implementation)."""
+    assert should_exclude_hidden("/home/foo///")


### PR DESCRIPTION
But include them when users really want to find them, by typing the prefix
of their names.

Resolves #321 

Normal state: Exclude ".git"

<img width="1396" height="764" alt="image" src="https://github.com/user-attachments/assets/83bb80c8-7890-4c66-a30b-9fb80c4b62c8" />

When user wants to find hidden subfolders:

<img width="1396" height="764" alt="image" src="https://github.com/user-attachments/assets/0001d46e-e1fb-49ea-849a-7ca72666820c" />


---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Adjust path autocomplete to intelligently include or exclude hidden subdirectories based on the user’s typed prefix across Unix and Windows.

Enhancements:
- Introduce cross-platform hidden-directory detection and filtering in path autocomplete suggestions, allowing explicit discovery via dot-prefixed input.
- Refine Unix and Windows candidate generation to use scandir/DirEntry, handle navigation tokens like "..", and improve exact-directory matching behavior.

Tests:
- Add unit tests for the hidden-filtering decision logic to cover dotfile prefixes, navigation components, separators, and trailing-slash edge cases.

## Summary by Sourcery

Adjust path autocomplete to filter hidden subdirectories by default while still allowing users to discover them via dot-prefixed input, with consistent behavior across Unix and Windows.

New Features:
- Enable path-input autocomplete to reveal hidden subdirectories when the user types a dot-prefixed component in the path.

Enhancements:
- Introduce cross-platform hidden-directory detection using DirEntry metadata and dot-prefix rules in autocomplete suggestions.
- Refine Unix and Windows autocomplete candidate generation to use scandir/Path, handle exact-directory matches, and ignore suggestions while navigating with "..".

Tests:
- Add unit tests covering the hidden-filtering decision logic, including dotfile prefixes, navigation tokens, separators, and trailing-slash edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved path autocomplete handling for missing or inaccessible directories.
  - Hidden directories are now excluded by default, while remaining available when explicitly requested.
  - Path navigation and parent-directory completion now behave consistently across Windows and Unix systems.
  - Suppressed unnecessary `..` suggestions.

- **Tests**
  - Added comprehensive coverage for hidden paths, separators, parent traversal, and trailing slashes across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->