### PR TITLE
Change keybind for opening sorting popup from 'o' to ',' for sane

### DIFF
--- a/src/rovr/config/keybinds/sane.toml
+++ b/src/rovr/config/keybinds/sane.toml
@@ -78,7 +78,7 @@ copy_to_system_clip = ["s"]
 copy_current_directory = ["u"]
 
 [keybinds.change_sort_order]
-open_popup = ["o"]
+open_popup = [","]
 name = ["a"]
 extension = ["e"]
 natural = ["n"]


### PR DESCRIPTION
<!--describe your pull request-->

This will resolve the exact situation described in #234, where a single button has two values, which went unnoticed for so long. I think the same keyboard shortcut used in vim preset would work just fine for sane.

---

by submitting this pull request, i agree that

- [ ] i have run `poe check` to check for any style issues and fixed them
- [ ] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [ ] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [ ] my commits (or at least the pr title) follow the conventional commits format as much as possible

_To be honest, I obviously didn't do any of that for such a small commit._

## Summary by Sourcery

Bug Fixes:
- Resolve conflicting keybinding by assigning a unique shortcut for opening the sorting popup in the sane preset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changed the key used to open the sort-order popup from `o` to `,`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->