### PR TITLE
feat: cached previews

### DIFF
--- a/src/rovr/__main__.py
+++ b/src/rovr/__main__.py
@@ -207,6 +207,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="List available preview themes.",
     )
     dev_group.add_argument(
+        "--clear-cache",
+        dest="clear_cache",
+        action="store_true",
+        help="Clear the cache folder.",
+    )
+    dev_group.add_argument(
         "--force-crash-in",
         dest="force_crash_in",
         type=float,
@@ -263,6 +269,21 @@ def cli(argv: list[str] | None = None) -> None:
             raise SystemExit(1)
         print("keys.toml is valid.")
         return
+    if args.clear_cache:
+        from os import _exit as exit
+        from shutil import rmtree
+
+        from rovr.variables.maps import RovrVars
+
+        rmtree(RovrVars.ROVRTEMP, ignore_errors=True)
+        # check if cache is fully cleaned
+        if not os.path.exists(RovrVars.ROVRTEMP) or not os.listdir(RovrVars.ROVRTEMP):
+            pprint("[bold green]Cache cleared successfully![/]")
+            exit(0)
+        else:
+            pprint("[bold red]Failed to clear cache![/]")
+            pprint(f"[red]{os.listdir(RovrVars.ROVRTEMP)} items still exist.[/]")
+            exit(1)
 
     global is_dev
     if args.dev or is_dev:

--- a/src/rovr/__main__.py
+++ b/src/rovr/__main__.py
@@ -275,7 +275,7 @@ def cli(argv: list[str] | None = None) -> None:
 
         from rovr.variables.maps import RovrVars
 
-        rmtree(RovrVars.ROVRTEMP, ignore_errors=True)
+        rmtree(os.path.join(RovrVars.ROVRTEMP, "previews"), ignore_errors=True)
         # check if cache is fully cleaned
         if not os.path.exists(RovrVars.ROVRTEMP) or not os.listdir(RovrVars.ROVRTEMP):
             pprint("[bold green]Cache cleared successfully![/]")

--- a/src/rovr/__main__.py
+++ b/src/rovr/__main__.py
@@ -275,14 +275,17 @@ def cli(argv: list[str] | None = None) -> None:
 
         from rovr.variables.maps import RovrVars
 
-        rmtree(os.path.join(RovrVars.ROVRTEMP, "previews"), ignore_errors=True)
+        rmtree(
+            (prevpath := os.path.join(RovrVars.ROVRTEMP, "previews")),
+            ignore_errors=True,
+        )
         # check if cache is fully cleaned
-        if not os.path.exists(RovrVars.ROVRTEMP) or not os.listdir(RovrVars.ROVRTEMP):
+        if not os.path.exists(prevpath) or not (items := os.listdir(prevpath)):
             pprint("[bold green]Cache cleared successfully![/]")
             exit(0)
         else:
             pprint("[bold red]Failed to clear cache![/]")
-            pprint(f"[red]{os.listdir(RovrVars.ROVRTEMP)} items still exist.[/]")
+            pprint(f"[red]{len(items)} items still exist.[/]")
             exit(1)
 
     global is_dev

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -1392,7 +1392,11 @@ class PreviewContainer(Actionable, Container):
                     realpath = path.realpath(file_path)
                     stat_result = os.stat(realpath)
                     content: list[str] | None = load_from_cache(
-                        realpath, "archive", stat_result, ("json", "utf-8"), list
+                        realpath,
+                        "archive",
+                        stat_result,
+                        ("json", "utf-8"),
+                        pass_as=list,
                     )
                     if content is None:
                         try:

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import os
 import subprocess
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -14,6 +15,9 @@ import textual_image.renderable
 import textual_image.widget
 from PIL import Image, UnidentifiedImageError
 from PIL.Image import Image as PILImage
+from rich.console import Console
+from rich.errors import MarkupError
+from rich.text import Text
 from textual import events, on, work
 from textual.app import ComposeResult
 from textual.containers import Container
@@ -38,17 +42,88 @@ from rovr.functions import path as path_utils
 from rovr.functions import preview_utils
 from rovr.functions.ansi import ansi_to_rich_text
 from rovr.functions.pdf import get_pdf_images, get_pdf_info
-from rovr.functions.utils import multiprocessing_process_error_checker, should_cancel
-from rovr.variables.constants import PreviewContainerTitles, config, file_one
+from rovr.functions.utils import (
+    load_from_cache,
+    multiprocessing_process_error_checker,
+    save_to_cache,
+    should_cancel,
+)
+from rovr.variables.constants import (
+    RESAMPLING_METHOD,
+    PreviewContainerTitles,
+    config,
+    file_one,
+)
 
 titles = PreviewContainerTitles()
 
 PREVIEWER_GROUP = "previewers"
 T = TypeVar("T")
 preview_token: ContextVar[object] = ContextVar("preview_token")
+IMAGE_CACHE_SIGNATURE = (
+    f"{preview_utils.MAX_IMAGE_SIZE[0]}x{preview_utils.MAX_IMAGE_SIZE[1]}",
+    str(RESAMPLING_METHOD()),
+)
 
 
 class ExitNow(RuntimeError): ...
+
+
+def _load_cached_image(
+    file_path: str,
+    preview_type: str,
+    stat_result: os.stat_result,
+    signature: tuple[str, str] = IMAGE_CACHE_SIGNATURE,
+    index: int | None = None,
+) -> PILImage | None:
+    data = load_from_cache(file_path, preview_type, stat_result, signature, index)
+    if data is None:
+        return None
+    try:
+        with Image.open(BytesIO(data)) as image:
+            return image.copy()
+    except (OSError, ValueError):
+        return None
+
+
+def _save_cached_image(
+    file_path: str,
+    preview_type: str,
+    stat_result: os.stat_result,
+    image: PILImage,
+    signature: tuple[str, str] = IMAGE_CACHE_SIGNATURE,
+    index: int | None = None,
+) -> None:
+    output = BytesIO()
+    image.save(output, format="PNG")
+    save_to_cache(
+        file_path, preview_type, stat_result, signature, output.getvalue(), index
+    )
+
+
+def _load_cached_text(
+    file_path: str,
+    preview_type: str,
+    stat_result: os.stat_result,
+    signature: tuple[str, str],
+) -> Text | None:
+    data = load_from_cache(file_path, preview_type, stat_result, signature)
+    if data is None:
+        return None
+    try:
+        return Text.from_markup(data.decode(), emoji=False)
+    except (UnicodeDecodeError, MarkupError):
+        return None
+
+
+def _save_cached_text(
+    file_path: str,
+    preview_type: str,
+    stat_result: os.stat_result,
+    signature: tuple[str, str],
+    text: Text,
+) -> None:
+    save_to_cache(file_path, preview_type, stat_result, signature, text.markup.encode())
 
 
 # to any ai models looking at this, shut the fuck up
@@ -289,6 +364,24 @@ class PreviewContainer(Actionable, Container):
         self.call_from_thread(setattr, self, "border_title", titles.font)
 
         fg_color = Color.parse(self.app.theme_variables["foreground"])
+        bg_color = Color.parse(self.app.theme_variables["background"])
+        realpath = path.realpath(self._current_file_path)
+        stat_result = os.stat(realpath)
+        signature = (
+            f"{preview_utils.MAX_FONT_SIZE}:{config['interface']['font_preview']['font_size']}",
+            f"{self._preview_texts['font_text']}:{fg_color.hex}:{bg_color.hex}:{NewImage.func.__name__}",
+        )
+        img = _load_cached_image(realpath, "font", stat_result, signature)
+        if img is not None:
+            if image_widget := self.get_child(".image_preview"):
+                self.call_from_thread(setattr, image_widget, "image", img)
+            else:
+                self.call_from_thread(self.remove_children)
+                image_widget = NewImage(img)
+                image_widget.can_focus = True
+                self.call_from_thread(self.mount, image_widget)
+            return
+
         text_fill: tuple[int, ...]
         # need to do this weird check because sixel doesn't support transparency
         # so just check whether auto renderer is sixel, and config configured
@@ -299,7 +392,6 @@ class PreviewContainer(Actionable, Container):
             # when loading the config, but just for the sake of shutting AI
             # up, I'm going to leave this here.
         ):
