### PR TITLE
feat: auto-enter and exit select mode

### DIFF
--- a/docs/src/content/docs/dev/reference/schema.mdx
+++ b/docs/src/content/docs/dev/reference/schema.mdx
@@ -17,35 +17,36 @@ description: config schema humanified
     - [1.10.1. Property `Rovr Config > interface > spinner > oneOf > item 0`](#interface_spinner_oneOf_i0)
     - [1.10.2. Property `Rovr Config > interface > spinner > oneOf > item 1`](#interface_spinner_oneOf_i1)
       - [1.10.2.1. Rovr Config > interface > spinner > oneOf > item 1 > item 1 items](#interface_spinner_oneOf_i1_items)
-  - [1.11. Property `Rovr Config > interface > details_list`](#interface_details_list)
-    - [1.11.1. Rovr Config > interface > details_list > details_list items](#interface_details_list_items)
-      - [1.11.1.1. Property `Rovr Config > interface > details_list > details_list items > type`](#interface_details_list_items_type)
-      - [1.11.1.2. Property `Rovr Config > interface > details_list > details_list items > label`](#interface_details_list_items_label)
-      - [1.11.1.3. Property `Rovr Config > interface > details_list > details_list items > max_length`](#interface_details_list_items_max_length)
-      - [1.11.1.4. Property `Rovr Config > interface > details_list > details_list items > format`](#interface_details_list_items_format)
-  - [1.12. Property `Rovr Config > interface > image_viewer`](#interface_image_viewer)
-    - [1.12.1. Property `Rovr Config > interface > image_viewer > protocol`](#interface_image_viewer_protocol)
-    - [1.12.2. Property `Rovr Config > interface > image_viewer > max_size`](#interface_image_viewer_max_size)
-      - [1.12.2.1. Rovr Config > interface > image_viewer > max_size > max_size items](#interface_image_viewer_max_size_items)
-    - [1.12.3. Property `Rovr Config > interface > image_viewer > resampling`](#interface_image_viewer_resampling)
-  - [1.13. Property `Rovr Config > interface > font_preview`](#interface_font_preview)
-    - [1.13.1. Property `Rovr Config > interface > font_preview > max_size`](#interface_font_preview_max_size)
-      - [1.13.1.1. Rovr Config > interface > font_preview > max_size > max_size items](#interface_font_preview_max_size_items)
-    - [1.13.2. Property `Rovr Config > interface > font_preview > font_size`](#interface_font_preview_font_size)
-  - [1.14. Property `Rovr Config > interface > allow_tab_nav`](#interface_allow_tab_nav)
-  - [1.15. Property `Rovr Config > interface > append_new_tabs`](#interface_append_new_tabs)
-  - [1.16. Property `Rovr Config > interface > double_click_delay`](#interface_double_click_delay)
-  - [1.17. Property `Rovr Config > interface > drive_watcher_frequency`](#interface_drive_watcher_frequency)
-  - [1.18. Property `Rovr Config > interface > clock`](#interface_clock)
-    - [1.18.1. Property `Rovr Config > interface > clock > enabled`](#interface_clock_enabled)
-    - [1.18.2. Property `Rovr Config > interface > clock > align`](#interface_clock_align)
-  - [1.19. Property `Rovr Config > interface > preview_text`](#interface_preview_text)
-    - [1.19.1. Property `Rovr Config > interface > preview_text > error`](#interface_preview_text_error)
-    - [1.19.2. Property `Rovr Config > interface > preview_text > start`](#interface_preview_text_start)
-    - [1.19.3. Property `Rovr Config > interface > preview_text > font_text`](#interface_preview_text_font_text)
-  - [1.20. Property `Rovr Config > interface > compact_mode`](#interface_compact_mode)
-    - [1.20.1. Property `Rovr Config > interface > compact_mode > buttons`](#interface_compact_mode_buttons)
-    - [1.20.2. Property `Rovr Config > interface > compact_mode > panels`](#interface_compact_mode_panels)
+  - [1.11. Property `Rovr Config > interface > allow_auto_select_mode`](#interface_allow_auto_select_mode)
+  - [1.12. Property `Rovr Config > interface > details_list`](#interface_details_list)
+    - [1.12.1. Rovr Config > interface > details_list > details_list items](#interface_details_list_items)
+      - [1.12.1.1. Property `Rovr Config > interface > details_list > details_list items > type`](#interface_details_list_items_type)
+      - [1.12.1.2. Property `Rovr Config > interface > details_list > details_list items > label`](#interface_details_list_items_label)
+      - [1.12.1.3. Property `Rovr Config > interface > details_list > details_list items > max_length`](#interface_details_list_items_max_length)
+      - [1.12.1.4. Property `Rovr Config > interface > details_list > details_list items > format`](#interface_details_list_items_format)
+  - [1.13. Property `Rovr Config > interface > image_viewer`](#interface_image_viewer)
+    - [1.13.1. Property `Rovr Config > interface > image_viewer > protocol`](#interface_image_viewer_protocol)
+    - [1.13.2. Property `Rovr Config > interface > image_viewer > max_size`](#interface_image_viewer_max_size)
+      - [1.13.2.1. Rovr Config > interface > image_viewer > max_size > max_size items](#interface_image_viewer_max_size_items)
+    - [1.13.3. Property `Rovr Config > interface > image_viewer > resampling`](#interface_image_viewer_resampling)
+  - [1.14. Property `Rovr Config > interface > font_preview`](#interface_font_preview)
+    - [1.14.1. Property `Rovr Config > interface > font_preview > max_size`](#interface_font_preview_max_size)
+      - [1.14.1.1. Rovr Config > interface > font_preview > max_size > max_size items](#interface_font_preview_max_size_items)
+    - [1.14.2. Property `Rovr Config > interface > font_preview > font_size`](#interface_font_preview_font_size)
+  - [1.15. Property `Rovr Config > interface > allow_tab_nav`](#interface_allow_tab_nav)
+  - [1.16. Property `Rovr Config > interface > append_new_tabs`](#interface_append_new_tabs)
+  - [1.17. Property `Rovr Config > interface > double_click_delay`](#interface_double_click_delay)
+  - [1.18. Property `Rovr Config > interface > drive_watcher_frequency`](#interface_drive_watcher_frequency)
+  - [1.19. Property `Rovr Config > interface > clock`](#interface_clock)
+    - [1.19.1. Property `Rovr Config > interface > clock > enabled`](#interface_clock_enabled)
+    - [1.19.2. Property `Rovr Config > interface > clock > align`](#interface_clock_align)
+  - [1.20. Property `Rovr Config > interface > preview_text`](#interface_preview_text)
+    - [1.20.1. Property `Rovr Config > interface > preview_text > error`](#interface_preview_text_error)
+    - [1.20.2. Property `Rovr Config > interface > preview_text > start`](#interface_preview_text_start)
+    - [1.20.3. Property `Rovr Config > interface > preview_text > font_text`](#interface_preview_text_font_text)
+  - [1.21. Property `Rovr Config > interface > compact_mode`](#interface_compact_mode)
+    - [1.21.1. Property `Rovr Config > interface > compact_mode > buttons`](#interface_compact_mode_buttons)
+    - [1.21.2. Property `Rovr Config > interface > compact_mode > panels`](#interface_compact_mode_panels)
 - [2. Property `Rovr Config > settings`](#settings)
   - [2.1. Property `Rovr Config > settings > use_recycle_bin`](#settings_use_recycle_bin)
   - [2.2. Property `Rovr Config > settings > right_click`](#settings_right_click)
@@ -449,6 +450,7 @@ description: config schema humanified
 | [scrolloff](#interface_scrolloff)                                     | integer         | The number of files to keep above and below the cursor when moving through the file list.                                                                                                                        |
 | [show_hidden_files](#interface_show_hidden_files)                     | boolean         | Show hidden files and folders (those starting with a dot on Unix, or explicitly hidden on Windows/MacOS).                                                                                                        |
 | [spinner](#interface_spinner)                                         | Combination     | The spinner to use when loading files. Can be a string or an array of strings for a custom spinner.                                                                                                              |
+| [allow_auto_select_mode](#interface_allow_auto_select_mode)           | boolean         | Automatically enter select mode if you use shift+arrow keys to extend selection, and disable when there is only one selected left.                                                                               |
 | [details_list](#interface_details_list)                               | array of object | Metadata columns shown right-aligned in the file list, ordered by priority.<br />Earlier entries are dropped last when the panel becomes too narrow;<br />later entries are dropped first. Set to [] to disable. |
 | [image_viewer](#interface_image_viewer)                               | object          | Settings related to the image viewer used in the preview sidebar                                                                                                                                                 |
 | [font_preview](#interface_font_preview)                               | object          | Settings related to the font preview used in the preview sidebar                                                                                                                                                 |
@@ -605,7 +607,17 @@ Not properly hot-reloaded.
 | **Type**     | `string` |
 | **Required** | No       |
 
-### <a name="interface_details_list"></a>1.11. Property `Rovr Config > interface > details_list`
+### <a name="interface_allow_auto_select_mode"></a>1.11. Property `Rovr Config > interface > allow_auto_select_mode`
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+| **Default**  | `true`    |
+
+**Description:** Automatically enter select mode if you use shift+arrow keys to extend selection, and disable when there is only one selected left.
+
+### <a name="interface_details_list"></a>1.12. Property `Rovr Config > interface > details_list`
 
 |              |                   |
 | ------------ | ----------------- |
@@ -629,7 +641,7 @@ later entries are dropped first. Set to [] to disable.
 | --------------------------------------------------- | ----------- |
 | [details_list items](#interface_details_list_items) |             |
 
-#### <a name="interface_details_list_items"></a>1.11.1. Rovr Config > interface > details_list > details_list items
+#### <a name="interface_details_list_items"></a>1.12.1. Rovr Config > interface > details_list > details_list items
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -644,7 +656,7 @@ later entries are dropped first. Set to [] to disable.
 | [max_length](#interface_details_list_items_max_length) | integer          | Column width cap in cells. Defaults to the natural width of the type.<br />The label's width acts as a lower bound.                                                                                             |
 | [format](#interface_details_list_items_format)         | string           | strftime format for mtime/atime/ctime columns.<br />Defaults to metadata.datetime_format.                                                                                                                       |
 
-##### <a name="interface_details_list_items_type"></a>1.11.1.1. Property `Rovr Config > interface > details_list > details_list items > type`
+##### <a name="interface_details_list_items_type"></a>1.12.1.1. Property `Rovr Config > interface > details_list > details_list items > type`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -666,7 +678,7 @@ Must be one of:
 - "group"
 - "git"
 
-##### <a name="interface_details_list_items_label"></a>1.11.1.2. Property `Rovr Config > interface > details_list > details_list items > label`
+##### <a name="interface_details_list_items_label"></a>1.12.1.2. Property `Rovr Config > interface > details_list > details_list items > label`
 
 |              |          |
 | ------------ | -------- |
@@ -675,7 +687,7 @@ Must be one of:
 
 **Description:** Column header label. Defaults to a built-in label for the type.
 
-##### <a name="interface_details_list_items_max_length"></a>1.11.1.3. Property `Rovr Config > interface > details_list > details_list items > max_length`
+##### <a name="interface_details_list_items_max_length"></a>1.12.1.3. Property `Rovr Config > interface > details_list > details_list items > max_length`
 
 |              |           |
 | ------------ | --------- |
@@ -689,7 +701,7 @@ The label's width acts as a lower bound.
 | ------------ | ------ |
 | **Minimum**  | &ge; 1 |
 
-##### <a name="interface_details_list_items_format"></a>1.11.1.4. Property `Rovr Config > interface > details_list > details_list items > format`
+##### <a name="interface_details_list_items_format"></a>1.12.1.4. Property `Rovr Config > interface > details_list > details_list items > format`
 
 |              |          |
 | ------------ | -------- |
@@ -699,7 +711,7 @@ The label's width acts as a lower bound.
 **Description:** strftime format for mtime/atime/ctime columns.
 Defaults to metadata.datetime_format.
 
-### <a name="interface_image_viewer"></a>1.12. Property `Rovr Config > interface > image_viewer`
+### <a name="interface_image_viewer"></a>1.13. Property `Rovr Config > interface > image_viewer`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -715,7 +727,7 @@ Defaults to metadata.datetime_format.
 | [max_size](#interface_image_viewer_max_size)     | array of integer | The maximum size for the image viewer. If the image exceeds this size, it will be scaled down to fit within these dimensions while maintaining its aspect ratio. |
 | [resampling](#interface_image_viewer_resampling) | enum (of string) | The resampling method to use when resizing images. This is only applicable when the image exceeds the maximum size specified in \`max_size\`.                    |
 
-#### <a name="interface_image_viewer_protocol"></a>1.12.1. Property `Rovr Config > interface > image_viewer > protocol`
+#### <a name="interface_image_viewer_protocol"></a>1.13.1. Property `Rovr Config > interface > image_viewer > protocol`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -734,7 +746,7 @@ Must be one of:
 - "Halfcell"
 - "Unicode"
 
-#### <a name="interface_image_viewer_max_size"></a>1.12.2. Property `Rovr Config > interface > image_viewer > max_size`
+#### <a name="interface_image_viewer_max_size"></a>1.13.2. Property `Rovr Config > interface > image_viewer > max_size`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -756,7 +768,7 @@ Must be one of:
 | -------------------------------------------------------- | ----------- |
 | [max_size items](#interface_image_viewer_max_size_items) |             |
 
-##### <a name="interface_image_viewer_max_size_items"></a>1.12.2.1. Rovr Config > interface > image_viewer > max_size > max_size items
+##### <a name="interface_image_viewer_max_size_items"></a>1.13.2.1. Rovr Config > interface > image_viewer > max_size > max_size items
 
 |              |           |
 | ------------ | --------- |
@@ -767,7 +779,7 @@ Must be one of:
 | ------------ | ------ |
 | **Minimum**  | &ge; 1 |
 
-#### <a name="interface_image_viewer_resampling"></a>1.12.3. Property `Rovr Config > interface > image_viewer > resampling`
+#### <a name="interface_image_viewer_resampling"></a>1.13.3. Property `Rovr Config > interface > image_viewer > resampling`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -786,7 +798,7 @@ Must be one of:
 - "bicubic"
 - "lanczos"
 
-### <a name="interface_font_preview"></a>1.13. Property `Rovr Config > interface > font_preview`
+### <a name="interface_font_preview"></a>1.14. Property `Rovr Config > interface > font_preview`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -801,7 +813,7 @@ Must be one of:
 | [max_size](#interface_font_preview_max_size)   | array of integer | The maximum size for the font preview. If the rendered font preview exceeds this size, it will be scaled down to fit within these dimensions while maintaining its aspect ratio. |
 | [font_size](#interface_font_preview_font_size) | integer          | The font size to use when rendering font previews. This is only applicable when the font preview exceeds the maximum size specified in \`max_size\`.                             |
 
-#### <a name="interface_font_preview_max_size"></a>1.13.1. Property `Rovr Config > interface > font_preview > max_size`
+#### <a name="interface_font_preview_max_size"></a>1.14.1. Property `Rovr Config > interface > font_preview > max_size`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -823,7 +835,7 @@ Must be one of:
 | -------------------------------------------------------- | ----------- |
 | [max_size items](#interface_font_preview_max_size_items) |             |
 
-##### <a name="interface_font_preview_max_size_items"></a>1.13.1.1. Rovr Config > interface > font_preview > max_size > max_size items
+##### <a name="interface_font_preview_max_size_items"></a>1.14.1.1. Rovr Config > interface > font_preview > max_size > max_size items
 
 |              |           |
 | ------------ | --------- |
@@ -834,7 +846,7 @@ Must be one of:
 | ------------ | ------ |
 | **Minimum**  | &ge; 1 |
 
-#### <a name="interface_font_preview_font_size"></a>1.13.2. Property `Rovr Config > interface > font_preview > font_size`
+#### <a name="interface_font_preview_font_size"></a>1.14.2. Property `Rovr Config > interface > font_preview > font_size`
 
 |              |           |
 | ------------ | --------- |
@@ -844,7 +856,7 @@ Must be one of:
 
 **Description:** The font size to use when rendering font previews. This is only applicable when the font preview exceeds the maximum size specified in `max_size`.
 
-### <a name="interface_allow_tab_nav"></a>1.14. Property `Rovr Config > interface > allow_tab_nav`
+### <a name="interface_allow_tab_nav"></a>1.15. Property `Rovr Config > interface > allow_tab_nav`
 
 |              |           |
 | ------------ | --------- |
@@ -854,7 +866,7 @@ Must be one of:
 
 **Description:** Allow navigating the main app screen with `tab` and `shift+tab`
 
-### <a name="interface_append_new_tabs"></a>1.15. Property `Rovr Config > interface > append_new_tabs`
+### <a name="interface_append_new_tabs"></a>1.16. Property `Rovr Config > interface > append_new_tabs`
 
 |              |           |
 | ------------ | --------- |
@@ -866,7 +878,7 @@ Must be one of:
 `true` =&gt; Append to the end of the tab list.
 `false` =&gt; Insert after the active tab.
 
-### <a name="interface_double_click_delay"></a>1.16. Property `Rovr Config > interface > double_click_delay`
+### <a name="interface_double_click_delay"></a>1.17. Property `Rovr Config > interface > double_click_delay`
 
 |              |          |
 | ------------ | -------- |
@@ -876,7 +888,7 @@ Must be one of:
 
 **Description:** The delay between two consecutive clicks to enter into a directory, or open a file.
 
-### <a name="interface_drive_watcher_frequency"></a>1.17. Property `Rovr Config > interface > drive_watcher_frequency`
+### <a name="interface_drive_watcher_frequency"></a>1.18. Property `Rovr Config > interface > drive_watcher_frequency`
 
 |              |          |
 | ------------ | -------- |
@@ -886,7 +898,7 @@ Must be one of:
 
 **Description:** How often (in seconds) to check for changes in mounted drives in the sidebar.
 
-### <a name="interface_clock"></a>1.18. Property `Rovr Config > interface > clock`
+### <a name="interface_clock"></a>1.19. Property `Rovr Config > interface > clock`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -899,7 +911,7 @@ Must be one of:
 | [enabled](#interface_clock_enabled) | boolean          | Show a clock in the tabs bar.                                    |
 | [align](#interface_clock_align)     | enum (of string) | Align the clock to either the 'right' or 'left' of the tabs bar. |
 
-#### <a name="interface_clock_enabled"></a>1.18.1. Property `Rovr Config > interface > clock > enabled`
+#### <a name="interface_clock_enabled"></a>1.19.1. Property `Rovr Config > interface > clock > enabled`
 
 |              |           |
 | ------------ | --------- |
@@ -909,7 +921,7 @@ Must be one of:
 
 **Description:** Show a clock in the tabs bar.
 
-#### <a name="interface_clock_align"></a>1.18.2. Property `Rovr Config > interface > clock > align`
+#### <a name="interface_clock_align"></a>1.19.2. Property `Rovr Config > interface > clock > align`
 
 |              |                    |
 | ------------ | ------------------ |
@@ -924,7 +936,7 @@ Must be one of:
 - "left"
 - "right"
 
-### <a name="interface_preview_text"></a>1.19. Property `Rovr Config > interface > preview_text`
+### <a name="interface_preview_text"></a>1.20. Property `Rovr Config > interface > preview_text`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -938,7 +950,7 @@ Must be one of:
 | [start](#interface_preview_text_start)         | string | This is shown when the rovr starts up. You may see it for a split second, but it will never appear afterwards. You cannot view this properly in this docs. |
 | [font_text](#interface_preview_text_font_text) | string | When a font file is previewed, this text will be rendered in the font if possible.                                                                         |
 
-#### <a name="interface_preview_text_error"></a>1.19.1. Property `Rovr Config > interface > preview_text > error`
+#### <a name="interface_preview_text_error"></a>1.20.1. Property `Rovr Config > interface > preview_text > error`
 
 |              |                                     |
 | ------------ | ----------------------------------- |
@@ -948,7 +960,7 @@ Must be one of:
 
 **Description:** If for any reason the file preview refused to show, this appears.
 
-#### <a name="interface_preview_text_start"></a>1.19.2. Property `Rovr Config > interface > preview_text > start`
+#### <a name="interface_preview_text_start"></a>1.20.2. Property `Rovr Config > interface > preview_text > start`
 
 |              |                                                                                                                                      |
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
@@ -958,7 +970,7 @@ Must be one of:
 
 **Description:** This is shown when the rovr starts up. You may see it for a split second, but it will never appear afterwards. You cannot view this properly in this docs.
 
-#### <a name="interface_preview_text_font_text"></a>1.19.3. Property `Rovr Config > interface > preview_text > font_text`
+#### <a name="interface_preview_text_font_text"></a>1.20.3. Property `Rovr Config > interface > preview_text > font_text`
 
 |              |                                                                                                                            |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------- |
@@ -968,7 +980,7 @@ Must be one of:
 
 **Description:** When a font file is previewed, this text will be rendered in the font if possible.
 
-### <a name="interface_compact_mode"></a>1.20. Property `Rovr Config > interface > compact_mode`
+### <a name="interface_compact_mode"></a>1.21. Property `Rovr Config > interface > compact_mode`
 
 |                           |             |
 | ------------------------- | ----------- |
@@ -981,7 +993,7 @@ Must be one of:
 | [buttons](#interface_compact_mode_buttons) | boolean | Whether to compact the buttons and path input to one line instead of three.  |
 | [panels](#interface_compact_mode_panels)   | boolean | Whether to make the panels smaller to add more room for the file list itself |
 
-#### <a name="interface_compact_mode_buttons"></a>1.20.1. Property `Rovr Config > interface > compact_mode > buttons`
+#### <a name="interface_compact_mode_buttons"></a>1.21.1. Property `Rovr Config > interface > compact_mode > buttons`
 
 |              |           |
 | ------------ | --------- |
@@ -991,7 +1003,7 @@ Must be one of:
 
 **Description:** Whether to compact the buttons and path input to one line instead of three.
 
-#### <a name="interface_compact_mode_panels"></a>1.20.2. Property `Rovr Config > interface > compact_mode > panels`
+#### <a name="interface_compact_mode_panels"></a>1.21.2. Property `Rovr Config > interface > compact_mode > panels`
 
 |              |           |
 | ------------ | --------- |

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -1164,7 +1164,7 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
 
         from pathlib import Path
 
-        if not self.file_list.select_mode_enabled:
+        if not self.file_list.select_mode:
             await self.file_list._on_click(
                 events.Click(
                     widget=self.file_list,

--- a/src/rovr/classes/config.pyi
+++ b/src/rovr/classes/config.pyi
@@ -81,6 +81,9 @@ r""" Default value of the field path 'Rovr Config icons files' """
 _ROVR_CONFIG_ICONS_FOLDERS_DEFAULT: list[Any] = []
 r""" Default value of the field path 'Rovr Config icons folders' """
 
+_ROVR_CONFIG_INTERFACE_ALLOW_AUTO_SELECT_MODE_DEFAULT = True
+r""" Default value of the field path 'Rovr Config interface allow_auto_select_mode' """
+
 _ROVR_CONFIG_INTERFACE_ALLOW_TAB_NAV_DEFAULT = False
 r""" Default value of the field path 'Rovr Config interface allow_tab_nav' """
 
@@ -634,6 +637,13 @@ class _RovrConfigInterface(TypedDict, total=False):
     default: ⣾⣽⣻⢿⡿⣟⣯⣷
 
     Aggregation type: oneOf
+    """
+
+    allow_auto_select_mode: bool
+    r"""
+    Automatically enter select mode if you use shift+arrow keys to extend selection, and disable when there is only one selected left.
+
+    default: True
     """
 
     details_list: list["_RovrConfigInterfaceDetailsListItem"]

--- a/src/rovr/classes/mixins.py
+++ b/src/rovr/classes/mixins.py
@@ -295,7 +295,10 @@ class CheckboxRenderingMixin:
 
 class ScrollOffMixin:
     def scroll_to_highlight(
-        self, top: bool = False, scrolloff: int = config["interface"]["scrolloff"]
+        self,
+        top: bool = False,
+        scrolloff: int = config["interface"]["scrolloff"],
+        immediate: bool = True,
     ) -> None:
         """Scroll to the highlighted option.
 
@@ -303,6 +306,7 @@ class ScrollOffMixin:
             top: Ensure highlighted option is at the top of the widget.
             scrolloff: Minimum number of lines to keep visible above/below the highlighted option.
                 If scrolloff is larger than half the screen height, the cursor will be centered.
+            immediate: If True, scroll immediately without animation.
         """
         highlighted = self.highlighted
         if type(highlighted) is not int or not self.is_mounted:
@@ -326,7 +330,7 @@ class ScrollOffMixin:
                 force=True,
                 animate=False,
                 center=True,
-                immediate=True,
+                immediate=immediate,
             )
         else:
             adjusted_y = max(0, y - scrolloff)
@@ -339,7 +343,7 @@ class ScrollOffMixin:
                 force=True,
                 animate=False,
                 top=top,
-                immediate=True,
+                immediate=immediate,
             )
 
 

--- a/src/rovr/classes/mixins.py
+++ b/src/rovr/classes/mixins.py
@@ -179,9 +179,7 @@ class CheckboxRenderingMixin:
         Returns:
             The width of the left gutter.
         """
-        if getattr(self, "dummy", False) or not getattr(
-            self, "select_mode_enabled", True
-        ):
+        if getattr(self, "dummy", False) or not getattr(self, "select_mode", True):
             return 0
 
         icons = [
@@ -246,9 +244,7 @@ class CheckboxRenderingMixin:
             A Strip that is the line to render.
         """
         # Check if we should render checkboxes
-        if getattr(self, "dummy", False) or not getattr(
-            self, "select_mode_enabled", True
-        ):
+        if getattr(self, "dummy", False) or not getattr(self, "select_mode", True):
             return self.super_render_line(y)
 
         # Base line rendering

--- a/src/rovr/classes/session_manager.py
+++ b/src/rovr/classes/session_manager.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict, deque
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 from rovr.variables.constants import config
 
@@ -37,7 +37,7 @@ class SessionManager:
         self.directories: deque[str] = deque(maxlen=config["settings"]["history_size"])
         self.historyIndex: int = 0
         self.lastHighlighted: OrderedDict[str, SessionOptionDict] = OrderedDict()
-        self.selectMode: bool = False
+        self.selectMode: Literal[False, "implicit", "explicit"] = False
         self.selectedItems: list[SessionOptionDict] = []
         self.search: str = ""
 

--- a/src/rovr/classes/session_manager.py
+++ b/src/rovr/classes/session_manager.py
@@ -27,7 +27,7 @@ class SessionManager:
                                  `settings.history_size` entries (least-recently-used
                                  eviction). If a directory is not in the dictionary, the
                                  default is 0. Use `remember_highlight` to write to it.
-        selectMode (bool): Whether select mode is enabled for that directory.
+        selectMode (False | "implicit" | "explicit"): Whether select mode is enabled for that directory.
         selectedItems (list[SessionOptionDict]): A list of selected items within the
                                                                       current directory
         search (str): The current search string.

--- a/src/rovr/components/search_container.py
+++ b/src/rovr/components/search_container.py
@@ -57,7 +57,7 @@ class SearchInput(Input):
             if self.item_list_type == "Selection":
                 for option_id in self.selected:
                     with contextlib.suppress(OptionDoesNotExist):
-                        if not self.items_list.select_mode_enabled:
+                        if not self.items_list.select_mode:
                             with self.items_list.prevent(
                                 self.items_list.SelectedChanged
                             ):
@@ -114,7 +114,7 @@ class SearchInput(Input):
                 assert self.items_list.parent is not None
                 set_scuffed_subtitle(
                     self.items_list.parent,
-                    "SELECT" if self.items_list.select_mode_enabled else "NORMAL",
+                    "SELECT" if self.items_list.select_mode else "NORMAL",
                     "0/0",
                 )
         if self.items_list.highlighted is None:
@@ -130,7 +130,7 @@ class SearchInput(Input):
         if self.item_list_type == "Selection":
             for option_id in self.selected:
                 with contextlib.suppress(OptionDoesNotExist):
-                    if not self.items_list.select_mode_enabled:
+                    if not self.items_list.select_mode:
                         with self.items_list.prevent(self.items_list.SelectedChanged):
                             self.items_list.select(
                                 self.items_list.get_option(option_id)

--- a/src/rovr/config/schema.json
+++ b/src/rovr/config/schema.json
@@ -266,6 +266,11 @@
           "description": "The spinner to use when loading files. Can be a string or an array of strings for a custom spinner.",
           "default": "⣾⣽⣻⢿⡿⣟⣯⣷"
         },
+        "allow_auto_select_mode": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically enter select mode if you use shift+arrow keys to extend selection, and disable when there is only one selected left."
+        },
         "details_list": {
           "type": "array",
           "default": [],

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -973,7 +973,7 @@ class FileList(
             or (
                 ver == "post"
                 and self.select_mode == "implicit"
-                and len(self.selected) <= 1
+                and len(self.selected) <= 0
             )
         ):
             await self.toggle_mode("implicit")

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -678,17 +678,7 @@ class FileList(
         if self.highlighted is None:
             self.highlighted = 0
         # update tracked mtime for the watcher
-        try:
-            is_file = highlighted_option.dir_entry.is_file()
-        except OSError:
-            is_file = False
-        if is_file:
-            with suppress(OSError):
-                self.app._highlighted_file_mtime = (
-                    highlighted_option.dir_entry.stat().st_mtime
-                )
-        else:
-            self.app._highlighted_file_mtime = None
+        self.call_after_refresh(self.set_mtime, highlighted_option)
         # preview
         self.app.query_one("MetadataContainer").update_metadata(
             event.option.dir_entry, event.option
@@ -705,6 +695,16 @@ class FileList(
             )
             return
         self.app.query_one("#unzip").update_state(highlighted_option.dir_entry.path)
+
+    @work(thread=True)
+    def set_mtime(self, option: FileListSelectionWidget) -> None:
+        """Set the mtime of the highlighted option for watcher purposes."""
+        if self.dummy:
+            return
+        with suppress(OSError):
+            mtime = option.dir_entry.stat().st_mtime
+            if option == self.highlighted_option:
+                self.call_next(setattr, self.app, "_highlighted_file_mtime", mtime)
 
     @property
     def options(self) -> Sequence[FileListSelectionWidget]:
@@ -980,18 +980,17 @@ class FileList(
 
     async def action_select_up(self) -> None:
         """Select the current and previous file."""
-        if self.highlighted_option and (not self.get_option_at_index(0).disabled):
+        if self.highlighted is not None and (not self.get_option_at_index(0).disabled):
             await self.implicit_selector("pre")
             if self.highlighted == 0:
                 self.select(self.get_option_at_index(0))
             else:
-                self.select(self.highlighted_option)
+                await self.select_range(self.highlighted - 1, self.highlighted)
                 self.action_cursor_up()
-                self.select(self.highlighted_option)
 
     async def action_select_down(self) -> None:
         """Select the current and next file."""
-        if self.highlighted and (not self.get_option_at_index(0).disabled):
+        if self.highlighted is not None and (not self.get_option_at_index(0).disabled):
             await self.implicit_selector("pre")
             if self.highlighted == len(self.options) - 1:
                 self.select(self.get_option_at_index(self.option_count - 1))

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -641,17 +641,14 @@ class FileList(
                 self.highlighted = 0
             self.app.tabWidget.active_tab.selectedItems = []
         else:
-            selected_ids = self.selected.copy()
             session: SessionManager = self.app.tabWidget.active_tab.session
+            selected_ids = set(self.selected)
+            session.selectedItems = [
+                {"name": option.dir_entry.name, "index": index}
+                for index, option in enumerate(self.options)
+                if option.value in selected_ids
+            ]
             session.selectedItems = []
-            for selected_id in selected_ids:
-                option = self.get_option(selected_id)
-                if not isinstance(option, FileListSelectionWidget):
-                    continue
-                session.selectedItems.append({
-                    "name": option.dir_entry.name,
-                    "index": self.options.index(option),
-                })
 
     # No clue why I'm using an OptionList method for SelectionList
     async def on_option_list_option_highlighted(
@@ -667,7 +664,7 @@ class FileList(
         if not isinstance(event.option, FileListSelectionWidget):
             return
         if self.app._on_mount_done:
-            self.update_border_subtitle()
+            self.call_next(self.update_border_subtitle)
         else:
             self.call_after_refresh(self.update_border_subtitle)
         # Get the highlighted option
@@ -960,6 +957,15 @@ class FileList(
             else:
                 self.select_all()
 
+    async def select_range(self, start: int, end: int) -> None:
+        """Select a range of options from start to end."""
+        if self.get_option_at_index(0).disabled:
+            return
+        first, last = sorted((start, end))
+        for index in range(first, last + 1):
+            self._selected[self._options[index].value] = None
+        self._message_changed()
+
     async def implicit_selector(self, ver: Literal["pre", "post"]) -> None:
         """Select the current item in implicit mode."""
         if config["interface"]["allow_auto_select_mode"] and (
@@ -985,66 +991,49 @@ class FileList(
 
     async def action_select_down(self) -> None:
         """Select the current and next file."""
-        if self.highlighted_option and (not self.get_option_at_index(0).disabled):
+        if self.highlighted and (not self.get_option_at_index(0).disabled):
             await self.implicit_selector("pre")
             if self.highlighted == len(self.options) - 1:
                 self.select(self.get_option_at_index(self.option_count - 1))
             else:
-                self.select(self.highlighted_option)
+                await self.select_range(self.highlighted, self.highlighted + 1)
                 self.action_cursor_down()
-                self.select(self.highlighted_option)
 
     async def action_select_page_up(self) -> None:
         """Select the options between the current and the previous 'page'."""
         if self.highlighted_option and (not self.get_option_at_index(0).disabled):
             await self.implicit_selector("pre")
-            old = self.highlighted
+            old = self.highlighted or 0
             self.action_page_up()
-            new = self.highlighted
-            old = 0 if old is None else old
-            new = 0 if new is None else new
-            assert isinstance(old, int) and isinstance(new, int)
-            for index in range(new, old + 1):
-                self.select(self.get_option_at_index(index))
+            new = self.highlighted or 0
+            await self.select_range(new, old)
 
     async def action_select_page_down(self) -> None:
         """Select the options between the current and the next 'page'."""
         if self.highlighted_option and (not self.get_option_at_index(0).disabled):
             await self.implicit_selector("pre")
-            old = self.highlighted
+            old = self.highlighted or 0
             self.action_page_down()
-            new = self.highlighted
-            old = 0 if old is None else old
-            new = 0 if new is None else new
-            assert isinstance(old, int) and isinstance(new, int)
-            for index in range(old, new + 1):
-                self.select(self.get_option_at_index(index))
+            new = self.highlighted or 0
+            await self.select_range(old, new)
 
     async def action_select_home(self) -> None:
         """Select the options between the current and the first option"""
         if self.highlighted_option and (not self.get_option_at_index(0).disabled):
             await self.implicit_selector("pre")
-            old = self.highlighted
+            old = self.highlighted or 0
             self.action_first()
-            new = self.highlighted
-            old = 0 if old is None else old
-            new = 0 if new is None else new
-            assert isinstance(old, int) and isinstance(new, int)
-            for index in range(new, old + 1):
-                self.select(self.get_option_at_index(index))
+            new = self.highlighted or 0
+            await self.select_range(new, old)
 
     async def action_select_end(self) -> None:
         """Select the options between the current and the last option"""
         if self.highlighted_option and (not self.get_option_at_index(0).disabled):
             await self.implicit_selector("pre")
-            old = self.highlighted
+            old = self.highlighted or 0
             self.action_last()
-            new = self.highlighted
-            old = 0 if old is None else old
-            new = 0 if new is None else new
-            assert isinstance(old, int) and isinstance(new, int)
-            for index in range(old, new + 1):
-                self.select(self.get_option_at_index(index))
+            new = self.highlighted or 0
+            await self.select_range(old, new)
 
     def action_select(self) -> None:
         super().action_select()
@@ -1066,19 +1055,20 @@ class FileList(
             return
         cwd = path_utils.normalise(getcwd())
         if self.select_mode:
-            selected_ids = self.selected.copy()
             session = self.app.tabWidget.active_tab.session
             session.selectedItems = []
             paths_to_open = []
+            selected_ids = set(self.selected)
+            session.selectedItems = [
+                {"name": option.dir_entry.name, "index": index}
+                for index, option in enumerate(self.options)
+                if option.value in selected_ids
+            ]
             for selected_id in selected_ids:
                 option = self.get_option(selected_id)
+                full_path = path.join(cwd, option.dir_entry.name)
                 if not isinstance(option, FileListSelectionWidget):
                     continue
-                session.selectedItems.append({
-                    "name": option.dir_entry.name,
-                    "index": self.options.index(option),
-                })
-                full_path = path.join(cwd, option.dir_entry.name)
                 if path.isdir(full_path):
                     self.app.cd(full_path, clear_search=True)
                 else:

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -648,7 +648,6 @@ class FileList(
                 for index, option in enumerate(self.options)
                 if option.value in selected_ids
             ]
-            session.selectedItems = []
 
     # No clue why I'm using an OptionList method for SelectionList
     async def on_option_list_option_highlighted(
@@ -711,7 +710,7 @@ class FileList(
         return self._options
 
     async def toggle_mode(
-        self, type: Literal["implicit", "explicit"] = "explicit"
+        self, type: Literal["implicit", "explicit"] | None = "explicit"
     ) -> None:
         """Toggle the selection mode between select and normal."""
         if (
@@ -720,10 +719,11 @@ class FileList(
             and not self.select_mode
         ):
             return
-        if self.select_mode:
-            self.select_mode = False
-        else:
-            self.select_mode = type
+        if type is not None:
+            if self.select_mode:
+                self.select_mode = False
+            else:
+                self.select_mode = type
         self._line_cache.clear()
         self._option_render_cache.clear()
         self.refresh(layout=True, repaint=True)
@@ -1040,7 +1040,11 @@ class FileList(
 
     async def action_toggle_select_item(self) -> None:
         """Toggle selection of the currently highlighted item in visual mode."""
-        if self.highlighted_option and (not self.get_option_at_index(0).disabled):
+        if (
+            self.select_mode
+            and self.highlighted_option
+            and (not self.get_option_at_index(0).disabled)
+        ):
             self.action_select()
 
     async def action_open(self) -> None:

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -1,7 +1,7 @@
 import shlex
 from contextlib import suppress
 from os import path, scandir
-from typing import Callable, ClassVar, Sequence
+from typing import Callable, ClassVar, Literal, Sequence
 
 from rich.segment import Segment
 from textual import events, work
@@ -126,7 +126,6 @@ class FileList(
         self,
         dummy: bool = False,
         enter_into: str = "",
-        select: bool = False,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
@@ -137,13 +136,12 @@ class FileList(
         Args:
             dummy (bool): Whether this is a dummy file list.
             enter_into (str): The path to enter into when a folder is selected.
-            select (bool): Whether the selection is select or normal.
         """
         super().__init__(name=name, id=id, classes=classes, disabled=disabled)
         self._options: list[FileListSelectionWidget] = []
         self.dummy = dummy
         self.enter_into = enter_into
-        self.select_mode_enabled = select
+        self.select_mode: Literal[False, "implicit", "explicit"] = False
         if not self.dummy:
             self.items_in_cwd: set[str] = set()
         self.file_list_pause_check = False
@@ -331,7 +329,7 @@ class FileList(
                 and event.button != 3
             ):
                 self.action_select()
-            elif self.select_mode_enabled and event.button != 3:
+            elif self.select_mode and event.button != 3:
                 self.highlighted = clicked_option
                 self.action_select()
             else:
@@ -482,7 +480,7 @@ class FileList(
             if callable(update_header):
                 self.call_after_refresh(update_header)
             # fix selected options
-            if (has_selected or self.select_mode_enabled) and name_to_index:
+            if (has_selected or self.select_mode) and name_to_index:
                 self.update_from_session(session, name_to_index)
             # session handler
             self.app.query_one("#path_switcher", PathInput).value = cwd + (
@@ -542,7 +540,7 @@ class FileList(
             if not add_to_session:
                 self.input.clear_selected()
             if self.list_of_options[0].disabled:  # special option
-                if self.select_mode_enabled:
+                if self.select_mode:
                     await self.toggle_mode()
                 self.update_border_subtitle()
         finally:
@@ -633,7 +631,7 @@ class FileList(
                 if self.highlighted is None:
                     self.highlighted = 0
                 self.app.tabWidget.active_tab.selectedItems = []
-        elif not self.select_mode_enabled:
+        elif not self.select_mode:
             full_path = path.join(cwd, file_name)
             if path.isdir(full_path):
                 self.app.cd(full_path, clear_search=True)
@@ -715,23 +713,28 @@ class FileList(
     def options(self) -> Sequence[FileListSelectionWidget]:
         return self._options
 
-    async def toggle_mode(self) -> None:
+    async def toggle_mode(
+        self, type: Literal["implicit", "explicit"] = "explicit"
+    ) -> None:
         """Toggle the selection mode between select and normal."""
         if (
             self.highlighted_option
             and self.highlighted_option.disabled
-            and not self.select_mode_enabled
+            and not self.select_mode
         ):
             return
-        self.select_mode_enabled = not self.select_mode_enabled
+        if self.select_mode:
+            self.select_mode = False
+        else:
+            self.select_mode = type
         self._line_cache.clear()
         self._option_render_cache.clear()
         self.refresh(layout=True, repaint=True)
-        self.app.tabWidget.active_tab.session.selectMode = self.select_mode_enabled
+        self.app.tabWidget.active_tab.session.selectMode = self.select_mode
         with self.prevent(SelectionList.SelectedChanged):
             self.deselect_all()
         self.update_border_subtitle()
-        if self.select_mode_enabled:
+        if self.select_mode:
             self.add_class("select-mode")
         else:
             self.remove_class("select-mode")
@@ -750,7 +753,7 @@ class FileList(
             and not hasattr(self.get_option_at_index(0), "dir_entry")
         ):
             return
-        if not self.select_mode_enabled:
+        if not self.select_mode:
             return [str(path_utils.normalise(self.highlighted_option.dir_entry.path))]
         else:
             values = self.selected
@@ -786,7 +789,7 @@ class FileList(
             utils.set_scuffed_subtitle(self.parent, "NORMAL", "0/0")
             # tell metadata to die
             self.app.query_one("MetadataContainer").remove_children()
-        elif (not self.select_mode_enabled) or (self.selected is None):
+        elif (not self.select_mode) or (self.selected is None):
             utils.set_scuffed_subtitle(
                 self.parent,
                 "NORMAL",
@@ -802,22 +805,22 @@ class FileList(
     # hist_previous keybind twice too fast, it registers it as once, so
     # there really is no choice, aside from using on_button_pressed :/
     def action_hist_previous(self) -> None:
-        if not self.select_mode_enabled:
+        if not self.select_mode:
             if self.app.query_one("#back").disabled:
                 self.app.query_one("UpButton").on_button_pressed()
             else:
                 self.app.query_one("BackButton").on_button_pressed()
 
     def action_hist_next(self) -> None:
-        if not self.select_mode_enabled and not self.app.query_one("#forward").disabled:
+        if not self.select_mode and not self.app.query_one("#forward").disabled:
             self.app.query_one("ForwardButton").on_button_pressed()
 
     def action_up_tree(self) -> None:
-        if not self.select_mode_enabled:
+        if not self.select_mode:
             self.app.query_one("UpButton").on_button_pressed()
 
     def action_bypass_up_tree(self) -> None:
-        if not self.select_mode_enabled:
+        if not self.select_mode:
             # get parent directory, go up until theres a folder with more than one item
             to_dir = path.dirname(getcwd())
             prev_to_dir = getcwd()
@@ -845,7 +848,7 @@ class FileList(
                 self.app.cd(prev_to_dir, clear_search=True)
 
     def action_bypass_down_tree(self) -> None:
-        if not self.select_mode_enabled:
+        if not self.select_mode:
             highlighted_option = self.highlighted_option
             if highlighted_option is not None:
                 if highlighted_option.dir_entry.is_file():
@@ -950,20 +953,29 @@ class FileList(
         if self.highlighted_option:
             if self.get_option_at_index(0).disabled:
                 return
-            if not self.select_mode_enabled:
+            if not self.select_mode:
                 await self.toggle_mode()
             if len(self.selected) == len(self.options):
                 self.deselect_all()
             else:
                 self.select_all()
 
-    def action_select_up(self) -> None:
-        """Select the current and previous file."""
-        if (
-            self.highlighted_option
-            and self.select_mode_enabled
-            and (not self.get_option_at_index(0).disabled)
+    async def implicit_selector(self, ver: Literal["pre", "post"]) -> None:
+        """Select the current item in implicit mode."""
+        if config["interface"]["allow_auto_select_mode"] and (
+            (ver == "pre" and not self.select_mode)
+            or (
+                ver == "post"
+                and self.select_mode == "implicit"
+                and len(self.selected) <= 1
+            )
         ):
+            await self.toggle_mode("implicit")
+
+    async def action_select_up(self) -> None:
+        """Select the current and previous file."""
+        if self.highlighted_option and (not self.get_option_at_index(0).disabled):
+            await self.implicit_selector("pre")
             if self.highlighted == 0:
                 self.select(self.get_option_at_index(0))
             else:
@@ -971,13 +983,10 @@ class FileList(
                 self.action_cursor_up()
                 self.select(self.highlighted_option)
 
-    def action_select_down(self) -> None:
+    async def action_select_down(self) -> None:
         """Select the current and next file."""
-        if (
-            self.highlighted_option
-            and self.select_mode_enabled
-            and (not self.get_option_at_index(0).disabled)
-        ):
+        if self.highlighted_option and (not self.get_option_at_index(0).disabled):
+            await self.implicit_selector("pre")
             if self.highlighted == len(self.options) - 1:
                 self.select(self.get_option_at_index(self.option_count - 1))
             else:
@@ -985,13 +994,10 @@ class FileList(
                 self.action_cursor_down()
                 self.select(self.highlighted_option)
 
-    def action_select_page_up(self) -> None:
+    async def action_select_page_up(self) -> None:
         """Select the options between the current and the previous 'page'."""
-        if (
-            self.highlighted_option
-            and self.select_mode_enabled
-            and (not self.get_option_at_index(0).disabled)
-        ):
+        if self.highlighted_option and (not self.get_option_at_index(0).disabled):
+            await self.implicit_selector("pre")
             old = self.highlighted
             self.action_page_up()
             new = self.highlighted
@@ -1001,13 +1007,10 @@ class FileList(
             for index in range(new, old + 1):
                 self.select(self.get_option_at_index(index))
 
-    def action_select_page_down(self) -> None:
+    async def action_select_page_down(self) -> None:
         """Select the options between the current and the next 'page'."""
-        if (
-            self.highlighted_option
-            and self.select_mode_enabled
-            and (not self.get_option_at_index(0).disabled)
-        ):
+        if self.highlighted_option and (not self.get_option_at_index(0).disabled):
+            await self.implicit_selector("pre")
             old = self.highlighted
             self.action_page_down()
             new = self.highlighted
@@ -1017,13 +1020,10 @@ class FileList(
             for index in range(old, new + 1):
                 self.select(self.get_option_at_index(index))
 
-    def action_select_home(self) -> None:
+    async def action_select_home(self) -> None:
         """Select the options between the current and the first option"""
-        if (
-            self.highlighted_option
-            and self.select_mode_enabled
-            and (not self.get_option_at_index(0).disabled)
-        ):
+        if self.highlighted_option and (not self.get_option_at_index(0).disabled):
+            await self.implicit_selector("pre")
             old = self.highlighted
             self.action_first()
             new = self.highlighted
@@ -1033,13 +1033,10 @@ class FileList(
             for index in range(new, old + 1):
                 self.select(self.get_option_at_index(index))
 
-    def action_select_end(self) -> None:
+    async def action_select_end(self) -> None:
         """Select the options between the current and the last option"""
-        if (
-            self.highlighted_option
-            and self.select_mode_enabled
-            and (not self.get_option_at_index(0).disabled)
-        ):
+        if self.highlighted_option and (not self.get_option_at_index(0).disabled):
+            await self.implicit_selector("pre")
             old = self.highlighted
             self.action_last()
             new = self.highlighted
@@ -1049,13 +1046,13 @@ class FileList(
             for index in range(old, new + 1):
                 self.select(self.get_option_at_index(index))
 
-    def action_toggle_select_item(self) -> None:
+    def action_select(self) -> None:
+        super().action_select()
+        self.call_later(self.call_later, self.implicit_selector, "post")
+
+    async def action_toggle_select_item(self) -> None:
         """Toggle selection of the currently highlighted item in visual mode."""
-        if (
-            self.highlighted_option
-            and self.select_mode_enabled
-            and (not self.get_option_at_index(0).disabled)
-        ):
+        if self.highlighted_option and (not self.get_option_at_index(0).disabled):
             self.action_select()
 
     async def action_open(self) -> None:
@@ -1064,11 +1061,11 @@ class FileList(
         if (
             self.highlighted_option
             and self.highlighted_option.disabled
-            and not self.select_mode_enabled
+            and not self.select_mode
         ):
             return
         cwd = path_utils.normalise(getcwd())
-        if self.select_mode_enabled:
+        if self.select_mode:
             selected_ids = self.selected.copy()
             session = self.app.tabWidget.active_tab.session
             session.selectedItems = []

--- a/src/rovr/header/tabs.py
+++ b/src/rovr/header/tabs.py
@@ -153,7 +153,7 @@ class Tabline(Tabs):
         def callback() -> None:
             assert isinstance(event.tab, TablineTab)
             assert isinstance(self.app.file_list.input, Input)
-            self.app.file_list.select_mode_enabled = event.tab.session.selectMode
+            self.app.file_list.select_mode = event.tab.session.selectMode
             if event.tab.session.search != "":
                 self.app.file_list.input.value = event.tab.session.search
 

--- a/src/rovr/header/tabs.py
+++ b/src/rovr/header/tabs.py
@@ -154,7 +154,7 @@ class Tabline(Tabs):
             assert isinstance(event.tab, TablineTab)
             assert isinstance(self.app.file_list.input, Input)
             self.app.file_list.select_mode = event.tab.session.selectMode
-            self.app.file_list.toggle_mode(None)
+            self.call_next(self.app.file_list.toggle_mode, None)
             if event.tab.session.search != "":
                 self.app.file_list.input.value = event.tab.session.search
 

--- a/src/rovr/header/tabs.py
+++ b/src/rovr/header/tabs.py
@@ -154,6 +154,7 @@ class Tabline(Tabs):
             assert isinstance(event.tab, TablineTab)
             assert isinstance(self.app.file_list.input, Input)
             self.app.file_list.select_mode = event.tab.session.selectMode
+            self.app.file_list.toggle_mode(None)
             if event.tab.session.search != "":
                 self.app.file_list.input.value = event.tab.session.search
 

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -249,7 +249,7 @@ async def test_tab_multiselection(tmp_path: Path) -> None:
         app.tabWidget.action_next_tab()
         await workers_finished(pilot, app.file_list)
 
-        assert app.file_list.select_mode_enabled
+        assert app.file_list.select_mode
         indexes = [0, 2, 4, 7]
         for selected_id in app.file_list.selected:
             assert app.file_list.get_option_index(selected_id) in indexes

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -249,7 +249,7 @@ async def test_tab_multiselection(tmp_path: Path) -> None:
         app.tabWidget.action_next_tab()
         await workers_finished(pilot, app.file_list)
 
-        assert app.file_list.select_mode
+        assert app.file_list.select_mode == "explicit"
         indexes = [0, 2, 4, 7]
         for selected_id in app.file_list.selected:
             assert app.file_list.get_option_index(selected_id) in indexes


### PR DESCRIPTION
also maybe some performance improvements ig idk

## Summary by Sourcery

Introduce an auto-enter/exit select mode for the file list, controlled by configuration and wired through sessions, while refining selection handling and metadata updating.

New Features:
- Add configurable automatic select mode that turns on when extending selection with shift navigation and turns off when only one item remains selected.
- Support distinct implicit and explicit select modes in the file list for more flexible multi-selection behaviour.

Enhancements:
- Refactor selection mode state from a simple boolean to a richer state shared with tab sessions and header tabs.
- Add range-selection helpers for shift+arrow/page/home/end operations to simplify and unify multi-selection logic.
- Update selected item tracking to use set-based lookups and direct session population for better consistency.
- Offload highlighted file mtime computation to a worker and gate it on the current highlighted option to reduce blocking and improve responsiveness.
- Allow scroll-to-highlight behaviour to optionally skip immediate scrolling to better control scrolling animations.

Documentation:
- Extend config schema docs with the new interface.allow_auto_select_mode option, including description and default value, and shift subsequent section numbering accordingly.

Tests:
- Adjust navigation tests to assert against the new select_mode state rather than the old boolean flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic selection mode when extending selections with Shift+Arrow keys.
  * Added the `interface.allow_auto_select_mode` setting, enabled by default, to control this behaviour.
  * Improved range selection across navigation, paging, and Home/End actions.

* **Bug Fixes**
  * Improved selection state consistency when opening files, restoring selections, switching tabs, and refreshing lists.
  * Corrected scrolling behaviour when highlighting items, including support for non-immediate scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->