### PR TITLE
feat: keep a virtual path of current directory

### DIFF
--- a/src/rovr/action_buttons/copy_button.py
+++ b/src/rovr/action_buttons/copy_button.py
@@ -1,4 +1,3 @@
-from os import getcwd
 from pathlib import Path
 
 from textual import events, work
@@ -8,6 +7,7 @@ from textual.widgets.option_list import Option
 
 from rovr.classes.textual_options import FileListSelectionWidget
 from rovr.components.popup_option_list import PopupOptionList
+from rovr.functions.cwd import getcwd
 from rovr.functions.icons import get_icon
 from rovr.functions.path import dump_exc, normalise
 from rovr.functions.system_clipboard import (

--- a/src/rovr/action_buttons/new_item_button.py
+++ b/src/rovr/action_buttons/new_item_button.py
@@ -1,5 +1,5 @@
 import contextlib
-from os import getcwd, makedirs, path
+from os import makedirs, path
 from tempfile import NamedTemporaryFile
 from typing import cast
 
@@ -9,6 +9,7 @@ from textual.widgets import Button
 from textual.worker import Worker, WorkerError
 
 from rovr.classes.textual_validators import IsValidFilePath, PathNoLongerExists
+from rovr.functions.cwd import getcwd
 from rovr.functions.icons import get_icon
 from rovr.functions.path import dump_exc, normalise
 from rovr.functions.utils import command, run_command

--- a/src/rovr/action_buttons/paste_button.py
+++ b/src/rovr/action_buttons/paste_button.py
@@ -1,6 +1,8 @@
+from textual import work
 from textual.widgets import Button
 
 from rovr.classes.textual_options import ClipboardSelectionValue
+from rovr.functions.cwd import getcwd
 from rovr.functions.icons import get_icon
 from rovr.functions.utils import s
 from rovr.screens.paste_screen import PasteScreen
@@ -15,6 +17,7 @@ class PasteButton(Button):
         if config["interface"]["tooltips"]:
             self.tooltip = "Paste files from clipboard"
 
+    @work
     async def on_button_pressed(self) -> None:
         """Paste files from clipboard"""
         if self.disabled:
@@ -37,12 +40,7 @@ class PasteButton(Button):
                 ],
             )
 