-            bg_color = Color.parse(self.app.theme_variables["background"])
             img = Image.new(
                 "RGB",
                 (preview_utils.MAX_FONT_SIZE[0], preview_utils.MAX_FONT_SIZE[1]),
@@ -349,6 +441,7 @@ class PreviewContainer(Actionable, Container):
             font=font,
             fill=text_fill,
         )
+        _save_cached_image(realpath, "font", stat_result, img, signature)
         if should_cancel():
             return
 
@@ -393,46 +486,57 @@ class PreviewContainer(Actionable, Container):
 
         # load svg as bytes
         try:
-            self.call_next(self.LOADER_WIDGET.set_status, "loading svg...")
-            if self.app.MULTIPROCESSING_PROCESS_ALLOWED:
-                try:
-                    png_bytes = preview_utils.load_svg(self._current_file_path)
-                except ValueError as exc:
-                    if multiprocessing_process_error_checker(self.app, exc):
-                        png_bytes = preview_utils.load_svg_sync(self._current_file_path)
-                    else:
-                        raise
-            else:
-                png_bytes = preview_utils.load_svg_sync(self._current_file_path)
-            if png_bytes is None:
-                self.notify(
-                    "Failed to load SVG. The file may be corrupted or not an SVG file.",
-                    title="SVG Preview",
-                    severity="error",
-                )
-                self.call_from_thread(self.remove_children)
-                self.border_title = ""
-                return
-            elif png_bytes == b"cancelled":
-                return
+            realpath = path.realpath(self._current_file_path)
+            stat_result = os.stat(realpath)
+            pil_object = _load_cached_image(realpath, "svg", stat_result)
+            if pil_object is None:
+                self.call_next(self.LOADER_WIDGET.set_status, "loading svg...")
+                if self.app.MULTIPROCESSING_PROCESS_ALLOWED:
+                    try:
+                        png_bytes = preview_utils.load_svg(self._current_file_path)
+                    except ValueError as exc:
+                        if multiprocessing_process_error_checker(self.app, exc):
+                            png_bytes = preview_utils.load_svg_sync(
+                                self._current_file_path
+                            )
+                        else:
+                            raise
+                else:
+                    png_bytes = preview_utils.load_svg_sync(self._current_file_path)
+                if png_bytes is None:
+                    self.notify(
+                        "Failed to load SVG. The file may be corrupted or not an SVG file.",
+                        title="SVG Preview",
+                        severity="error",
+                    )
+                    self.call_from_thread(self.remove_children)
+                    self.border_title = ""
+                    return
+                elif png_bytes == b"cancelled":
+                    return
 
