### PR TITLE
fix(app): refactor to better support chooser file

### DIFF
--- a/docs/src/content/docs/features/cd-on-quit.mdx
+++ b/docs/src/content/docs/features/cd-on-quit.mdx
@@ -77,7 +77,9 @@ rovr also supports other Yazi-style CLI options for direct integration with scri
 
 #### `--chooser-file`
 
-Write selected files to a specified file when rovr exits:
+Write opened files to a specified file when rovr exits. Opening a file accepts
+the highlighted file, or every selected file in visual mode. Quitting without
+opening a file cancels the selection and leaves the chooser file unchanged:
 
 ```bash
 # Using a temporary file

--- a/src/rovr/__main__.py
+++ b/src/rovr/__main__.py
@@ -119,7 +119,7 @@ def _build_parser() -> argparse.ArgumentParser:
         dest="chooser_file",
         default="",
         type=str,
-        help="Write chosen file(s) (\\n-separated) to this file on exit.",
+        help="Write opened file(s) (\\n-separated) to this file on exit.",
     )
     paths_group.add_argument(
         "--cwd-file",

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -237,6 +237,7 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
         # Runtime output files from CLI
         self._cwd_file: str | TextIOWrapper | None = cwd_file
         self._chooser_file: str | TextIOWrapper | None = chooser_file
+        self._chooser_paths: list[str] | None = None
         self._show_keys: bool = show_keys
         self._exit_with_tree: bool = tree_dom
         self._force_crash_in: float = force_crash_in
@@ -735,23 +736,22 @@ class Application(Actionable, DNDApp, inherit_bindings=False):
                     message += (
                         f"Failed to write cwd file `{path.basename(self._cwd_file)}`!\n"
                     )
-        # Write selected/active item(s) to --chooser-file, if provided
-        if self._chooser_file:
-            selected = await self.file_list.get_selected_objects()
-            if selected:
-                if isinstance(self._chooser_file, TextIOWrapper):
-                    try:
-                        self._chooser_file.write("\n".join(selected))
-                        self._chooser_file.flush()
-                    except OSError:
-                        message += "Failed to write chooser to stdout!\n"
-                else:
-                    try:
-                        with open(self._chooser_file, "w", encoding="utf-8") as f:
-                            f.write("\n".join(selected))
-                    except OSError:
-                        # Any failure writing chooser file should not block exit
-                        message += f"Failed to write chooser file `{path.basename(self._chooser_file)}`"
+        # Only an explicit open action confirms a chooser selection.
+        if self._chooser_file and self._chooser_paths:
+            selected = self._chooser_paths
+            if isinstance(self._chooser_file, TextIOWrapper):
+                try:
+                    self._chooser_file.write("\n".join(selected))
+                    self._chooser_file.flush()
+                except OSError:
+                    message += "Failed to write chooser to stdout!\n"
+            else:
+                try:
+                    with open(self._chooser_file, "w", encoding="utf-8") as f:
+                        f.write("\n".join(selected))
+                except OSError:
+                    # Any failure writing chooser file should not block exit
+                    message += f"Failed to write chooser file `{path.basename(self._chooser_file)}`"
         self.exit(message.strip() if message else None)
 
     @on(ExitApp)

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -561,6 +561,9 @@ class FileList(
 
     async def file_selected_handler(self, paths: list[str]) -> None:
         if self.app._chooser_file:
+            self.app._chooser_paths = [
+                str(path_utils.normalise(item)) for item in paths
+            ]
             self.call_next(self.app.action_quit)
             return
 
@@ -1058,6 +1061,13 @@ class FileList(
             return
         cwd = path_utils.normalise(getcwd())
         if self.select_mode:
+            if self.app._chooser_file:
+                selected = await self.get_selected_objects()
+                if not selected and self.highlighted_option:
+                    selected = [str(self.highlighted_option.dir_entry.path)]
+                if selected:
+                    await self.file_selected_handler(selected)
+                return
             session = self.app.tabWidget.active_tab.session
             session.selectedItems = []
             paths_to_open = []

--- a/src/rovr/variables/constants.py
+++ b/src/rovr/variables/constants.py
@@ -144,7 +144,7 @@ bindings = (
         for bind in config["keybinds"]["page_up"]
     ]
     + [
-        Binding(bind, "select", "Select", show=False)
+        Binding(bind, "open", "Open", show=False)
         for bind in config["keybinds"]["down_tree"]
     ]
     + [

--- a/tests/test_chooser.py
+++ b/tests/test_chooser.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+import pytest
+
+from rovr.app import Application
+
+from .conftest import iter_until
+
+
+@pytest.mark.asyncio
+async def test_chooser_quit_does_not_write_selection(tmp_path: Path) -> None:
+    selected_file = tmp_path / "file.txt"
+    selected_file.touch()
+    chooser_file = tmp_path / "chooser-output"
+    app = Application(tmp_path.as_posix(), chooser_file=chooser_file.as_posix())
+
+    async with app.run_test(size=(143, 37)) as pilot:
+        await iter_until(pilot, lambda: bool(app.file_list.options))
+        app.action_quit()
+        await pilot.pause()
+
+    assert not chooser_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_chooser_open_writes_highlighted_file(tmp_path: Path) -> None:
+    selected_file = tmp_path / "file.txt"
+    selected_file.touch()
+    chooser_file = tmp_path / "chooser-output"
+    app = Application(tmp_path.as_posix(), chooser_file=chooser_file.as_posix())
+
+    async with app.run_test(size=(143, 37)) as pilot:
+        await iter_until(pilot, lambda: bool(app.file_list.options))
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert chooser_file.read_text(encoding="utf-8") == selected_file.as_posix()
+
+
+@pytest.mark.asyncio
+async def test_chooser_open_writes_visual_selection(tmp_path: Path) -> None:
+    selected_files = [tmp_path / f"file-{index}.txt" for index in range(3)]
+    for selected_file in selected_files:
+        selected_file.touch()
+    chooser_file = tmp_path / "chooser-output"
+    app = Application(tmp_path.as_posix(), chooser_file=chooser_file.as_posix())
+
+    async with app.run_test(size=(143, 37)) as pilot:
+        await iter_until(pilot, lambda: len(app.file_list.options) == 3)
+        await app.file_list.toggle_mode()
+        app.file_list.select(app.file_list.get_option_at_index(0))
+        app.file_list.select(app.file_list.get_option_at_index(2))
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert chooser_file.read_text(encoding="utf-8").splitlines() == [
+        selected_files[0].as_posix(),
+        selected_files[2].as_posix(),
+    ]


### PR DESCRIPTION
mostly because i wanted termfilechooser ig

<!--describe your pull request-->

<!--also include videos, screenshots or gifs if applicable if it is a new feature-->

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Refine chooser-file behavior so that only explicitly opened files are written, updating app logic, keybindings, and documentation accordingly.

Bug Fixes:
- Ensure quitting without opening a file no longer writes the current selection to the chooser file.

Enhancements:
- Track chooser selections in the application and write them on quit only after an explicit open action.
- Adjust select-mode open handling to support writing either the highlighted file or the visual selection to the chooser file.
- Update keybinding configuration so the tree navigation binding triggers open rather than select.

Documentation:
- Clarify `--chooser-file` documentation to describe the new semantics of writing only opened files and cancelling on quit without open.

Tests:
- Add tests verifying that quitting does not write chooser output, opening writes the highlighted file, and visual selections are correctly written to the chooser file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chooser output now records files when they are opened, including the highlighted file or multiple files selected in visual mode.
  - Updated chooser help text and documentation to clarify this behaviour.
  - Tree navigation now opens the highlighted item directly.

- **Bug Fixes**
  - Quitting without opening a file no longer creates or changes the chooser output file.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->