### PR TITLE
feat: `%` expansions

### DIFF
--- a/docs/src/content/docs/dev/features/context-menu.mdx
+++ b/docs/src/content/docs/dev/features/context-menu.mdx
@@ -53,8 +53,8 @@ you can create submenus by using the `options` field instead of `action`:
 ```toml
 right_click = [
   { label = "Open With", options = [
-    { label = "VSCode", action = { run = 'code "${selected_files}"', run_type = "background" } },
-    { label = "Helix", action = { run = 'hx "${selected_files}"', run_type = "suspend" } },
+    { label = "VSCode", action = { run = 'code %s', run_type = "background" } },
+    { label = "Helix", action = { run = 'hx %s', run_type = "suspend" } },
   ] },
 ]
 ```
@@ -80,16 +80,16 @@ shell actions are configured as objects with the following properties:
 ```toml
 right_click = [
   # basic command (background execution)
-  { label = "Open in VSCode", action = { run = 'code "${selected_files}"', run_type = "background" } },
+  { label = "Open in VSCode", action = { run = 'code %s', run_type = "background" } },
 
   # suspend rovr for interactive commands
-  { label = "Edit with Helix", action = { run = 'hx "${selected_files}"', run_type = "suspend" } },
+  { label = "Edit with Helix", action = { run = 'hx %s', run_type = "suspend" } },
 
   # show command output as notification
-  { label = "Get SHA256", action = { run = 'pwsh -nop -c "(Get-FileHash -Algorithm SHA256 \"${highlighted_file}\").Hash"', run_type = "background" } },
+  { label = "Get SHA256", action = { run = 'pwsh -nop -c "(Get-FileHash -Algorithm SHA256 \"%h\").Hash"', run_type = "background" } },
 
   # shell mode for complex commands (piping, etc.)
-  { label = "Count lines", action = { run = 'cat "${highlighted_file}" | wc -l', run_type = "background", shell = true } },
+  { label = "Count lines", action = { run = 'cat "%h" | wc -l', run_type = "background", shell = true } },
 ]
 ```
 