-            async def callback(response: str) -> None:
-                """Callback to paste files after confirmation"""
-                if response:
-                    self.app.query_one("ProcessContainer").paste_items(to_copy, to_cut)
-
-            self.app.push_screen(
+            result = await self.app.push_screen_wait(
                 PasteScreen(
                     message="Are you sure you want to "
                     + (
@@ -54,6 +52,10 @@ class PasteButton(Button):
                     + "?",
                     paths={"copy": to_copy, "cut": to_cut},
                     destructive=True,
-                ),
-                callback=callback,
+                )
             )
+
+            if result:
+                self.app.query_one("ProcessContainer").paste_items(
+                    to_copy, to_cut, getcwd()
+                )

--- a/src/rovr/action_buttons/rename_item_button.py
+++ b/src/rovr/action_buttons/rename_item_button.py
@@ -1,6 +1,6 @@
 import contextlib
 import os
-from os import getcwd, path
+from os import path
 from shutil import move
 from tempfile import NamedTemporaryFile
 
@@ -9,6 +9,7 @@ from textual.widgets import Button
 from textual.worker import Worker, WorkerError
 
 from rovr.classes.textual_validators import IsValidFilePath, PathNoLongerExists
+from rovr.functions.cwd import getcwd
 from rovr.functions.icons import get_icon
 from rovr.functions.path import dump_exc, normalise
 from rovr.functions.utils import command, run_command

--- a/src/rovr/action_buttons/unzip_button.py
+++ b/src/rovr/action_buttons/unzip_button.py
@@ -1,10 +1,11 @@
-from os import getcwd, path
+from os import path
 
 from textual import work
 from textual.widgets import Button
 
 from rovr.classes.textual_validators import IsValidFilePath
 from rovr.functions import utils
+from rovr.functions.cwd import getcwd
 from rovr.functions.icons import get_icon
 from rovr.functions.path import normalise
 from rovr.screens import ModalInput

--- a/src/rovr/action_buttons/zip_button.py
+++ b/src/rovr/action_buttons/zip_button.py
@@ -1,4 +1,4 @@
-from os import getcwd, path
+from os import path
 from typing import cast
 
 from textual import work
@@ -7,6 +7,7 @@ from textual.widgets import Button
 from rovr.classes.textual_validators import (
     IsValidFilePath,
 )
+from rovr.functions.cwd import getcwd
 from rovr.functions.icons import get_icon
 from rovr.functions.path import normalise
 from rovr.screens import ArchiveCreationScreen

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -9,7 +9,7 @@ from contextlib import suppress
 from dataclasses import replace
 from importlib import resources
 from io import TextIOWrapper
-from os import chdir, getcwd, path
+from os import path
 from subprocess import Popen, TimeoutExpired
 from time import perf_counter
 from typing import Callable, ClassVar, Iterable
@@ -78,6 +78,7 @@ from rovr.core import (
 )
 from rovr.footer import Clipboard, MetadataContainer, ProcessContainer
 from rovr.functions import drive_workers, multiprocessing_utils
+from rovr.functions.cwd import chdir, getcwd
 from rovr.functions.path import (
     dump_exc,
     ensure_existing_directory,
@@ -254,7 +255,9 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
             startup_paths = list(startup_path)
         self._startup_locations: list[tuple[str, str | None]] = []
         for startup_item in startup_paths:
-            resolved_path = path.abspath(path.expanduser(startup_item))
+            resolved_path = path.normpath(
+                path.join(getcwd(), path.expanduser(startup_item))
+            )
             directory = normalise(ensure_existing_directory(resolved_path))
             focus_on = (
                 path.basename(resolved_path) if path.isfile(resolved_path) else None

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -255,8 +255,11 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
             startup_paths = list(startup_path)
         self._startup_locations: list[tuple[str, str | None]] = []
         for startup_item in startup_paths:
+            expanded_path = path.expanduser(startup_item)
             resolved_path = path.normpath(
-                path.join(getcwd(), path.expanduser(startup_item))
+                expanded_path
+                if path.isabs(expanded_path)
+                else path.join(getcwd(), expanded_path)
             )
             directory = normalise(ensure_existing_directory(resolved_path))
             focus_on = (

--- a/src/rovr/classes/textual_options.py
+++ b/src/rovr/classes/textual_options.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from os import DirEntry, getcwd, path
+from os import DirEntry, path
 from typing import Callable, Literal, Mapping, NamedTuple, TypeAlias
 
 import rich.repr
@@ -14,6 +14,7 @@ from textual_autocomplete import DropdownItem
 
 from rovr.functions import details as detail_utils
 from rovr.functions import icons as icon_utils
+from rovr.functions.cwd import getcwd
 from rovr.functions.path import is_hidden_file, normalise
 
 IconFactory: TypeAlias = Callable[[], tuple[str, str]]

--- a/src/rovr/classes/textual_validators.py
+++ b/src/rovr/classes/textual_validators.py
@@ -1,7 +1,8 @@
-from os import getcwd, path
+from os import path
 
 from textual.validation import ValidationResult, Validator
 
+from rovr.functions.cwd import getcwd
 from rovr.functions.path import normalise
 from rovr.variables.constants import os_type
 

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -1,6 +1,6 @@
 import shlex
 from contextlib import suppress
-from os import getcwd, path, scandir
+from os import path, scandir
 from typing import Callable, ClassVar, Sequence
 
 from rich.segment import Segment
@@ -29,6 +29,7 @@ from rovr.functions import details as detail_utils
 from rovr.functions import path as path_utils
 from rovr.functions import pins as pin_utils
 from rovr.functions import utils
+from rovr.functions.cwd import getcwd
 from rovr.navigation_widgets import PathInput
 from rovr.state_manager import StateManager
 from rovr.variables.constants import (

--- a/src/rovr/core/file_list_right_click_menu.py
+++ b/src/rovr/core/file_list_right_click_menu.py
@@ -17,6 +17,7 @@ from rovr.classes.config import (
 from rovr.classes.textual_options import RightClickMenuOption
 from rovr.classes.type_aliases import DirEntryType
 from rovr.components import PopupOptionList
+from rovr.functions.cwd import getcwd
 from rovr.functions.path import ifed
 from rovr.functions.utils import check_key, expand_command, is_archive, run_command
 from rovr.variables.constants import bindings, config
@@ -108,8 +109,6 @@ def give_me_an_option(
             return PartialOption(id="copy_highlighted", disabled=no_items)
         case "system:copy_current_directory":
             try:
-                from os import getcwd
-
                 getcwd()
                 return PartialOption(id="copy_current_directory", disabled=False)
             except FileNotFoundError:

--- a/src/rovr/footer/process_container.py
+++ b/src/rovr/footer/process_container.py
@@ -21,6 +21,7 @@ from rovr.classes.mixins import Action, Actionable
 from rovr.classes.type_aliases import BarPanicDismissible, BarPanicNotify
 from rovr.functions import icons as icon_utils
 from rovr.functions import path as path_utils
+from rovr.functions.cwd import getcwd
 from rovr.functions.utils import is_being_used, should_cancel
 from rovr.screens import (
     Dismissible,
@@ -953,7 +954,7 @@ class ProcessContainer(Actionable, VerticalScroll):
             dest (str): The directory to copy to.
         """
         if dest == "":
-            dest = os.getcwd()
+            dest = getcwd()
         bar = self.threaded_new_process_bar(classes="active")
         self.app.call_from_thread(
             bar.update_icon,
@@ -1438,7 +1439,7 @@ class ProcessContainer(Actionable, VerticalScroll):
         """
         from urllib import error, request
 
-        dest = os.getcwd()
+        dest = getcwd()
         bar = self.threaded_new_process_bar(max=len(uris) + 1, classes="active")
         self.app.call_from_thread(
             bar.update_icon,

--- a/src/rovr/functions/cwd.py
+++ b/src/rovr/functions/cwd.py
@@ -1,0 +1,72 @@
+import os
+from os import path
+
+
+def _initial_cwd() -> str:
+    """Choose a valid logical cwd when the module is imported.
+
+    The inherited ``PWD`` is retained only when it is absolute and points to
+    the process's physical working directory. This preserves a symlink path
+    supplied by the launching shell without trusting a stale environment value.
+
+    Returns:
+        The validated logical cwd, or the physical cwd as a fallback.
+    """
+    physical_cwd = os.getcwd()
+    pwd = os.environ.get("PWD")
+    if pwd is not None and path.isabs(pwd):
+        try:
+            if path.samefile(pwd, physical_cwd):
+                return path.normpath(pwd)
+        except OSError:
+            pass
+    return physical_cwd
+
+
+_logical_cwd = _initial_cwd()
+
+
+def getcwd() -> str:
+    """Return the logical cwd, preserving traversed directory symlinks.
+
+    The tracked path is checked against the process's physical cwd on every
+    call. If another caller changed directories or the logical path disappeared,
+    the physical cwd becomes the new logical cwd.
+
+    Returns:
+        The logical current working directory.
+    """
+    global _logical_cwd
+
+    physical_cwd = os.getcwd()
+    try:
+        if path.samefile(_logical_cwd, physical_cwd):
+            return _logical_cwd
+    except OSError:
+        pass
+
+    _logical_cwd = physical_cwd
+    os.environ["PWD"] = physical_cwd
+    return physical_cwd
+
+
+def chdir(directory: str) -> None:
+    """Change directory while retaining the logical path used to reach it.
+
+    Args:
+        directory: An absolute path or a path relative to the logical cwd.
+    """
+    global _logical_cwd
+
+    logical_cwd = getcwd()
+    logical_directory = (
+        path.normpath(directory)
+        if path.isabs(directory)
+        else path.normpath(path.join(logical_cwd, directory))
+    )
+    os.chdir(directory)
+    _logical_cwd = logical_directory
+    os.environ["PWD"] = logical_directory
+
+
+__all__ = ["getcwd", "chdir"]

--- a/src/rovr/functions/cwd.py
+++ b/src/rovr/functions/cwd.py
@@ -56,7 +56,7 @@ class _WorkingDirectory:
                 if path.isabs(directory)
                 else path.normpath(path.join(self.getcwd(), directory))
             )
-            os.chdir(directory)
+            os.chdir(logical_directory)
             self._physical_cwd = os.getcwd()
             self._logical_cwd = logical_directory
             os.environ["PWD"] = logical_directory

--- a/src/rovr/functions/cwd.py
+++ b/src/rovr/functions/cwd.py
@@ -1,72 +1,86 @@
 import os
 from os import path
+from threading import RLock
 
 
-def _initial_cwd() -> str:
-    """Choose a valid logical cwd when the module is imported.
+class _WorkingDirectory:
+    """Synchronize Rovr's logical cwd with the process cwd."""
 
-    The inherited ``PWD`` is retained only when it is absolute and points to
-    the process's physical working directory. This preserves a symlink path
-    supplied by the launching shell without trusting a stale environment value.
+    def __init__(self) -> None:
+        """Initialize the context from the process cwd and inherited ``PWD``."""
+        self._lock = RLock()
+        self._physical_cwd = os.getcwd()
+        self._logical_cwd = self._initial_cwd()
 
-    Returns:
-        The validated logical cwd, or the physical cwd as a fallback.
-    """
-    physical_cwd = os.getcwd()
-    pwd = os.environ.get("PWD")
-    if pwd is not None and path.isabs(pwd):
+    def _initial_cwd(self) -> str:
+        """Choose a valid logical cwd from the inherited ``PWD``.
+
+        Returns:
+            The validated logical cwd, or the physical cwd as a fallback.
+        """
+        pwd = os.environ.get("PWD")
+        if pwd is None or not path.isabs(pwd):
+            return self._physical_cwd
         try:
-            if path.samefile(pwd, physical_cwd):
+            if path.samefile(pwd, self._physical_cwd):
                 return path.normpath(pwd)
         except OSError:
             pass
-    return physical_cwd
+        return self._physical_cwd
+
+    def getcwd(self) -> str:
+        """Return the logical cwd, resynchronizing after external changes.
+
+        Returns:
+            The logical current working directory.
+        """
+        with self._lock:
+            physical_cwd = os.getcwd()
+            if physical_cwd == self._physical_cwd:
+                return self._logical_cwd
+
+            self._physical_cwd = physical_cwd
+            self._logical_cwd = physical_cwd
+            os.environ["PWD"] = physical_cwd
+            return physical_cwd
+
+    def chdir(self, directory: str) -> None:
+        """Change directory while retaining the logical path used to reach it.
+
+        Args:
+            directory: An absolute path or a path relative to the logical cwd.
+        """
+        with self._lock:
+            logical_directory = (
+                path.normpath(directory)
+                if path.isabs(directory)
+                else path.normpath(path.join(self.getcwd(), directory))
+            )
+            os.chdir(directory)
+            self._physical_cwd = os.getcwd()
+            self._logical_cwd = logical_directory
+            os.environ["PWD"] = logical_directory
 
 
-_logical_cwd = _initial_cwd()
+_working_directory = _WorkingDirectory()
 
 
 def getcwd() -> str:
-    """Return the logical cwd, preserving traversed directory symlinks.
-
-    The tracked path is checked against the process's physical cwd on every
-    call. If another caller changed directories or the logical path disappeared,
-    the physical cwd becomes the new logical cwd.
+    """Return the logical current working directory.
 
     Returns:
         The logical current working directory.
     """
-    global _logical_cwd
-
-    physical_cwd = os.getcwd()
-    try:
-        if path.samefile(_logical_cwd, physical_cwd):
-            return _logical_cwd
-    except OSError:
-        pass
-
-    _logical_cwd = physical_cwd
-    os.environ["PWD"] = physical_cwd
-    return physical_cwd
+    return _working_directory.getcwd()
 
 
 def chdir(directory: str) -> None:
-    """Change directory while retaining the logical path used to reach it.
+    """Change the process and logical working directories.
 
     Args:
         directory: An absolute path or a path relative to the logical cwd.
     """
-    global _logical_cwd
-
-    logical_cwd = getcwd()
-    logical_directory = (
-        path.normpath(directory)
-        if path.isabs(directory)
-        else path.normpath(path.join(logical_cwd, directory))
-    )
-    os.chdir(directory)
-    _logical_cwd = logical_directory
-    os.environ["PWD"] = logical_directory
+    _working_directory.chdir(directory)
 
 
 __all__ = ["getcwd", "chdir"]

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -14,6 +14,8 @@ from textual.message import Message
 from textual.screen import Screen, ScreenResultType
 from textual.worker import NoActiveWorker, WorkerCancelled, get_current_worker
 
+from rovr.functions.cwd import getcwd
+
 
 def set_scuffed_subtitle(element: DOMNode, *sections: str) -> None:
     """The most scuffed way to display a custom subtitle
@@ -250,7 +252,7 @@ async def expand_command(app: App, command: list[str]) -> list[str]: ...
 async def expand_command(app: App, command: str | list[str]) -> str | list[str]:
     from rovr.functions.path import normalise
 
-    cwd = normalise(os.getcwd())
+    cwd = normalise(getcwd())
     highlighted = ""
     if app.file_list.highlighted_option is not None and hasattr(
         app.file_list.highlighted_option, "dir_entry"

--- a/src/rovr/header/tabs.py
+++ b/src/rovr/header/tabs.py
@@ -1,5 +1,5 @@
 from contextlib import suppress
-from os import getcwd, path
+from os import path
 
 from rich.style import Style
 from textual import on, work
@@ -13,6 +13,7 @@ from textual.widgets._tabs import Tab, Underline
 from textual.worker import WorkerCancelled
 
 from rovr.classes.session_manager import SessionManager
+from rovr.functions.cwd import getcwd
 from rovr.functions.path import normalise
 
 

--- a/src/rovr/navigation_widgets/buttons.py
+++ b/src/rovr/navigation_widgets/buttons.py
@@ -1,8 +1,9 @@
-from os import getcwd, path
+from os import path
 
 from textual.widgets import Button
 
 from rovr.classes.session_manager import SessionManager
+from rovr.functions.cwd import getcwd
 from rovr.functions.icons import get_icon
 
 

--- a/src/rovr/navigation_widgets/path_input.py
+++ b/src/rovr/navigation_widgets/path_input.py
@@ -1,6 +1,6 @@
 import os
 import stat
-from os import getcwd, path
+from os import path
 from pathlib import Path
 from typing import ClassVar, Generator, cast
 
@@ -14,6 +14,7 @@ from textual_autocomplete import DropdownItem, PathAutoComplete, TargetState
 
 from rovr.classes.mixins import Action, Actionable
 from rovr.classes.textual_options import PathDropdownItem
+from rovr.functions.cwd import getcwd
 from rovr.functions.icons import get_icon
 from rovr.functions.utils import check_key
 from rovr.variables.constants import config, os_type

--- a/src/rovr/screens/__main__.py
+++ b/src/rovr/screens/__main__.py
@@ -1,6 +1,5 @@
 # modal tester, use when necessary
 import random
-from os import getcwd
 from time import perf_counter
 from typing import Iterable
 
@@ -12,6 +11,7 @@ from textual.css.stylesheet import StylesheetParseError
 from textual.screen import Screen
 from textual.widgets import Button
 
+from rovr.functions.cwd import getcwd
 from rovr.screens import (
     ArchiveCreationScreen,
     DeleteFiles,

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -6,10 +6,30 @@ from textual import events
 
 from rovr.app import Application
 from rovr.components import SearchInput
+from rovr.functions.cwd import getcwd
 from rovr.header.tabs import TablineTab
 from rovr.navigation_widgets import BackButton
 
 from .conftest import iter_until, workers_finished
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name == "nt", reason="Creating symlinks may require privileges")
+async def test_navigation_preserves_directory_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=True)
+
+    app = Application(startup_path=link.as_posix())
+    async with app.run_test(size=(143, 37)) as pilot:
+        await iter_until(pilot, lambda: app.tabWidget.active_tab is not None)
+
+        assert getcwd() == link.as_posix()
+        assert app.tabWidget.active_tab.directory == link.as_posix()
+
+        await pilot.click("UpButton")
+        await iter_until(pilot, lambda: getcwd() == tmp_path.as_posix())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
fixes a problem i noticed while using linux

basically, when entering a symlink directory, `os.chdir` automatically resolves the symlink to the real path, which is not what i want.

this pr adds a new module to handle `os.getcwd` and `os.chdir` in a way that preserves symlinks

<!--describe your pull request-->

<!--also include videos, screenshots or gifs if applicable if it is a new feature-->

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Introduce a logical current working directory that preserves directory symlinks and integrate it across navigation and file operations.

New Features:
- Add a cwd helper module that tracks a logical current working directory and provides getcwd and chdir preserving symlink paths.

Enhancements:
- Update application startup path resolution and navigation widgets to use the logical cwd instead of os.getcwd and os.chdir for path handling.
- Adjust file operations and validators to respect the logical cwd when creating, renaming, copying, zipping, and unzipping items.

Tests:
- Add an async navigation test to verify that directory symlinks are preserved in the current directory and tab state on non-Windows platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved working-directory handling when starting the application from symbolic-link paths.
  * Preserved logical directory paths during navigation while maintaining reliable fallback behaviour when paths change or become invalid.
  * Improved consistency for file operations, command expansion, downloads, directory changes, and paste operations.
  * Paste confirmations now complete reliably before selected items are pasted.

* **Tests**
  * Added coverage verifying symbolic-link paths remain visible during startup and navigation, including moving to the parent directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->