### PR TITLE
refactor: consolidate is_hidden_file

### DIFF
--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -69,7 +69,6 @@ from rovr.classes.textual_validators import (
     IsValidFilePath,
 )
 from rovr.classes.theme import RovrStylesheet
-from rovr.classes.type_aliases import DirEntryType
 from rovr.components.popup_option_list import PopupOptionList
 from rovr.core import (
     FileList,
@@ -989,11 +988,16 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
             # check highlighted file mtime
             if not self.file_list.file_list_pause_check:
                 highlighted_option = file_list.highlighted_option
+                # TODO: The `file_list.highlighted_option` is modified at runtime
+                # and does not match the type checking.
+                # In `test_new_button` case, it becomes a `textual.widgets._selection_list.Selection` object
+                # instead of `FileListSelectionWidget`.
+                # It should be fixed to avoid surpising bug.
                 if highlighted_option is not None and isinstance(
-                    getattr(highlighted_option, "dir_entry", None), DirEntryType
+                    getattr(highlighted_option, "dir_entry", None), os.DirEntry
                 ):
                     highlighted_path = highlighted_option.dir_entry.path
-                    if not path.isdir(highlighted_path):
+                    if not highlighted_option.dir_entry.is_dir():
                         new_highlighted_mtime = None
                         with suppress(OSError):
                             new_highlighted_mtime = path.getmtime(highlighted_path)

--- a/src/rovr/classes/textual_options.py
+++ b/src/rovr/classes/textual_options.py
@@ -183,7 +183,7 @@ class FileListSelectionWidget(LazySelection):
         Args:
             icon_factory: The icon list from a utils function or a lazy icon resolver.
             label: The label for the option.
-            dir_entry: The nt.DirEntry class
+            dir_entry: The os.DirEntry class
             disabled: The initial enabled/disabled state. Enabled by default.
         """
         self.dir_entry = dir_entry

--- a/src/rovr/classes/type_aliases.py
+++ b/src/rovr/classes/type_aliases.py
@@ -1,22 +1,8 @@
-import os
-import sys
 from typing import Literal, TypeAlias, TypedDict
 
 SortByOptions: TypeAlias = Literal[
     "name", "size", "modified", "created", "extension", "natural"
 ]
-
-# windows needs nt, because os.scandir returns
-# nt.DirEntry instead of os.DirEntry on
-# windows. weird, yes, but I can't do anything
-if sys.platform == "win32":
-    import nt
-
-    DirEntryType: TypeAlias = os.DirEntry | nt.DirEntry
-    DirEntryTypes = (os.DirEntry, nt.DirEntry)
-else:
-    DirEntryType: TypeAlias = os.DirEntry
-    DirEntryTypes = os.DirEntry
 
 
 class BarPanicDismissible(TypedDict):

--- a/src/rovr/core/file_list_right_click_menu.py
+++ b/src/rovr/core/file_list_right_click_menu.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from subprocess import Popen
 from typing import ClassVar, Literal
@@ -15,7 +16,6 @@ from rovr.classes.config import (
     _RightClickItemOptionsItem,
 )
 from rovr.classes.textual_options import RightClickMenuOption
-from rovr.classes.type_aliases import DirEntryType
 from rovr.components import PopupOptionList
 from rovr.functions.cwd import getcwd
 from rovr.functions.path import ifed
@@ -42,7 +42,7 @@ async def get_shell_option(
     action = option["action"]["run"]
     action_parts = action if isinstance(action, list) else [action]
     disabled = False
-    dir_entry: DirEntryType | None = getattr(
+    dir_entry: os.DirEntry | None = getattr(
         app.file_list.highlighted_option, "dir_entry", None
     )
     if any("${highlighted_file}" in part for part in action_parts):

--- a/src/rovr/footer/metadata_container.py
+++ b/src/rovr/footer/metadata_container.py
@@ -149,7 +149,7 @@ class MetadataContainer(VerticalScroll, inherit_bindings=False):
             file_info += self.info_of_dir_entry(dir_entry)
         # got the type, now we follow
         file_stat = dir_entry.stat()
-        is_hidden = is_hidden_file(dir_entry.path)
+        is_hidden = is_hidden_file(dir_entry)
 
         values_list = []
         for field in config["metadata"]["fields"]:

--- a/src/rovr/functions/path.py
+++ b/src/rovr/functions/path.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import ctypes
 import os
 import re
 import shlex
@@ -22,8 +21,6 @@ from textual.dom import DOMNode
 from rovr import pprint
 from rovr.classes.config import _OpenerIf, _RightClickIf
 from rovr.classes.type_aliases import (
-    DirEntryType,
-    DirEntryTypes,
     SortByOptions,
 )
 from rovr.variables.constants import log_name
@@ -49,62 +46,27 @@ def natsort_cacheless(key: str) -> tuple[str | int, ...]:
     return _natsort(key)
 
 
-if sys.platform == "win32":
-    _GetFileAttributesW = ctypes.windll.kernel32.GetFileAttributesW
-    _GetFileAttributesW.argtypes = [ctypes.c_wchar_p]
-    _GetFileAttributesW.restype = ctypes.c_uint32
+def is_hidden_file(entry: os.DirEntry) -> bool:
+    """Check whether a ``DirEntry`` represents a hidden item.
 
+    Args:
+        entry: A ``DirEntry`` from ``os.scandir``.
 
-@overload
-def is_hidden_file(filepath: str) -> bool: ...
-
-
-@overload
-def is_hidden_file(filepath: DirEntryType) -> bool: ...
-
-
-def is_hidden_file(filepath: str | DirEntryType) -> bool:
-    if not isinstance(filepath, str):
-        if sys.platform == "win32":
-            try:
-                return bool(
-                    filepath.stat(follow_symlinks=False).st_file_attributes
-                    & stat.FILE_ATTRIBUTE_HIDDEN
-                )
-            except OSError:
-                return False
-        if filepath.name.startswith("."):
-            return True
-        if sys.platform == "darwin":
-            try:
-                return bool(
-                    getattr(filepath.stat(follow_symlinks=False), "st_flags", 0)
-                    & getattr(stat, "UF_HIDDEN", 0)
-                )
-            except OSError:
-                return False
+    Returns:
+        ``True`` if the entry is hidden, ``False`` otherwise.
+    """
+    if entry.name.startswith(".") and sys.platform != "win32":
+        return True
+    try:
+        file_stat = entry.stat(follow_symlinks=False)
+    except OSError:
         return False
+
+    if sys.platform == "darwin":
+        return bool(file_stat.st_flags & stat.UF_HIDDEN)
     if sys.platform == "win32":
-        try:
-            attrs = _GetFileAttributesW(filepath)
-            if attrs == 0xFFFFFFFF:  # INVALID_FILE_ATTRIBUTES
-                return False
-            return bool(attrs & 0x02)  # FILE_ATTRIBUTE_HIDDEN
-        except (OSError, AttributeError):
-            return False
-    elif sys.platform == "darwin":
-        # dotfiles should always be hidden, and so should UF_HIDDEN-flagged files
-        name_hidden = path.basename(filepath).startswith(".")
-        try:
-            st = os.stat(filepath, follow_symlinks=False)
-            flag_hidden = bool(
-                getattr(st, "st_flags", 0) & getattr(stat, "UF_HIDDEN", 0)
-            )
-        except OSError:
-            flag_hidden = False
-        return name_hidden or flag_hidden
-    else:
-        return path.basename(filepath).startswith(".")
+        return bool(file_stat.st_file_attributes & stat.FILE_ATTRIBUTE_HIDDEN)
+    return False
 
 
 # insanely scuffed implementation, but it's required due
@@ -247,7 +209,7 @@ def get_filtered_dir_names(cwd: str | bytes, show_hidden: bool = False) -> set[s
 class CWDObjectReturnDict(TypedDict):
     name: str
     icon: Callable[[], tuple[str, str]]
-    dir_entry: DirEntryType
+    dir_entry: os.DirEntry
 
 
 def get_extension_sort_key(file_dict: dict) -> tuple[int, str]:
@@ -350,7 +312,7 @@ def sync_get_cwd_object(
         files: list[CWDObjectReturnDict] = []
 
         for item in entries:
-            if not isinstance(item, DirEntryTypes):
+            if not isinstance(item, os.DirEntry):
                 raise TypeError(f"Expected a DirEntry object but got {type(item)}")
             if not show_hidden and is_hidden_file(item):
                 continue
@@ -535,7 +497,7 @@ def ensure_existing_directory(directory: str) -> str:
     return directory
 
 
-def get_direntry_for(file_path: str) -> DirEntryType | None:
+def get_direntry_for(file_path: str) -> os.DirEntry | None:
     """Get the DirEntry object for a given file path.
 
     Args:
@@ -627,7 +589,7 @@ def ifed(app: App, conditions: _RightClickIf | _OpenerIf) -> bool:
     """
     from fnmatch import fnmatch
 
-    dir_entry: DirEntryType | None = getattr(
+    dir_entry: os.DirEntry | None = getattr(
         app.file_list.highlighted_option, "dir_entry", None
     )
     disabled = False

--- a/src/rovr/navigation_widgets/path_input.py
+++ b/src/rovr/navigation_widgets/path_input.py
@@ -1,5 +1,4 @@
 import os
-import stat
 import sys
 from os import path
 from pathlib import Path
@@ -17,6 +16,7 @@ from rovr.classes.mixins import Action, Actionable
 from rovr.classes.textual_options import PathDropdownItem
 from rovr.functions.cwd import getcwd
 from rovr.functions.icons import get_icon
+from rovr.functions.path import is_hidden_file
 from rovr.functions.utils import check_key
 from rovr.variables.constants import config
 
@@ -29,29 +29,6 @@ def get_subdirectories(parent: str | os.PathLike) -> Generator[os.DirEntry, None
                     yield entry
     except (FileNotFoundError, OSError):
         return
-
-
-def is_dir_entry_hidden(entry: os.DirEntry) -> bool:
-    """Check whether a ``DirEntry`` represents a hidden item.
-
-    Args:
-        entry: A ``DirEntry`` from ``os.scandir``.
-
-    Returns:
-        ``True`` if the entry is hidden, ``False`` otherwise.
-    """
-    if entry.name.startswith(".") and sys.platform != "win32":
-        return True
-    try:
-        file_stat = entry.stat(follow_symlinks=False)
-    except OSError:
-        return False
-
-    if sys.platform == "darwin":
-        return bool(file_stat.st_flags & stat.UF_HIDDEN)
-    if sys.platform == "win32":
-        return bool(file_stat.st_file_attributes & stat.FILE_ATTRIBUTE_HIDDEN)
-    return False
 
 
 def should_exclude_hidden(path_str: str) -> bool:
@@ -126,7 +103,7 @@ def _unix_get_candidates(path_str: str) -> list[DropdownItem]:
     items: list[DropdownItem] = []
     should_filter = should_exclude_hidden(path_str)
     for entry in get_subdirectories(parent):
-        if should_filter and is_dir_entry_hidden(entry):
+        if should_filter and is_hidden_file(entry):
             continue
         items.append(PathDropdownItem(f"{entry.name}/", entry.path))
     items.sort(key=lambda x: x.path.lower())
@@ -191,7 +168,7 @@ def _win_get_candidates(path_str: str) -> list[DropdownItem]:
     items: list[DropdownItem] = []
     should_filter = should_exclude_hidden(path_str)
     for entry in get_subdirectories(parent):
-        if should_filter and is_dir_entry_hidden(entry):
+        if should_filter and is_hidden_file(entry):
             continue
         items.append(PathDropdownItem(f"{entry.name}\\", entry.path))
     items.sort(key=lambda x: x.path.lower())


### PR DESCRIPTION
There are two functions to check if a file is hidden.
I replace the first function with the implementation of the second.

I also remove the import of `nt` module, because it is non-standard, not ever mentioned in https://docs.python.org/3/library/

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Consolidate hidden-file detection into a single DirEntry-based helper and simplify DirEntry typing across the codebase.

Enhancements:
- Replace the generic path-based hidden file checker with a DirEntry-focused is_hidden_file utility used throughout navigation and metadata components.
- Standardize usage on os.DirEntry by removing platform-specific DirEntry type aliases and updating consumers to rely directly on os.DirEntry.
- Clarify type expectations and add a note about runtime mutation of highlighted options in the file list to reduce surprising bugs.

Chores:
- Remove unused ctypes and nt imports and related Windows-specific attribute handling that are no longer needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hidden-file detection across Windows, macOS and Unix-like systems.
  * File listings and navigation now apply consistent hidden-file filtering.
  * Directory handling is more reliable when selecting files and displaying metadata.
* **Documentation**
  * Updated file-selection documentation to accurately describe directory entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->