@@ -97,14 +97,24 @@ right_click = [
 
 shell actions support variable expansions via `rovr/functions/utils.py::expand_command`:
 
-| variable                       | description                                                    |
-| ------------------------------ | -------------------------------------------------------------- |
-| `${highlighted_file}`          | path to the currently highlighted file                         |
-| `${selected_files}`            | space-separated list of all selected file paths (shell-quoted) |
-| `${current_working_directory}` | the current directory path                                     |
-| `${highlighted_file_name}`     | the name of the highlighted file (without path)                |
+| expansion | description                                                       |
+| --------- | ----------------------------------------------------------------- |
+| `%cwd`    | current working directory                                         |
+| `%rcwd`   | real path of the current working directory                        |
+| `%h`      | currently highlighted file                                        |
+| `%rh`     | real path of the currently highlighted file                       |
+| `%nh`     | name of the currently highlighted file, without its parent path   |
+| `%rnh`    | name of the real path of the currently highlighted file           |
+| `%s`      | shell-quoted, space-separated selected file paths                 |
+| `%rs`     | shell-quoted, space-separated real paths of selected files        |
+| `%copy`   | shell-quoted paths in rovr's copy clipboard                       |
+| `%cut`    | shell-quoted paths in rovr's cut clipboard                        |
+| `%th`     | highlighted file in the next tab                                  |
+| `%tNh`    | highlighted file `N` tabs after the focused tab, such as `%t2h`   |
+| `%Th`     | highlighted file in the previous tab                              |
+| `%TNh`    | highlighted file `N` tabs before the focused tab, such as `%T2h`  |
 
-each variable also has an alternative `real_` version that properly converts the file path to the OS-specific format (which means Windows will use backslash as separator)
+tab-relative expansions wrap around the tab list. The old `${variable}` expansions are deprecated.
 
 ## conditional display
 
@@ -112,8 +122,8 @@ menu items can be conditionally shown or hidden based on file path, operating sy
 
 ```toml
 right_click = [
-  { label = "Open in VSCode", action = { run = 'code "${selected_files}"', run_type = "background" } },
-  { label = "Pixelorama", action = { run = 'pixelorama "${selected_files}"', run_type = "suspend" }, if = { path = ["*.png", "*.jpg"] } },
+  { label = "Open in VSCode", action = { run = 'code %s', run_type = "background" } },
+  { label = "Pixelorama", action = { run = 'pixelorama %s', run_type = "suspend" }, if = { path = ["*.png", "*.jpg"] } },
   { label = "Windows Only", action = { run = 'echo hello', run_type = "background" }, if = { os = ["Windows"] } },
   { label = "Git Projects", action = { run = 'git status', run_type = "background" }, if = { cwd = ["C:/Projects/*"] } },
   { label = "Folder Action", action = { run = 'do something', run_type = "background" }, if = { directory = true } },
@@ -152,10 +162,10 @@ instead of redefining the full list, you can use `prepend_right_click` and `appe
 ```toml
 [settings]
 prepend_right_click = [
-  { label = "My Tool", action = { run = 'mytool "${selected_files}"', run_type = "background" } },
+  { label = "My Tool", action = { run = 'mytool %s', run_type = "background" } },
 ]
 append_right_click = [
-  { label = "Get SHA256", action = { run = 'sha256sum "${highlighted_file}"', run_type = "background" }, if = { directory = false } },
+  { label = "Get SHA256", action = { run = 'sha256sum "%h"', run_type = "background" }, if = { directory = false } },
 ]
 ```
 
@@ -179,6 +189,6 @@ right_click = [
   { label = "\uf014 Delete", action = "rovr:delete" },
   { label = "\uf410 Zip", action = "rovr:zip" },
   { label = "\uf07c Unzip", action = "rovr:unzip" },
-  { label = "\uea74 Properties", action = { run = "powershell -nop -c \"(New-Object -ComObject Shell.Application).NameSpace('${current_working_directory}'.replace('/', '\\\\')).ParseName('${highlighted_file_name}').InvokeVerb('Properties'); Start-Sleep -m 500; do { Start-Sleep -m500 } while ((Get-Process | Where-Object { $_.MainWindowTitle -match '${highlighted_file_name} Properties' }))\"", run_type = "suspend" }, if = { os = ["Windows"] } },
+  { label = "\uea74 Properties", action = { run = "powershell -nop -c \"(New-Object -ComObject Shell.Application).NameSpace('%cwd'.replace('/', '\\\\')).ParseName('%nh').InvokeVerb('Properties'); Start-Sleep -m 500; do { Start-Sleep -m500 } while ((Get-Process | Where-Object { $_.MainWindowTitle -match '%nh Properties' }))\"", run_type = "suspend" }, if = { os = ["Windows"] } },
 ]
 ```

--- a/docs/src/content/docs/dev/features/context-menu.mdx
+++ b/docs/src/content/docs/dev/features/context-menu.mdx
@@ -189,6 +189,13 @@ right_click = [
   { label = "\uf014 Delete", action = "rovr:delete" },
   { label = "\uf410 Zip", action = "rovr:zip" },
   { label = "\uf07c Unzip", action = "rovr:unzip" },
-  { label = "\uea74 Properties", action = { run = "powershell -nop -c \"(New-Object -ComObject Shell.Application).NameSpace('%cwd'.replace('/', '\\\\')).ParseName('%nh').InvokeVerb('Properties'); Start-Sleep -m 500; do { Start-Sleep -m500 } while ((Get-Process | Where-Object { $_.MainWindowTitle -match '%nh Properties' }))\"", run_type = "suspend" }, if = { os = ["Windows"] } },
+  { label = "\uea74 Properties", action = { run = [
+    "powershell",
+    "-NoProfile",
+    "-Command",
+    "& { param([string] $cwd, [string] $name) $shell = New-Object -ComObject Shell.Application; $shell.NameSpace($cwd).ParseName($name).InvokeVerb('Properties'); Start-Sleep -Milliseconds 500; while (Get-Process | Where-Object { $_.MainWindowTitle -match ([regex]::Escape($name) + ' Properties') }) { Start-Sleep -Milliseconds 500 } }",
+    "%rcwd",
+    "%rnh",
+  ], run_type = "background", shell = false }, if = { os = ["Windows"] } },
 ]
 ```

--- a/src/rovr/config/config.toml
+++ b/src/rovr/config/config.toml
@@ -61,16 +61,16 @@ history_size = 200
 # set as default options in the menu, it can be used as reference
 right_click = [
   # { label = "\uf0b0 Open With", if = { directory = false }, options = [
-  #   { label = "\ue8da VSCode", action = { run = 'code "${selected_files}"', run_type = "orphan" } },
-  #   { label = "\ue272 Helix", action = { run = 'hx "${selected_files}"', run_type = "suspend" }, if = { path = ["C:/Users/notso/Git/*"] } },
-  #   { label = "\ue0c6 Pixelorama", action = { run = 'pixelorama "${selected_files}"', run_type = "suspend" }, if = { path = ["*.png"] } },
+  #   { label = "\ue8da VSCode", action = { run = 'code %s', run_type = "orphan" } },
+  #   { label = "\ue272 Helix", action = { run = 'hx %s', run_type = "suspend" }, if = { path = ["C:/Users/notso/Git/*"] } },
+  #   { label = "\ue0c6 Pixelorama", action = { run = 'pixelorama %s', run_type = "suspend" }, if = { path = ["*.png"] } },
   # ] },
   { label = "\uf0c5 Copy", options = [
     { label = "\uf07f Copy in rovr", action = "rovr:copy" },
     { label = "\U000f0147 Copy highlighted file path", action = "system:copy_highlighted" },
     { label = "\U000f14e5 Copy current directory path", action = "system:copy_current_directory" },
     { label = "\U000f1265 Copy to OS clipboard", action = "system:copy_to_system_clip" },
-    # { label = " Copy SHA256", action = { run = 'pwsh -nop -c "(Get-FileHash -Algorithm SHA256 \"${highlighted_file}\").Hash | Set-Clipboard"', run_type = "background" }, if = { directory = false } }
+    # { label = " Copy SHA256", action = { run = 'pwsh -nop -c "(Get-FileHash -Algorithm SHA256 \"%s\").Hash | Set-Clipboard"', run_type = "background" }, if = { directory = false } }
   ] },
   { label = "\uf0c4 Cut", action = "rovr:cut" },
   { label = "\uf429 Paste", action = "rovr:paste" },
@@ -79,7 +79,7 @@ right_click = [
   { label = "\uf014 Delete", action = "rovr:delete" },
   { label = "\uf410 Zip", action = "rovr:zip" },
   { label = "\uf07c Unzip", action = "rovr:unzip" },
-  { label = "\uea74 Properties", action = { run = "powershell -nop -c \"(New-Object -ComObject Shell.Application).NameSpace('${current_working_directory}'.replace('/', '\\')).ParseName('${highlighted_file_name}').InvokeVerb('Properties'); Start-Sleep -m 500; do { Start-Sleep -m 500 } while ((Get-Process | Where-Object { $_.MainWindowTitle -match '${highlighted_file_name} Properties' }))\"", run_type = "background" }, if = { os = ["Windows"] } },
+  { label = "\uea74 Properties", action = { run = "powershell -nop -c \"(New-Object -ComObject Shell.Application).NameSpace('%rcwd').ParseName('%rnh').InvokeVerb('Properties'); Start-Sleep -m 500; do { Start-Sleep -m 500 } while ((Get-Process | Where-Object { $_.MainWindowTitle -match '%rnh Properties' }))\"", run_type = "background" }, if = { os = ["Windows"] } },
   # { label = " Get SHA256", action = { run = 'pwsh -nop -c "(Get-FileHash -Algorithm SHA256 \"${highlighted_file}\").Hash"', run_type = "background" }, if = { directory = false }}
 ]
 drive_exclude = ["/var/*"]

--- a/src/rovr/config/config.toml
+++ b/src/rovr/config/config.toml
@@ -79,7 +79,14 @@ right_click = [
   { label = "\uf014 Delete", action = "rovr:delete" },
   { label = "\uf410 Zip", action = "rovr:zip" },
   { label = "\uf07c Unzip", action = "rovr:unzip" },
-  { label = "\uea74 Properties", action = { run = "powershell -nop -c \"(New-Object -ComObject Shell.Application).NameSpace('%rcwd').ParseName('%rnh').InvokeVerb('Properties'); Start-Sleep -m 500; do { Start-Sleep -m 500 } while ((Get-Process | Where-Object { $_.MainWindowTitle -match '%rnh Properties' }))\"", run_type = "background" }, if = { os = ["Windows"] } },
+  { label = "\uea74 Properties", action = { run = [
+    "powershell",
+    "-NoProfile",
+    "-Command",
+    "& { param([string] $cwd, [string] $name) $shell = New-Object -ComObject Shell.Application; $shell.NameSpace($cwd).ParseName($name).InvokeVerb('Properties'); Start-Sleep -Milliseconds 500; while (Get-Process | Where-Object { $_.MainWindowTitle -match ([regex]::Escape($name) + ' Properties') }) { Start-Sleep -Milliseconds 500 } }",
+    "%rcwd",
+    "%rnh",
+  ], run_type = "background", shell = false }, if = { os = ["Windows"] } },
   # { label = " Get SHA256", action = { run = 'pwsh -nop -c "(Get-FileHash -Algorithm SHA256 \"${highlighted_file}\").Hash"', run_type = "background" }, if = { directory = false }}
 ]
 drive_exclude = ["/var/*"]

--- a/src/rovr/functions/path.py
+++ b/src/rovr/functions/path.py
@@ -583,14 +583,8 @@ def is_os(allowed: list[str]) -> bool:
         accepted = {"windows", "win32", "win64", "win", "ms-windows"}
     elif sys.platform == "darwin":
         accepted = {"macos", "darwin", "osx", "mac"}
-    elif sys.platform == "android":
-        accepted = {"android"}
     elif sys.platform.startswith("linux"):
         accepted = {"linux"}
-    elif sys.platform.startswith("freebsd") or sys.platform.startswith("openbsd"):
-        accepted = {"freebsd", "openbsd"}
-    elif sys.platform == "ios":
-        accepted = {"ios"}
     else:
         accepted = {sys.platform.lower()}
     return any(os_name.lower() in accepted for os_name in allowed)

--- a/src/rovr/functions/path.py
+++ b/src/rovr/functions/path.py
@@ -580,11 +580,20 @@ def is_os(allowed: list[str]) -> bool:
     import sys
 
     if sys.platform == "win32":
-        return any(os_name.lower() in ("windows", "win32") for os_name in allowed)
+        accepted = {"windows", "win32", "win64", "win", "ms-windows"}
     elif sys.platform == "darwin":
-        return any(os_name.lower() in ("macos", "darwin") for os_name in allowed)
+        accepted = {"macos", "darwin", "osx", "mac"}
+    elif sys.platform == "android":
+        accepted = {"android"}
+    elif sys.platform.startswith("linux"):
+        accepted = {"linux"}
+    elif sys.platform.startswith("freebsd") or sys.platform.startswith("openbsd"):
+        accepted = {"freebsd", "openbsd"}
+    elif sys.platform == "ios":
+        accepted = {"ios"}
     else:
-        return sys.platform.capitalize() in allowed
+        accepted = {sys.platform.lower()}
+    return any(os_name.lower() in accepted for os_name in allowed)
 
 
 def ifed(

--- a/src/rovr/functions/path.py
+++ b/src/rovr/functions/path.py
@@ -576,6 +576,17 @@ def dump_exc(widget: DOMNode | None, exc: Exception | Traceback) -> str | None: 
     return dump_path
 
 
+def is_os(allowed: list[str]) -> bool:
+    import sys
+
+    if sys.platform == "win32":
+        return any(os_name.lower() in ("windows", "win32") for os_name in allowed)
+    elif sys.platform == "darwin":
+        return any(os_name.lower() in ("macos", "darwin") for os_name in allowed)
+    else:
+        return sys.platform.capitalize() in allowed
+
+
 def ifed(
     app: App,
     conditions: _RightClickIf
@@ -606,9 +617,7 @@ def ifed(
                     )
                 )
             case "os":
-                disabled = not any(
-                    os.lower() == sys.platform for os in conditions["os"]
-                )
+                disabled = not is_os(conditions["os"])
             case "cwd":
                 disabled = not (
                     any(

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -185,8 +185,6 @@ def run_command(
 
             def func() -> subprocess.CompletedProcess:
                 with app.suspend():
-                    if globals().get("is_dev", False):
-                        print(command)
                     return subprocess.run(command, shell=shell)
 
             try:
@@ -348,9 +346,11 @@ async def expand_command(app: App, command: str | list[str]) -> str | list[str]:
         return expanded
 
     if isinstance(command, list):
-        print(to_return := [_expand(cmd) for cmd in command])
+        to_return = [_expand(cmd) for cmd in command]
     else:
-        print(to_return := _expand(command))
+        to_return = _expand(command)
+    if globals().get("is_dev", False):
+        print(f"{command}\n-> {to_return}")
     return to_return
 
 

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -298,13 +298,12 @@ async def expand_command(app: App, command: str | list[str]) -> str | list[str]:
         expanded = expanded.replace("${highlighted_file}", highlighted).replace(
             "${real_highlighted_file}", os.path.realpath(highlighted)
         )
-        if selected_files:
-            expanded = expanded.replace(
-                "${selected_files}", shjoin(selected_files)
-            ).replace(
-                "${real_selected_files}",
-                shjoin([os.path.realpath(f) for f in selected_files]),
-            )
+        expanded = expanded.replace(
+            "${selected_files}", shjoin(selected_files)
+        ).replace(
+            "${real_selected_files}",
+            shjoin([os.path.realpath(f) for f in selected_files]),
+        )
         expanded = expanded.replace(
             "${highlighted_file_name}", os.path.basename(highlighted)
         ).replace(

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -147,6 +147,8 @@ def run_command(
         from shlex import join as shjoin
 
         command = shjoin(command)
+    if globals().get("is_dev", False):
+        print(command)
 
     match run_type:
         case "orphan":
@@ -241,6 +243,9 @@ def multiprocessing_process_error_checker(app: App, exc: Exception) -> bool:
     return False
 
 
+percent_expand = re.compile(r"%([tT])(\d*)h(?![a-zA-Z0-9_])|%[a-zA-Z_]+")
+
+
 @overload
 async def expand_command(app: App, command: str) -> str: ...
 
@@ -250,7 +255,10 @@ async def expand_command(app: App, command: list[str]) -> list[str]: ...
 
 
 async def expand_command(app: App, command: str | list[str]) -> str | list[str]:
+    from shlex import join as shjoin
+
     from rovr.functions.path import normalise
+    from rovr.header.tabs import TablineTab
 
     cwd = normalise(getcwd())
     highlighted = ""
@@ -258,10 +266,34 @@ async def expand_command(app: App, command: str | list[str]) -> str | list[str]:
         app.file_list.highlighted_option, "dir_entry"
     ):
         highlighted = normalise(app.file_list.highlighted_option.dir_entry.path)
+    selected = app.query_one("Clipboard").selected
+    copy, cut = (
+        [item.path for item in selected if item.type_of_selection == "copy"],
+        [item.path for item in selected if item.type_of_selection == "cut"],
+    )
 
     selected_files = await app.file_list.get_selected_objects() or []
+    tabs = list(app.tabWidget.query(TablineTab))
+
+    def _expand_tab(match: re.Match[str]) -> str:
+        direction, distance = match.group(1), match.group(2)
+        if not tabs or app.tabWidget.active_tab not in tabs:
+            return match.group(0)
+        target = tabs[
+            (
+                tabs.index(app.tabWidget.active_tab)
+                + (int(distance or 1) * (1 if direction == "t" else -1))
+            )
+            % len(tabs)
+        ]
+        if target is app.tabWidget.active_tab:
+            return highlighted
+        last_highlight = target.session.lastHighlighted.get(target.directory)
+        name = last_highlight["name"] if last_highlight else target.focus_on
+        return normalise(os.path.join(target.directory, name)) if name else ""
 
     def _expand(cmd: str) -> str:
+        # deprecated stuff
         expanded = cmd.replace("${current_working_directory}", cwd).replace(
             "${real_current_working_directory", os.path.realpath(cwd)
         )
@@ -269,8 +301,6 @@ async def expand_command(app: App, command: str | list[str]) -> str | list[str]:
             "${real_highlighted_file}", os.path.realpath(highlighted)
         )
         if selected_files:
-            from shlex import join as shjoin
-
             expanded = expanded.replace(
                 "${selected_files}", shjoin(selected_files)
             ).replace(
@@ -283,12 +313,45 @@ async def expand_command(app: App, command: str | list[str]) -> str | list[str]:
             "${real_highlighted_file_name}",
             os.path.basename(os.path.realpath(highlighted)),
         )
+        if cmd != expanded:
+            app.notify(
+                "Expansion syntax [primary]${thing}[/] is deprecated, please use [primary]%thing[/] instead",
+                timeout=5,
+                severity="warning",
+            )
+        # we will start using %<thing> from now on
+        # scan for %<thing>
+        if percent_expand.search(expanded):
+            expanded = percent_expand.sub(
+                # have i told you how frigtening my brain is
+                lambda match: (
+                    _expand_tab(match)
+                    if match.group(1) is not None
+                    else {
+                        "%cwd": lambda: cwd,
+                        "%rcwd": lambda: os.path.realpath(cwd),
+                        "%h": lambda: highlighted,
+                        "%rh": lambda: os.path.realpath(highlighted),
+                        "%nh": lambda: os.path.basename(highlighted),
+                        "%rnh": lambda: os.path.basename(os.path.realpath(highlighted)),
+                        "%s": lambda: shjoin(selected_files),
+                        "%rs": lambda: shjoin([
+                            os.path.realpath(f) for f in selected_files
+                        ]),
+                        "%cut": lambda: shjoin(cut),
+                        "%copy": lambda: shjoin(copy),
+                    }.get(match.group(0), lambda: match.group(0))()
+                ),
+                expanded,
+            )
+
         return expanded
 
     if isinstance(command, list):
-        return [_expand(cmd) for cmd in command]
+        print(to_return := [_expand(cmd) for cmd in command])
     else:
-        return _expand(command)
+        print(to_return := _expand(command))
+    return to_return
 
 
 @lru_cache(maxsize=512)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,4 +1,11 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
 from rovr.functions import config, utils
+from rovr.functions.path import normalise
 
 
 def test_deep_merge() -> None:
@@ -61,3 +68,46 @@ def test_natural_size() -> None:
     assert utils.natural_size(123456789, "binary", 2) == "117.74 MiB"
     assert utils.natural_size(123456789, "decimal", 2) == "123.46 MB"
     assert utils.natural_size(123456789, "gnu", 2) == "117.74M"
+
+
+@pytest.mark.asyncio
+async def test_expand_command_tab_highlights(tmp_path: Path) -> None:
+    directories = [
+        normalise(str(tmp_path / name)) for name in ("first", "focused", "last")
+    ]
+    tabs = [
+        SimpleNamespace(
+            directory=directory,
+            focus_on=None,
+            session=SimpleNamespace(
+                lastHighlighted={directory: {"name": f"file-{index}", "index": 0}}
+            ),
+        )
+        for index, directory in enumerate(directories)
+    ]
+    highlighted = normalise(str(tmp_path / "focused" / "file-1"))
+    app = SimpleNamespace(
+        file_list=SimpleNamespace(
+            highlighted_option=SimpleNamespace(
+                dir_entry=SimpleNamespace(path=highlighted)
+            ),
+            get_selected_objects=_empty_selection,
+        ),
+        tabWidget=SimpleNamespace(active_tab=tabs[1], query=lambda _tab_type: tabs),
+        query_one=lambda _selector: SimpleNamespace(selected=[]),
+        notify=lambda *_args, **_kwargs: None,
+    )
+
+    result = await utils.expand_command(cast(Any, app), "%Th %T2h %th %t2h %trash")
+
+    assert result == " ".join([
+        normalise(str(tmp_path / "first" / "file-0")),
+        normalise(str(tmp_path / "last" / "file-2")),
+        normalise(str(tmp_path / "last" / "file-2")),
+        normalise(str(tmp_path / "first" / "file-0")),
+        "%trash",
+    ])
+
+
+async def _empty_selection() -> list[str]:
+    return []


### PR DESCRIPTION
not a breaking change, though it will warn you about the change (yes i will remove it in a future update)

## Summary by Sourcery

Introduce yazi-style percent-based command expansions and improve OS condition handling for context menu actions.

New Features:
- Add percent-based command expansion tokens (e.g. %cwd, %h, %s, %copy, %cut) including tab-relative variants for addressing files in other tabs.

Enhancements:
- Deprecate legacy ${variable} expansion syntax while keeping it functional with user-facing deprecation warnings.
- Improve OS-matching logic for right-click menu conditions via a dedicated is_os helper and update usage.
- Add optional debug printing of commands being run and their expanded forms when development flags are enabled.

Documentation:
- Update context menu documentation to describe the new percent-based expansion syntax and tab-relative tokens, and refresh examples to use the new style.

Tests:
- Add asynchronous tests covering tab-relative expansion behaviour for the new percent-based command syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added percent-based command expansions for directories, highlighted, selected, copied and cut files, plus relative tab navigation.
  * Added platform-aware conditions supporting Windows, macOS and Linux.
  * Development mode now displays commands before execution.

* **Bug Fixes**
  * Improved tab-relative expansion, including tab-list wraparound.

* **Documentation**
  * Updated context-menu examples and configuration guidance.
  * Documented legacy `${...}` syntax deprecation and migration to percent-based variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->