-            if should_cancel():
-                return
+                if should_cancel():
+                    return
 
-            self.call_next(self.LOADER_WIDGET.set_status, "resampling svg...")
+                self.call_next(self.LOADER_WIDGET.set_status, "resampling svg...")
 
-            if self.app.MULTIPROCESSING_PROCESS_ALLOWED:
-                try:
-                    pil_object = preview_utils.resample(Image.open(BytesIO(png_bytes)))
-                except ValueError as exc:
-                    if multiprocessing_process_error_checker(self.app, exc):
-                        pil_object = preview_utils.resample_sync(
+                if self.app.MULTIPROCESSING_PROCESS_ALLOWED:
+                    try:
+                        pil_object = preview_utils.resample(
                             Image.open(BytesIO(png_bytes))
                         )
-                    else:
-                        raise
-            else:
-                pil_object = preview_utils.resample_sync(Image.open(BytesIO(png_bytes)))
+                    except ValueError as exc:
+                        if multiprocessing_process_error_checker(self.app, exc):
+                            pil_object = preview_utils.resample_sync(
+                                Image.open(BytesIO(png_bytes))
+                            )
+                        else:
+                            raise
+                else:
+                    pil_object = preview_utils.resample_sync(
+                        Image.open(BytesIO(png_bytes))
+                    )
+                _save_cached_image(realpath, "svg", stat_result, pil_object)
 
             if should_cancel():
                 return
@@ -486,20 +590,29 @@ class PreviewContainer(Actionable, Container):
         self.call_from_thread(setattr, self, "border_title", titles.image)
 
         try:
-            if self.app.MULTIPROCESSING_PROCESS_ALLOWED:
-                try:
-                    pil_object = preview_utils.resample_file(self._current_file_path)
-                except ValueError as exc:
-                    if multiprocessing_process_error_checker(self.app, exc):
-                        pil_object = preview_utils.resample_file_sync(
+            realpath = path.realpath(self._current_file_path)
+            stat_result = os.stat(realpath)
+            pil_object = _load_cached_image(realpath, "image", stat_result)
+            if pil_object is None:
+                if self.app.MULTIPROCESSING_PROCESS_ALLOWED:
+                    try:
+                        pil_object = preview_utils.resample_file(
                             self._current_file_path
                         )
-                    else:
-                        raise
-            else:
-                pil_object = preview_utils.resample_file_sync(self._current_file_path)
-            if pil_object is None:
-                return
+                    except ValueError as exc:
+                        if multiprocessing_process_error_checker(self.app, exc):
+                            pil_object = preview_utils.resample_file_sync(
+                                self._current_file_path
+                            )
+                        else:
+                            raise
+                else:
+                    pil_object = preview_utils.resample_file_sync(
+                        self._current_file_path
+                    )
+                if pil_object is None:
+                    return
+                _save_cached_image(realpath, "image", stat_result, pil_object)
         except UnidentifiedImageError:
             if should_cancel():
                 return
@@ -591,6 +704,16 @@ class PreviewContainer(Actionable, Container):
                 f"Invalid args, first_page={first_page} > last_page={last_page}"
             )
 
+        assert self._current_file_path is not None
+        realpath = path.realpath(self._current_file_path)
+        stat_result = os.stat(realpath)
+        cached = [
+            _load_cached_image(realpath, "pdf", stat_result, index=page)
+            for page in range(first_page, last_page + 1)
+        ]
+        if all(image is not None for image in cached):
+            return cast(list[PILImage], cached)
+
         result = get_pdf_images(
             str(self._current_file_path),
             first_page=first_page,
@@ -606,12 +729,17 @@ class PreviewContainer(Actionable, Container):
         # Resample images once when loaded for better performance
         if self.app.MULTIPROCESSING_PROCESS_ALLOWED:
             try:
-                return preview_utils.resample_batch(result)
+                result = preview_utils.resample_batch(result)
             except ValueError as exc:
                 if multiprocessing_process_error_checker(self.app, exc):
-                    return preview_utils.resample_batch_sync(result)
-                raise
-        return preview_utils.resample_batch_sync(result)
+                    result = preview_utils.resample_batch_sync(result)
+                else:
+                    raise
+        else:
+            result = preview_utils.resample_batch_sync(result)
+        for page, image in zip(range(first_page, last_page + 1), result):
+            _save_cached_image(realpath, "pdf", stat_result, image, index=page)
+        return result
 
     def show_pdf_preview(self) -> None:
         """
@@ -740,6 +868,12 @@ class PreviewContainer(Actionable, Container):
             command.append(f"--line-range=:{max_lines}")
         assert self._current_file_path is not None
         command.extend(["--", self._current_file_path])
+        realpath = path.realpath(self._current_file_path)
+        stat_result = os.stat(realpath)
+        signature = (
+            f"{max_lines}:{config['interface']['show_line_numbers']}",
+            bat_executable,
+        )
 
         if should_cancel():
             return False
@@ -747,62 +881,65 @@ class PreviewContainer(Actionable, Container):
         self.call_from_thread(setattr, self, "border_title", titles.bat)
 
         try:
-            process = subprocess.Popen(
-                command,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            deadline = monotonic() + 5
-            while True:
-                try:
-                    stdout, stderr = process.communicate(timeout=1)
-                    break
-                except subprocess.TimeoutExpired:
-                    if should_cancel() or monotonic() >= deadline:
-                        process.kill()
-                        stdout, stderr = process.communicate()
-                        if should_cancel():
-                            return False
-                        raise subprocess.TimeoutExpired(command, 5, stdout, stderr)
+            new_content = _load_cached_text(realpath, "bat", stat_result, signature)
+            if new_content is None:
+                process = subprocess.Popen(
+                    command,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                deadline = monotonic() + 5
+                while True:
+                    try:
+                        stdout, stderr = process.communicate(timeout=1)
+                        break
+                    except subprocess.TimeoutExpired:
+                        if should_cancel() or monotonic() >= deadline:
+                            process.kill()
+                            stdout, stderr = process.communicate()
+                            if should_cancel():
+                                return False
+                            raise subprocess.TimeoutExpired(command, 5, stdout, stderr)
+
+                if should_cancel():
+                    return False
+
+                if process.returncode != 0:
+                    error_message = stderr.decode("utf-8", errors="ignore")
+                    if should_cancel():
+                        return False
+                    self.call_from_thread(self.remove_children)
+                    self.notify(
+                        error_message,
+                        title="Plugins: Bat",
+                        severity="warning",
+                    )
+                    return False
+
+                bat_output = stdout.decode("utf-8", errors="ignore")
+                new_content = ansi_to_rich_text(bat_output)
+                _save_cached_text(realpath, "bat", stat_result, signature, new_content)
 
             if should_cancel():
                 return False
 
-            if process.returncode == 0:
-                bat_output = stdout.decode("utf-8", errors="ignore")
-                new_content = ansi_to_rich_text(bat_output)
-
-                if should_cancel():
-                    return False
-
-                if static_widget := self.get_child("Static"):
-                    self.log("Using existing Static")
-                    self.call_from_thread(static_widget.update, new_content)
-                    self.call_from_thread(static_widget.set_classes, "bat_preview")
-                else:
-                    self.log("Mounting new Static")
-                    self.call_from_thread(self.remove_children)
-
-                    if should_cancel():
-                        return False
-
-                    static_widget = Static(new_content, classes="bat_preview")
-                    self.call_from_thread(self.mount, static_widget)
-                    if should_cancel():
-                        return False
-                    static_widget.can_focus = True
-                return True
+            if static_widget := self.get_child("Static"):
+                self.log("Using existing Static")
+                self.call_from_thread(static_widget.update, new_content)
+                self.call_from_thread(static_widget.set_classes, "bat_preview")
             else:
-                error_message = stderr.decode("utf-8", errors="ignore")
+                self.log("Mounting new Static")
+                self.call_from_thread(self.remove_children)
+
                 if should_cancel():
                     return False
-                self.call_from_thread(self.remove_children)
-                self.notify(
-                    error_message,
-                    title="Plugins: Bat",
-                    severity="warning",
-                )
-                return False
+
+                static_widget = Static(new_content, classes="bat_preview")
+                self.call_from_thread(self.mount, static_widget)
+                if should_cancel():
+                    return False
+                static_widget.can_focus = True
+            return True
         except ExitNow:
             raise
         except Exception as exc:
@@ -828,6 +965,23 @@ class PreviewContainer(Actionable, Container):
 
         lines: list[str] | None = None
         height = self.call_from_thread(lambda: self.region.height)
+        width = self.call_from_thread(lambda: self.region.width)
+        assert self._current_file_path is not None
+        realpath = path.realpath(self._current_file_path)
+        stat_result = os.stat(realpath)
+        signature = (
+            f"{width}x{height}:{config['interface']['show_line_numbers']}",
+            f"{config['theme']['preview']}:{config['theme']['transparent']}",
+        )
+        new_content = _load_cached_text(realpath, "text", stat_result, signature)
+        if new_content is not None:
+            if static_widget := self.get_child("Static"):
+                self.call_from_thread(static_widget.update, new_content)
+            else:
+                self.call_from_thread(self.remove_children)
+                self.call_from_thread(self.mount, Static(new_content))
+            return
+
         # force read by brute-forcing encoding methods
         encodings_to_try = [
             "utf8",
@@ -872,19 +1026,28 @@ class PreviewContainer(Actionable, Container):
             theme=config["theme"]["preview"],
             background_color="default" if config["theme"]["transparent"] else None,
         )
+        console = Console(width=max(width, 1), color_system="truecolor")
+        new_content = Text.assemble(
+            *(
+                (segment.text, segment.style or "")
+                for segment in console.render(syntax)
+                if not segment.control
+            )
+        )
+        _save_cached_text(realpath, "text", stat_result, signature, new_content)
 
         if should_cancel():
             return
 
         if static_widget := self.get_child("Static"):
-            self.call_from_thread(static_widget.update, syntax)
+            self.call_from_thread(static_widget.update, new_content)
         else:
             self.call_from_thread(self.remove_children)
 
             if should_cancel():
                 return
 
-            self.call_from_thread(self.mount, Static(syntax))
+            self.call_from_thread(self.mount, Static(new_content))
 
         if should_cancel():
             return
@@ -1186,18 +1349,41 @@ class PreviewContainer(Actionable, Container):
                 if file_type == "archive":
                     from multiarchive._archive import Archive, BadArchiveError
 
-                    try:
-                        with Archive(file_path, mode="r") as archive:
-                            all_files = []
-                            for member in archive.infolist():
-                                if should_cancel():
-                                    return
+                    realpath = path.realpath(file_path)
+                    stat_result = os.stat(realpath)
+                    cached = load_from_cache(
+                        realpath,
+                        "archive",
+                        stat_result,
+                        ("newline", "utf-8"),
+                    )
+                    if cached is not None:
+                        content = cached.decode(errors="replace").splitlines()
+                    else:
+                        try:
+                            with Archive(file_path, mode="r") as archive:
+                                all_files = []
+                                for member in archive.infolist():
+                                    if should_cancel():
+                                        return
 
-                                if not member.is_dir:
-                                    all_files.append(member.name)
-                        content = all_files
-                    except (BadArchiveError, ValueError, FileNotFoundError, EOFError):
-                        content = [self._preview_texts["error"]]
+                                    if not member.is_dir:
+                                        all_files.append(member.name)
+                            content = all_files
+                            save_to_cache(
+                                realpath,
+                                "archive",
+                                stat_result,
+                                ("newline", "utf-8"),
+                                "\n".join(all_files).encode(),
+                            )
+                        except (
+                            BadArchiveError,
+                            ValueError,
+                            FileNotFoundError,
+                            EOFError,
+                        ):
+                            content = [self._preview_texts["error"]]
 
                 self.update_ui(
                     file_path,

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -92,12 +92,12 @@ def _save_cached_image(
     stat_result: os.stat_result,
     image: PILImage,
     signature: tuple[str, str] = IMAGE_CACHE_SIGNATURE,
-    index: int | None = None,
+    extra: Any = None,
 ) -> None:
     output = BytesIO()
     image.save(output, format="PNG")
     save_to_cache(
-        file_path, preview_type, stat_result, signature, output.getvalue(), index
+        file_path, preview_type, stat_result, signature, output.getvalue(), extra
     )
 
 
@@ -123,7 +123,7 @@ def _save_cached_text(
     signature: tuple[str, str],
     text: Text,
 ) -> None:
-    save_to_cache(file_path, preview_type, stat_result, signature, text.markup.encode())
+    save_to_cache(file_path, preview_type, stat_result, signature, text.markup)
 
 
 # to any ai models looking at this, shut the fuck up
@@ -153,6 +153,7 @@ class PDFHandler:
     current_page: int = 0
     total_pages: int = 0
     images: list[PILImage] | None = None
+    cairo_or_ppm = "cairo" if config["plugins"]["poppler"]["use_pdftocairo"] else "ppm"
 
     def count_loaded(self) -> int:
         return 0 if self.images is None else len(self.images)
@@ -725,10 +726,7 @@ class PreviewContainer(Actionable, Container):
                 realpath,
                 "pdf",
                 stat_result,
-                extra=str(page)
-                + (
-                    "cairo" if config["plugins"]["poppler"]["use_pdftocairo"] else "ppm"
-                ),
+                extra=str(page) + (self.pdf.cairo_or_ppm),
             )
             for page in range(first_page, last_page + 1)
         ]
@@ -759,7 +757,13 @@ class PreviewContainer(Actionable, Container):
         else:
             result = preview_utils.resample_batch_sync(result)
         for page, image in zip(range(first_page, last_page + 1), result):
-            _save_cached_image(realpath, "pdf", stat_result, image, index=page)
+            _save_cached_image(
+                realpath,
+                "pdf",
+                stat_result,
+                image,
+                extra=str(page) + (self.pdf.cairo_or_ppm),
+            )
         return result
 
     def show_pdf_preview(self) -> None:
@@ -776,12 +780,27 @@ class PreviewContainer(Actionable, Container):
         # Convert PDF to images if not already done
         if self.pdf.images is None:
             try:
-                self.pdf.total_pages = int(
-                    get_pdf_info(
+                pdf_info: dict[str, str | int] | None = load_from_cache(
+                    str(self._current_file_path),
+                    "pdf_info",
+                    os.stat(str(self._current_file_path)),
+                    sig=(self.pdf.cairo_or_ppm, ""),
+                    pass_as=dict,
+                )
+                if pdf_info is None:
+                    pdf_info = get_pdf_info(
                         str(self._current_file_path),
                         poppler_path=PDFHandler.get_poppler_folder(),
-                    )["Pages"]
-                )
+                    )
+                    save_to_cache(
+                        str(self._current_file_path),
+                        "pdf_info",
+                        os.stat(str(self._current_file_path)),
+                        sig=(self.pdf.cairo_or_ppm, ""),
+                        data=pdf_info,
+                    )
+                self.pdf.total_pages = int(pdf_info.get("Pages", 0))
+
                 result = self.load_pdf_pages(
                     first_page=1, last_page=self.pdf.get_last_page_to_load()
                 )
@@ -1368,24 +1387,13 @@ class PreviewContainer(Actionable, Container):
                 self.log(f"Previewing as {file_type} (MIME: {mime_result.mime_type})")
 
                 if file_type == "archive":
-                    import json
-
                     from multiarchive._archive import Archive, BadArchiveError
 
                     realpath = path.realpath(file_path)
                     stat_result = os.stat(realpath)
-                    cached = load_from_cache(
-                        realpath,
-                        "archive",
-                        stat_result,
-                        ("json", "utf-8"),
+                    content: list[str] | None = load_from_cache(
+                        realpath, "archive", stat_result, ("json", "utf-8"), list
                     )
-                    content: list[str] | None = None
-                    if cached is not None:
-                        try:
-                            content = json.loads(cached.decode("utf-8"))
-                        except json.JSONDecodeError:
-                            content = None
                     if content is None:
                         try:
                             with Archive(file_path, mode="r") as archive:
@@ -1402,12 +1410,7 @@ class PreviewContainer(Actionable, Container):
                                 "archive",
                                 stat_result,
                                 ("json", "utf-8"),
-                                json.dumps(
-                                    all_files,
-                                    ensure_ascii=False,
-                                    check_circular=False,
-                                    separators=(",", ":"),
-                                ).encode("utf-8"),
+                                all_files,
                             )
                         except (
                             BadArchiveError,

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -1380,12 +1380,13 @@ class PreviewContainer(Actionable, Container):
                         stat_result,
                         ("json", "utf-8"),
                     )
+                    content: list[str] | None = None
                     if cached is not None:
                         try:
-                            content: list[str] = json.loads(cached.decode("utf-8"))
+                            content = json.loads(cached.decode("utf-8"))
                         except json.JSONDecodeError:
-                            content = [self._preview_texts["error"]]
-                    else:
+                            content = None
+                    if content is None:
                         try:
                             with Archive(file_path, mode="r") as archive:
                                 all_files = []

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -9,7 +9,7 @@ from functools import partial
 from io import BytesIO
 from os import path
 from time import monotonic, time
-from typing import Awaitable, Callable, TypeVar, cast, overload
+from typing import Any, Awaitable, Callable, TypeVar, cast, overload
 
 import textual_image.renderable
 import textual_image.widget
@@ -74,9 +74,9 @@ def _load_cached_image(
     preview_type: str,
     stat_result: os.stat_result,
     signature: tuple[str, str] = IMAGE_CACHE_SIGNATURE,
-    index: int | None = None,
+    extra: Any = None,
 ) -> PILImage | None:
-    data = load_from_cache(file_path, preview_type, stat_result, signature, index)
+    data = load_from_cache(file_path, preview_type, stat_result, signature, extra)
     if data is None:
         return None
     try:
@@ -366,7 +366,20 @@ class PreviewContainer(Actionable, Container):
         fg_color = Color.parse(self.app.theme_variables["foreground"])
         bg_color = Color.parse(self.app.theme_variables["background"])
         realpath = path.realpath(self._current_file_path)
-        stat_result = os.stat(realpath)
+        try:
+            stat_result = os.stat(realpath)
+        except FileNotFoundError:
+            if should_cancel():
+                return
+            self.call_from_thread(self.remove_children)
+            self.call_from_thread(
+                self.mount,
+                Static(
+                    self._preview_texts["error"],
+                    classes="special",
+                ),
+            )
+            return
         signature = (
             f"{preview_utils.MAX_FONT_SIZE}:{config['interface']['font_preview']['font_size']}",
             f"{self._preview_texts['font_text']}:{fg_color.hex}:{bg_color.hex}:{NewImage.func.__name__}",
@@ -708,7 +721,15 @@ class PreviewContainer(Actionable, Container):
         realpath = path.realpath(self._current_file_path)
         stat_result = os.stat(realpath)
         cached = [
-            _load_cached_image(realpath, "pdf", stat_result, index=page)
+            _load_cached_image(
+                realpath,
+                "pdf",
+                stat_result,
+                extra=str(page)
+                + (
+                    "cairo" if config["plugins"]["poppler"]["use_pdftocairo"] else "ppm"
+                ),
+            )
             for page in range(first_page, last_page + 1)
         ]
         if all(image is not None for image in cached):
@@ -1347,6 +1368,8 @@ class PreviewContainer(Actionable, Container):
                 self.log(f"Previewing as {file_type} (MIME: {mime_result.mime_type})")
 
                 if file_type == "archive":
+                    import json
+
                     from multiarchive._archive import Archive, BadArchiveError
 
                     realpath = path.realpath(file_path)
@@ -1355,10 +1378,13 @@ class PreviewContainer(Actionable, Container):
                         realpath,
                         "archive",
                         stat_result,
-                        ("newline", "utf-8"),
+                        ("json", "utf-8"),
                     )
                     if cached is not None:
-                        content = cached.decode(errors="replace").splitlines()
+                        try:
+                            content: list[str] = json.loads(cached.decode("utf-8"))
+                        except json.JSONDecodeError:
+                            content = [self._preview_texts["error"]]
                     else:
                         try:
                             with Archive(file_path, mode="r") as archive:
@@ -1374,8 +1400,13 @@ class PreviewContainer(Actionable, Container):
                                 realpath,
                                 "archive",
                                 stat_result,
-                                ("newline", "utf-8"),
-                                "\n".join(all_files).encode(),
+                                ("json", "utf-8"),
+                                json.dumps(
+                                    all_files,
+                                    ensure_ascii=False,
+                                    check_circular=False,
+                                    separators=(",", ":"),
+                                ).encode("utf-8"),
                             )
                         except (
                             BadArchiveError,

--- a/src/rovr/functions/drag_image.py
+++ b/src/rovr/functions/drag_image.py
@@ -10,6 +10,8 @@ from PIL import Image, ImageDraw, ImageFont, ImageOps
 from textual.color import Color, ColorParseError
 from textual_drivers.dnd import ImageLabel
 
+from rovr.functions.utils import load_from_cache, save_to_cache
+
 HEIGHT = 48
 MAX_WIDTH = 480
 TEXT_SIZE = 28
@@ -158,6 +160,16 @@ def render_drag_image(
 
 @lru_cache(maxsize=16)
 def _load_image_preview(image_path: str, _modified_ns: int) -> Image.Image:
+    realpath = os.path.realpath(image_path)
+    stat_result = os.stat(realpath)
+    signature = (f"{IMAGE_PREVIEW_SIZE[0]}x{IMAGE_PREVIEW_SIZE[1]}", "nearest")
+    if data := load_from_cache(realpath, "drag-image", stat_result, signature):
+        try:
+            with Image.open(BytesIO(data)) as image:
+                return image.copy()
+        except (OSError, ValueError):
+            pass
+
     with Image.open(image_path) as source:
         max_dimension = max(IMAGE_PREVIEW_SIZE)
         source.draft(None, (max_dimension, max_dimension))
@@ -180,7 +192,11 @@ def _load_image_preview(image_path: str, _modified_ns: int) -> Image.Image:
             fill=255,
         )
         preview.putalpha(mask)
-        return preview.convert("RGBA")
+        preview = preview.convert("RGBA")
+        output = BytesIO()
+        preview.save(output, format="PNG")
+        save_to_cache(realpath, "drag-image", stat_result, signature, output.getvalue())
+        return preview
 
 
 def _fit_text(

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -15,6 +15,7 @@ from textual.worker import NoActiveWorker, WorkerCancelled, get_current_worker
 
 from rovr.classes.type_aliases import ShellRunTypes
 from rovr.functions.cwd import getcwd
+from rovr.variables.maps import RovrVars
 
 
 def set_scuffed_subtitle(element: DOMNode, *sections: str) -> None:
@@ -399,6 +400,9 @@ def s(item: Any, notone: str = "s", isone: str = "") -> str:
     return isone if len(item) == 1 else notone
 
 
+preview_loc = os.path.join(RovrVars.ROVRCACHE, "previews")
+
+
 def load_from_cache(
     realpath: str,
     preview_type: str,
@@ -408,18 +412,16 @@ def load_from_cache(
 ) -> bytes | None:
     from hashlib import blake2b
 
-    from rovr.variables.maps import RovrVars
-
-    blk2b = blake2b(
+    hash = blake2b(
         f"{realpath}:{preview_type}:{stat_res.st_mtime_ns}:{stat_res.st_size}:{sig[0]}:{sig[1]}:{extra}".encode(),
         digest_size=16,
-    )
-    cache_path = os.path.join(RovrVars.ROVRCACHE, blk2b.hexdigest())
+    ).hexdigest()
+    cache_path = os.path.join(preview_loc, hash)
     try:
         with open(cache_path, "rb") as f:
             return f.read()
     except OSError:
-        return None
+        pass
 
 
 def save_to_cache(
@@ -428,19 +430,17 @@ def save_to_cache(
     stat_res: os.stat_result,
     sig: tuple[str, str],
     data: bytes,
-    index: int | None = None,
+    extra: Any = None,
 ) -> None:
     from hashlib import blake2b
 
-    from rovr.variables.maps import RovrVars
-
-    blk2b = blake2b(
-        f"{realpath}:{preview_type}:{stat_res.st_mtime_ns}:{stat_res.st_size}:{sig[0]}:{sig[1]}:{index}".encode(),
+    hash = blake2b(
+        f"{realpath}:{preview_type}:{stat_res.st_mtime_ns}:{stat_res.st_size}:{sig[0]}:{sig[1]}:{extra}".encode(),
         digest_size=16,
-    )
+    ).hexdigest()
     try:
-        os.makedirs(RovrVars.ROVRCACHE, exist_ok=True)
-        with open(os.path.join(RovrVars.ROVRCACHE, blk2b.hexdigest()), "wb") as f:
+        os.makedirs(preview_loc, exist_ok=True)
+        with open(os.path.join(preview_loc, hash), "wb") as f:
             f.write(data)
     except OSError:
         pass

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -428,7 +428,7 @@ def load_from_cache(
         elif pass_as is str:
             return content.decode()
         return content
-    except OSError:
+    except Exception:
         pass
 
 

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import os
 import re
 import subprocess
@@ -233,6 +232,8 @@ def dismiss(
 
 
 def multiprocessing_process_error_checker(app: App, exc: Exception) -> bool:
+    import multiprocessing
+
     is_dev = globals().get("is_dev", False)
     if isinstance(exc, ValueError) and "fds_to_keep" in str(exc):
         match multiprocessing.get_start_method(allow_none=True):
@@ -396,3 +397,50 @@ def command(
 
 def s(item: Any, notone: str = "s", isone: str = "") -> str:
     return isone if len(item) == 1 else notone
+
+
+def load_from_cache(
+    realpath: str,
+    preview_type: str,
+    stat_res: os.stat_result,
+    sig: tuple[str, str],
+    index: int | None = None,
+) -> bytes | None:
+    from hashlib import blake2b
+
+    from rovr.variables.maps import RovrVars
+
+    blk2b = blake2b(
+        f"{realpath}:{preview_type}:{stat_res.st_mtime_ns}:{stat_res.st_size}:{sig[0]}:{sig[1]}:{index}".encode(),
+        digest_size=16,
+    )
+    cache_path = os.path.join(RovrVars.ROVRCACHE, blk2b.hexdigest())
+    try:
+        with open(cache_path, "rb") as f:
+            return f.read()
+    except OSError:
+        return None
+
+
+def save_to_cache(
+    realpath: str,
+    preview_type: str,
+    stat_res: os.stat_result,
+    sig: tuple[str, str],
+    data: bytes,
+    index: int | None = None,
+) -> None:
+    from hashlib import blake2b
+
+    from rovr.variables.maps import RovrVars
+
+    blk2b = blake2b(
+        f"{realpath}:{preview_type}:{stat_res.st_mtime_ns}:{stat_res.st_size}:{sig[0]}:{sig[1]}:{index}".encode(),
+        digest_size=16,
+    )
+    try:
+        os.makedirs(RovrVars.ROVRCACHE, exist_ok=True)
+        with open(os.path.join(RovrVars.ROVRCACHE, blk2b.hexdigest()), "wb") as f:
+            f.write(data)
+    except OSError:
+        pass

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -400,7 +400,7 @@ def s(item: Any, notone: str = "s", isone: str = "") -> str:
     return isone if len(item) == 1 else notone
 
 
-preview_loc = os.path.join(RovrVars.ROVRCACHE, "previews")
+preview_loc = os.path.join(RovrVars.ROVRTEMP, "previews")
 
 
 def load_from_cache(

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -404,14 +404,14 @@ def load_from_cache(
     preview_type: str,
     stat_res: os.stat_result,
     sig: tuple[str, str],
-    index: int | None = None,
+    extra: Any = None,
 ) -> bytes | None:
     from hashlib import blake2b
 
     from rovr.variables.maps import RovrVars
 
     blk2b = blake2b(
-        f"{realpath}:{preview_type}:{stat_res.st_mtime_ns}:{stat_res.st_size}:{sig[0]}:{sig[1]}:{index}".encode(),
+        f"{realpath}:{preview_type}:{stat_res.st_mtime_ns}:{stat_res.st_size}:{sig[0]}:{sig[1]}:{extra}".encode(),
         digest_size=16,
     )
     cache_path = os.path.join(RovrVars.ROVRCACHE, blk2b.hexdigest())

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -409,7 +409,8 @@ def load_from_cache(
     stat_res: os.stat_result,
     sig: tuple[str, str],
     extra: Any = None,
-) -> bytes | None:
+    pass_as: type[Any] = bytes,
+) -> Any | None:
     from hashlib import blake2b
 
     hash = blake2b(
@@ -419,7 +420,14 @@ def load_from_cache(
     cache_path = os.path.join(preview_loc, hash)
     try:
         with open(cache_path, "rb") as f:
-            return f.read()
+            content = f.read()
+        if pass_as is list or pass_as is dict:
+            import json
+
+            return json.loads(content.decode())
+        elif pass_as is str:
+            return content.decode()
+        return content
     except OSError:
         pass
 
@@ -429,7 +437,7 @@ def save_to_cache(
     preview_type: str,
     stat_res: os.stat_result,
     sig: tuple[str, str],
-    data: bytes,
+    data: Any,
     extra: Any = None,
 ) -> None:
     from hashlib import blake2b
@@ -440,6 +448,16 @@ def save_to_cache(
     ).hexdigest()
     try:
         os.makedirs(preview_loc, exist_ok=True)
+        if isinstance(data, (dict, list)):
+            import json
+
+            data = json.dumps(
+                data, ensure_ascii=False, check_circular=False, separators=(",", ":")
+            ).encode()
+        elif isinstance(data, str):
+            data = data.encode()
+        elif not isinstance(data, bytes):
+            data = str(data).encode()
         with open(os.path.join(preview_loc, hash), "wb") as f:
             f.write(data)
     except OSError:

--- a/src/rovr/variables/maps.py
+++ b/src/rovr/variables/maps.py
@@ -62,12 +62,10 @@ VALID_KEY_CONTEXTS = frozenset({
 
 @dataclass
 class RovrVars:
-    ROVRCONFIG = (environ.get("ROVR_CONFIG_FOLDER") or dirs.user_config_dir).replace(
-        "\\", "/"
-    )
+    ROVRCONFIG = environ.get("ROVR_CONFIG_FOLDER") or dirs.user_config_dir
     ROVRTHEMES = ROVRCONFIG + "/themes"
-    ROVRCACHE = dirs.user_cache_dir.replace("\\", "/")
-    ROVRTEMP = dirs.user_runtime_dir.replace("\\", "/")
+    ROVRCACHE = dirs.user_cache_dir
+    ROVRTEMP = dirs.user_runtime_dir
     DOCUMENTS = general.user_documents_dir.replace("\\", "/")
     DOWNLOADS = general.user_downloads_dir.replace("\\", "/")
     PICTURES = general.user_pictures_dir.replace("\\", "/")


### PR DESCRIPTION
closes #337 

cache preview stuff

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Cache generated file previews and provide a way to clear the preview cache.

New Features:
- Add persistent caching for generated previews, including images, fonts, SVGs, PDFs, syntax-highlighted text, bat output, archives, and drag images.
- Add a developer CLI option to clear the preview cache.

Enhancements:
- Reuse cached previews based on source file metadata and rendering configuration while gracefully ignoring invalid cache entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Preview loading is faster through improved caching for images, PDFs, archive listings and rich text.
  * Drag-and-drop image previews can now be reused from cache.

* **Reliability**
  * Invalid or unavailable cached data is safely ignored and regenerated.

* **Improvements**
  * Cache clearing now targets preview data without removing other temporary files.
  * Configuration output now distinguishes configuration, state and temporary directories, with additional settings details.
  * Cache verification now reports remaining preview items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->