### PR TITLE
feat: scrollable text preview

### DIFF
--- a/src/rovr/assets/config.toml
+++ b/src/rovr/assets/config.toml
@@ -28,6 +28,7 @@ max_size = [1000, 1000]
 font_size = 50
 
 [interface.preview_text]
+max_file_size = 2097152
 error = "couldn't read this file! (\u00AC_\u00AC)" # ¬_¬
 start = """
   ___ ___

--- a/src/rovr/assets/schema.json
+++ b/src/rovr/assets/schema.json
@@ -361,6 +361,12 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "max_file_size": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 2097152,
+              "description": "Maximum number of bytes loaded for a text preview. Larger files are truncated and report the ignored line and byte counts."
+            },
             "error": {
               "type": "string",
               "default": "couldn't read this file! (\u00ac_\u00ac )",

--- a/src/rovr/classes/config.pyi
+++ b/src/rovr/classes/config.pyi
@@ -94,7 +94,7 @@ r""" Default value of the field path 'Rovr Config interface preview_text error' 
 _ROVR_CONFIG_INTERFACE_PREVIEW_TEXT_FONT_TEXT_DEFAULT = "abcdefghijklmnopqrstuvwxyz\nABCDEFGHIJKLMNOPQRSTUVWXYZ\noO08 iIlL1 g9qCQG a@ 5sS\n{} [==>  ] (*) <> ~-+ /\\\n"
 r""" Default value of the field path 'Rovr Config interface preview_text font_text' """
 
-_ROVR_CONFIG_INTERFACE_PREVIEW_TEXT_MAX_FILE_SIZE_DEFAULT = 1048576
+_ROVR_CONFIG_INTERFACE_PREVIEW_TEXT_MAX_FILE_SIZE_DEFAULT = 2097152
 r""" Default value of the field path 'Rovr Config interface preview_text max_file_size' """
 
 _ROVR_CONFIG_INTERFACE_PREVIEW_TEXT_START_DEFAULT = (
@@ -891,7 +891,7 @@ class _RovrConfigInterfacePreviewText(TypedDict, total=False):
     Maximum number of bytes loaded for a text preview. Larger files are truncated and report the ignored line and byte counts.
 
     minimum: 1
-    default: 1048576
+    default: 2097152
     """
 
     error: str

--- a/src/rovr/classes/config.pyi
+++ b/src/rovr/classes/config.pyi
@@ -94,6 +94,9 @@ r""" Default value of the field path 'Rovr Config interface preview_text error' 
 _ROVR_CONFIG_INTERFACE_PREVIEW_TEXT_FONT_TEXT_DEFAULT = "abcdefghijklmnopqrstuvwxyz\nABCDEFGHIJKLMNOPQRSTUVWXYZ\noO08 iIlL1 g9qCQG a@ 5sS\n{} [==>  ] (*) <> ~-+ /\\\n"
 r""" Default value of the field path 'Rovr Config interface preview_text font_text' """
 
+_ROVR_CONFIG_INTERFACE_PREVIEW_TEXT_MAX_FILE_SIZE_DEFAULT = 1048576
+r""" Default value of the field path 'Rovr Config interface preview_text max_file_size' """
+
 _ROVR_CONFIG_INTERFACE_PREVIEW_TEXT_START_DEFAULT = (
     " ___ ___\n|  _| . |\n|_| |___|\n _ _ ___\n| | |  _|\n \\_/|_|\n"
 )
@@ -883,6 +886,14 @@ _ROVRCONFIGINTERFACEIMAGEVIEWERRESAMPLING_LANCZOS: Literal["lanczos"] = "lanczos
 r"""The values for the 'The resampling method to use when resizing images. This is only applicable when the image exceeds the maximum size specified in `max_size`' enum"""
 
 class _RovrConfigInterfacePreviewText(TypedDict, total=False):
+    max_file_size: int
+    r"""
+    Maximum number of bytes loaded for a text preview. Larger files are truncated and report the ignored line and byte counts.
+
+    minimum: 1
+    default: 1048576
+    """
+
     error: str
     r"""
     If for any reason the file preview refused to show, this appears.

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -1167,10 +1167,11 @@ class PreviewContainer(Actionable, Container):
                     raw_content = file.read(max_file_size)
                     ignored_bytes = stat_result.st_size - len(raw_content)
                     ignored_lines = 0
-                    last_byte = b""
-                    while chunk := file.read(1024 * 1024):
+                    remaining_bytes = stat_result.st_size - len(raw_content)
+                    scan_limit = min(remaining_bytes, max_file_size)
+                    if scan_limit > 0:
+                        chunk = file.read(scan_limit)
                         ignored_lines += chunk.count(b"\n")
-                        last_byte = chunk[-1:]
                         if should_cancel():
                             return
             except FileNotFoundError:
@@ -1183,15 +1184,11 @@ class PreviewContainer(Actionable, Container):
                 content, incomplete_bytes = decoded
                 ignored_bytes += incomplete_bytes
                 if ignored_bytes:
-                    if last_byte != b"\n":
-                        ignored_lines += 1
                     if raw_content and not raw_content.endswith(b"\n"):
                         ignored_lines = max(0, ignored_lines - 1)
                     if not content.endswith("\n"):
                         content += "\n"
-                    content += (
-                        f"({ignored_lines:,} lines/{ignored_bytes:,} bytes ignored)"
-                    )
+                    content += f"---\n~({ignored_lines:,} lines/{ignored_bytes:,} bytes ignored)"
                 save_to_cache(
                     realpath, "windowed_text", stat_result, signature, content
                 )

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -15,16 +15,19 @@ import textual_image.renderable
 import textual_image.widget
 from PIL import Image, UnidentifiedImageError
 from PIL.Image import Image as PILImage
-from rich.console import Console
+from rich.cells import cell_len
 from rich.errors import MarkupError
+from rich.syntax import Syntax
 from rich.text import Text
 from textual import events, on, work
 from textual.app import ComposeResult
 from textual.containers import Container
 from textual.css.query import NoMatches
 from textual.dom import DOMNode
-from textual.geometry import Region
+from textual.geometry import Region, Size
 from textual.highlight import guess_language
+from textual.scroll_view import ScrollView
+from textual.strip import Strip
 from textual.timer import Timer
 from textual.widgets import Static
 from textual.widgets.selection_list import Selection
@@ -58,6 +61,17 @@ from rovr.variables.constants import (
 titles = PreviewContainerTitles()
 
 PREVIEWER_GROUP = "previewers"
+TEXT_PREVIEW_CACHE_VERSION = "windowed-v2"
+TEXT_ENCODINGS = (
+    "utf8",
+    "utf16",
+    "utf32",
+    "latin1",
+    "iso8859-1",
+    "mbcs",
+    "ascii",
+    "us-ascii",
+)
 T = TypeVar("T")
 preview_token: ContextVar[object] = ContextVar("preview_token")
 IMAGE_CACHE_SIGNATURE = (
@@ -67,6 +81,124 @@ IMAGE_CACHE_SIGNATURE = (
 
 
 class ExitNow(RuntimeError): ...
+
+
+def _decode_text_preview(data: bytes, truncated: bool) -> tuple[str, int] | None:
+    for encoding in TEXT_ENCODINGS:
+        try:
+            return data.decode(encoding), 0
+        except UnicodeDecodeError as exc:
+            if truncated and exc.end == len(data):
+                try:
+                    return data[: exc.start].decode(encoding), len(data) - exc.start
+                except UnicodeDecodeError:
+                    pass
+    return None
+
+
+class WindowedTextPreview(ScrollView):
+    """Render only the visible portion of a text preview."""
+
+    DEFAULT_CSS = """
+    WindowedTextPreview {
+        width: 1fr;
+        height: 1fr;
+        padding: 0;
+        scrollbar-size: 1 1;
+    }
+    """
+
+    def __init__(
+        self,
+        lines: list[str] | list[Text],
+        *,
+        language: str | None = None,
+        line_numbers: bool = False,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(classes=classes, can_focus=True)
+        self._lines: list[str] | list[Text] = []
+        self._language = language
+        self._line_numbers = line_numbers
+        self._gutter_width = 0
+        self._rendered_window: tuple[int, int, int, int, list[Strip]] | None = None
+        self.update_preview(lines, language=language, line_numbers=line_numbers)
+
+    def update_preview(
+        self,
+        lines: list[str] | list[Text],
+        *,
+        language: str | None = None,
+        line_numbers: bool = False,
+    ) -> None:
+        self._lines = lines or [""]
+        self._language = language
+        self._line_numbers = line_numbers
+        self._gutter_width = len(str(len(self._lines))) + 3 if line_numbers else 0
+        width = max(
+            cell_len((line.plain if isinstance(line, Text) else line).expandtabs(4))
+            for line in self._lines[:256]
+        )
+        self.virtual_size = Size(width + self._gutter_width, len(self._lines))
+        self._rendered_window = None
+        self.scroll_home(animate=False)
+        self.refresh(layout=True)
+
+    def _render_window(self, start: int, width: int, x: int) -> list[Strip]:
+        end = min(
+            start + max(self.scrollable_content_region.height, 1), len(self._lines)
+        )
+        selected = self._lines[start:end]
+        window_width = max(
+            cell_len((line.plain if isinstance(line, Text) else line).expandtabs(4))
+            for line in selected
+        )
+        if window_width + self._gutter_width > self.virtual_size.width:
+            self.virtual_size = Size(
+                window_width + self._gutter_width, self.virtual_size.height
+            )
+            self._scroll_update(self.virtual_size)
+        if self._language is not None:
+            renderable: Text | Syntax = Syntax(
+                "\n".join(cast(list[str], selected)),
+                lexer=self._language,
+                line_numbers=self._line_numbers,
+                start_line=start + 1,
+                word_wrap=False,
+                tab_size=4,
+                theme=config["theme"]["preview"],
+                background_color=(
+                    "default" if config["theme"]["transparent"] else None
+                ),
+                padding=0,
+            )
+        else:
+            renderable = Text("\n", no_wrap=True, overflow="crop").join(
+                cast(list[Text], selected)
+            )
+
+        options = self.app.console.options.update(width=max(x + width, 1))
+        background = self.visual_style.rich_style
+        return [
+            Strip(segments).crop(x, x + width).adjust_cell_length(width, background)
+            for segments in self.app.console.render_lines(
+                renderable, options, pad=False, new_lines=False
+            )
+        ]
+
+    def render_line(self, y: int) -> Strip:
+        width = self.scrollable_content_region.width
+        height = self.scrollable_content_region.height
+        start = int(self.scroll_offset.y)
+        x = int(self.scroll_offset.x)
+        cache = self._rendered_window
+        if cache is None or cache[:4] != (start, width, height, x):
+            lines = self._render_window(start, width, x)
+            cache = self._rendered_window = (start, width, height, x, lines)
+        try:
+            return cache[4][y]
+        except IndexError:
+            return Strip.blank(width, self.visual_style.rich_style)
 
 
 def _load_cached_image(
@@ -912,16 +1044,19 @@ class PreviewContainer(Actionable, Container):
             if config["interface"]["show_line_numbers"]
             else "--style=plain",
         ]
-        max_lines = self.call_from_thread(lambda: self.region.height)
-        if max_lines > 0:
-            command.append(f"--line-range=:{max_lines}")
+        # max_lines = self.call_from_thread(lambda: self.region.height)
+        # if max_lines > 0:
+        #     command.append(f"--line-range=:{max_lines}")
         assert self._current_file_path is not None
         command.extend(["--", self._current_file_path])
         realpath = path.realpath(self._current_file_path)
         stat_result = os.stat(realpath)
+        max_text_size = config["interface"]["preview_text"]["max_file_size"]
+        if stat_result.st_size > max_text_size:
+            return False
         signature = (
-            f"{max_lines}:{config['interface']['show_line_numbers']}",
-            bat_executable,
+            f"{config['interface']['show_line_numbers']}",
+            "",
         )
 
         if should_cancel():
@@ -972,22 +1107,30 @@ class PreviewContainer(Actionable, Container):
             if should_cancel():
                 return False
 
-            if static_widget := self.get_child("Static"):
-                self.log("Using existing Static")
-                self.call_from_thread(static_widget.update, new_content)
-                self.call_from_thread(static_widget.set_classes, "bat_preview")
+            lines = list(new_content.split("\n", allow_blank=True))
+            if text_preview := self.get_child(WindowedTextPreview):
+                self.call_from_thread(
+                    text_preview.update_preview,
+                    lines,
+                    language=None,
+                    line_numbers=False,
+                )
+                self.call_from_thread(
+                    text_preview.set_classes, "text_preview bat_preview"
+                )
             else:
-                self.log("Mounting new Static")
                 self.call_from_thread(self.remove_children)
 
                 if should_cancel():
                     return False
 
-                static_widget = Static(new_content, classes="bat_preview")
-                self.call_from_thread(self.mount, static_widget)
+                self.call_from_thread(
+                    lambda: self.mount(
+                        WindowedTextPreview(lines, classes="text_preview bat_preview")
+                    )
+                )
                 if should_cancel():
                     return False
-                static_widget.can_focus = True
             return True
         except ExitNow:
             raise
@@ -1008,95 +1151,94 @@ class PreviewContainer(Actionable, Container):
         if should_cancel():
             return
 
-        from rich.syntax import Syntax
-
         self.set_border("title", titles.file)
 
-        lines: list[str] | None = None
-        height = self.call_from_thread(lambda: self.region.height)
-        width = self.call_from_thread(lambda: self.region.width)
         assert self._current_file_path is not None
         realpath = path.realpath(self._current_file_path)
         stat_result = os.stat(realpath)
-        signature = (
-            f"{width}x{height}:{config['interface']['show_line_numbers']}",
-            f"{config['theme']['preview']}:{config['theme']['transparent']}",
+        max_file_size = config["interface"]["preview_text"]["max_file_size"]
+        signature = (str(max_file_size), TEXT_PREVIEW_CACHE_VERSION)
+        content: str | None = load_from_cache(
+            realpath, "windowed_text", stat_result, signature, pass_as=str
         )
-        new_content = _load_cached_text(realpath, "text", stat_result, signature)
-        if new_content is not None:
-            if static_widget := self.get_child("Static"):
-                self.call_from_thread(static_widget.update, new_content)
-            else:
-                self.call_from_thread(self.remove_children)
-                self.call_from_thread(self.mount, Static(new_content))
-            return
-
-        # force read by brute-forcing encoding methods
-        encodings_to_try = [
-            "utf8",
-            "utf16",
-            "utf32",
-            "latin1",
-            "iso8859-1",
-            "mbcs",
-            "ascii",
-            "us-ascii",
-        ]
-        for encoding in encodings_to_try:
+        if content is None:
             try:
-                lines: list[str] | None = []
-                with open(self._current_file_path, "r", encoding=encoding) as f:
-                    for _ in range(height):
-                        line = f.readline()
-                        if not line:
-                            break
-                        lines.append(line.strip("\n\r"))
+                with open(realpath, "rb") as file:
+                    raw_content = file.read(max_file_size)
+                    ignored_bytes = stat_result.st_size - len(raw_content)
+                    ignored_lines = 0
+                    last_byte = b""
+                    while chunk := file.read(1024 * 1024):
+                        ignored_lines += chunk.count(b"\n")
+                        last_byte = chunk[-1:]
                         if should_cancel():
                             return
-                break
-            except (UnicodeDecodeError, FileNotFoundError):
-                continue
-        if lines is None:
+            except FileNotFoundError:
+                return
+
+            decoded = _decode_text_preview(raw_content, ignored_bytes > 0)
+            if decoded is None:
+                content = None
+            else:
+                content, incomplete_bytes = decoded
+                ignored_bytes += incomplete_bytes
+                if ignored_bytes:
+                    if last_byte != b"\n":
+                        ignored_lines += 1
+                    if raw_content and not raw_content.endswith(b"\n"):
+                        ignored_lines = max(0, ignored_lines - 1)
+                    if not content.endswith("\n"):
+                        content += "\n"
+                    content += (
+                        f"({ignored_lines:,} lines/{ignored_bytes:,} bytes ignored)"
+                    )
+                save_to_cache(
+                    realpath, "windowed_text", stat_result, signature, content
+                )
+
+        if content is None:
             self._current_content = self._preview_texts["error"]
             self.mount_special_messages()
             return
 
-        text_to_display = "\n".join(lines)
-        # add syntax highlighting
-        language: str = (
-            guess_language(text_to_display, path=self._current_file_path) or "text"
-        )
-        syntax = Syntax(
-            text_to_display,
-            lexer=language,
-            line_numbers=config["interface"]["show_line_numbers"],
-            word_wrap=False,
-            tab_size=4,
-            theme=config["theme"]["preview"],
-            background_color="default" if config["theme"]["transparent"] else None,
-        )
-        console = Console(width=max(width, 1), color_system="truecolor")
-        new_content = Text.assemble(
-            *(
-                (segment.text, segment.style or "")
-                for segment in console.render(syntax)
-                if not segment.control
-            )
-        )
-        _save_cached_text(realpath, "text", stat_result, signature, new_content)
-
+        lines = content.splitlines() or [""]
+        sample_parts: list[str] = []
+        sample_length = 0
+        for line in lines:
+            remaining = 4096 - sample_length
+            if remaining <= 0:
+                break
+            sample_parts.append(line[:remaining])
+            sample_length += len(sample_parts[-1])
+        sample = "".join(sample_parts)
+        language: str = guess_language(sample, path=self._current_file_path) or "text"
         if should_cancel():
             return
 
-        if static_widget := self.get_child("Static"):
-            self.call_from_thread(static_widget.update, new_content)
+        if text_preview := self.get_child(WindowedTextPreview):
+            self.call_from_thread(
+                text_preview.update_preview,
+                lines,
+                language=language,
+                line_numbers=config["interface"]["show_line_numbers"],
+            )
+            self.call_from_thread(text_preview.set_classes, "text_preview")
         else:
             self.call_from_thread(self.remove_children)
 
             if should_cancel():
                 return
 
-            self.call_from_thread(self.mount, Static(new_content))
+            self.call_from_thread(
+                lambda: self.mount(
+                    WindowedTextPreview(
+                        lines,
+                        language=language,
+                        line_numbers=config["interface"]["show_line_numbers"],
+                        classes="text_preview",
+                    )
+                )
+            )
 
         if should_cancel():
             return
@@ -1573,6 +1715,8 @@ class PreviewContainer(Actionable, Container):
         """Trigger resize update from a thread."""
         context_token = preview_token.set(self._active_preview_token)
         try:
+            if self.get_child(WindowedTextPreview):
+                return
             if self.border_title in (
                 PreviewContainerTitles.file,
                 PreviewContainerTitles.bat,
@@ -1604,6 +1748,8 @@ class PreviewContainer(Actionable, Container):
     def action_up(self) -> None:
         if self._is_pdf() and self.pdf.images is not None:
             self.update_current_pdf_page_by_diff(-1)
+        elif text_preview := self.get_child(WindowedTextPreview):
+            text_preview.scroll_up(animate=False)
         elif self.border_title == titles.archive and (
             filelist := self.get_child(FileList)
         ):
@@ -1616,6 +1762,8 @@ class PreviewContainer(Actionable, Container):
     def action_down(self) -> None:
         if self._is_pdf() and self.pdf.images is not None:
             self.update_current_pdf_page_by_diff(1)
+        elif text_preview := self.get_child(WindowedTextPreview):
+            text_preview.scroll_down(animate=False)
         elif self.border_title == titles.archive and (
             filelist := self.get_child(FileList)
         ):
@@ -1628,6 +1776,8 @@ class PreviewContainer(Actionable, Container):
     def action_page_up(self) -> None:
         if self._is_pdf() and self.pdf.images is not None:
             self.update_current_pdf_page_by_diff(-1)
+        elif text_preview := self.get_child(WindowedTextPreview):
+            text_preview.scroll_page_up(animate=False)
         elif self.border_title == titles.archive and (
             filelist := self.get_child(FileList)
         ):
@@ -1640,6 +1790,8 @@ class PreviewContainer(Actionable, Container):
     def action_page_down(self) -> None:
         if self._is_pdf() and self.pdf.images is not None:
             self.update_current_pdf_page_by_diff(1)
+        elif text_preview := self.get_child(WindowedTextPreview):
+            text_preview.scroll_page_down(animate=False)
         elif self.border_title == titles.archive and (
             filelist := self.get_child(FileList)
         ):
@@ -1652,6 +1804,8 @@ class PreviewContainer(Actionable, Container):
     def action_home(self) -> None:
         if self._is_pdf() and self.pdf.images is not None:
             self.update_current_pdf_page(0)
+        elif text_preview := self.get_child(WindowedTextPreview):
+            text_preview.scroll_home(animate=False)
         elif self.border_title == titles.archive and (
             filelist := self.get_child(FileList)
         ):
@@ -1664,6 +1818,8 @@ class PreviewContainer(Actionable, Container):
     def action_end(self) -> None:
         if self._is_pdf() and self.pdf.images is not None:
             self.update_current_pdf_page(self.pdf.total_pages - 1)
+        elif text_preview := self.get_child(WindowedTextPreview):
+            text_preview.scroll_end(animate=False)
         elif self.border_title == titles.archive and (
             filelist := self.get_child(FileList)
         ):

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -48,6 +48,7 @@ from rovr.functions.pdf import get_pdf_images, get_pdf_info
 from rovr.functions.utils import (
     load_from_cache,
     multiprocessing_process_error_checker,
+    s,
     save_to_cache,
     should_cancel,
 )
@@ -1188,7 +1189,7 @@ class PreviewContainer(Actionable, Container):
                         ignored_lines = max(0, ignored_lines - 1)
                     if not content.endswith("\n"):
                         content += "\n"
-                    content += f"---\n~({ignored_lines:,} lines/{ignored_bytes:,} bytes ignored)"
+                    content += f"---\n(~{ignored_lines:,} line{s(ignored_lines)}/{ignored_bytes:,} byte{s(ignored_bytes)} ignored)"
                 save_to_cache(
                     realpath, "windowed_text", stat_result, signature, content
                 )

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -1056,7 +1056,7 @@ class PreviewContainer(Actionable, Container):
             return False
         signature = (
             f"{config['interface']['show_line_numbers']}",
-            "",
+            bat_executable,
         )
 
         if should_cancel():

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -397,7 +397,12 @@ def command(
 
 
 def s(item: Any, notone: str = "s", isone: str = "") -> str:
-    return isone if len(item) == 1 else notone
+    return (
+        isone
+        if (isinstance(item, list) and len(item) == 1)
+        or (type(item) is int and item == 1)
+        else notone
+    )
 
 
 preview_loc = os.path.join(RovrVars.ROVRTEMP, "previews")

--- a/src/rovr/style.tcss
+++ b/src/rovr/style.tcss
@@ -396,21 +396,34 @@ Tooltip {
   height: 1fr;
   padding: 0
 }
-
+PreviewContainer > LoadingPreview {
+  margin-left: 1
+}
 #preview_sidebar {
   margin: 0;
   padding: 0;
   width: $preview_sidebar_width;
   layout: horizontal;
   height: 1fr;
-  & > Static {
-    text-overflow: ellipsis;
-    text-wrap: nowrap;
+  overflow: auto;
+  scrollbar-size: 1 1;
+  & > .text_preview {
     width: 1fr;
-    overflow-x: hidden;
+    height: 1fr;
+    scrollbar-size: 1 1;
+  }
+  & > Static {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-wrap: wrap;
+    width: auto;
+    padding: 0 1;
     &.special {
-      text-overflow: fold;
-      text-wrap: wrap;
+      padding: 0 1;
+      width: 1fr;
+    }
+    &#bat_preview {
+      padding: 0
     }
   }
   & > Widget {
@@ -421,19 +434,6 @@ Tooltip {
     margin: 0;
     &.-maximized {
       border: $border-style $border-focused
-    }
-    &Static {
-      padding: 0 1;
-      scrollbar-size: 0 0;
-      overflow: hidden;
-      &#bat_preview {
-        padding: 0
-      }
-      &#special {
-        text-wrap: wrap;
-        text-overflow: fold;
-        padding: 0 1;
-      }
     }
     &FileList { height: 1fr }
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,9 @@ def isolate_test_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
     config_root = config_dir.as_posix()
     monkeypatch.setattr(maps.RovrVars, "ROVRCONFIG", config_root)
+    monkeypatch.setattr(
+        maps.RovrVars, "ROVRTEMP", tempfile.mkdtemp(prefix="rovr_test_temp_")
+    )
 
     cache_root = (config_dir / "cache").as_posix()
     monkeypatch.setattr(maps.RovrVars, "ROVRSTATE", cache_root)

--- a/tests/test_preview_container.py
+++ b/tests/test_preview_container.py
@@ -88,9 +88,12 @@ async def test_normal_preview_mounts_windowed_content(tmp_path: Path) -> None:
             finally:
                 preview_token.reset(context_token)
 
-        await asyncio.to_thread(show_preview)
+        with (
+            patch("rovr.core.preview_container.load_from_cache", return_value=None),
+            patch("rovr.core.preview_container.save_to_cache"),
+        ):
+            await asyncio.to_thread(show_preview)
         await pilot.pause()
-
         text_preview = preview.query_one(WindowedTextPreview)
         assert "value" in text_preview.render_line(0).text
 

--- a/tests/test_preview_container.py
+++ b/tests/test_preview_container.py
@@ -1,14 +1,33 @@
 import asyncio
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import patch
 
 import pytest
 from textual.app import App, ComposeResult
 
-from rovr.core.preview_container import ExitNow, PreviewContainer, preview_token
+from rovr.core.preview_container import (
+    ExitNow,
+    PreviewContainer,
+    WindowedTextPreview,
+    _decode_text_preview,
+    preview_token,
+)
+from rovr.variables.constants import config
 
 
 class PreviewTestApp(App[None]):
     def compose(self) -> ComposeResult:
         yield PreviewContainer()
+
+
+class WindowedPreviewTestApp(App[None]):
+    CSS = "WindowedTextPreview { width: 30; height: 5; }"
+
+    def compose(self) -> ComposeResult:
+        yield WindowedTextPreview(
+            [f"line {line}" for line in range(10_000)], language="python"
+        )
 
 
 async def test_call_from_thread_rejects_stale_preview() -> None:
@@ -30,3 +49,96 @@ async def test_call_from_thread_rejects_stale_preview() -> None:
         preview._active_preview_token = object()
         with pytest.raises(ExitNow):
             await asyncio.to_thread(call_with, current_token)
+
+
+async def test_windowed_preview_only_renders_visible_lines() -> None:
+    app = WindowedPreviewTestApp()
+
+    async with app.run_test(size=(40, 10)) as pilot:
+        preview = app.query_one(WindowedTextPreview)
+        await pilot.pause()
+
+        initial_width = preview.virtual_size.width
+        preview.render_line(0)
+        assert preview.virtual_size.height == 10_000
+        assert preview._rendered_window is not None
+        assert len(preview._rendered_window[4]) <= preview.size.height
+
+        preview.scroll_end(animate=False)
+        await pilot.pause()
+        assert preview.scroll_offset.y > 9_000
+        assert f"line {int(preview.scroll_offset.y)}" in preview.render_line(0).text
+        assert preview.virtual_size.width > initial_width
+
+
+async def test_normal_preview_mounts_windowed_content(tmp_path: Path) -> None:
+    source = tmp_path / "large.py"
+    source.write_text("value = 1\nvalue = 2\n", encoding="utf-8")
+    app = PreviewTestApp()
+
+    async with app.run_test(size=(80, 20)) as pilot:
+        preview = app.query_one(PreviewContainer)
+        preview._current_file_path = str(source)
+        token = preview._active_preview_token
+
+        def show_preview() -> None:
+            context_token = preview_token.set(token)
+            try:
+                preview.show_normal_file_preview()
+            finally:
+                preview_token.reset(context_token)
+
+        await asyncio.to_thread(show_preview)
+        await pilot.pause()
+
+        text_preview = preview.query_one(WindowedTextPreview)
+        assert "value" in text_preview.render_line(0).text
+
+
+async def test_truncated_preview_is_cached(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "large.txt"
+    source.write_bytes(b"first\nsecond\nthird\n")
+    monkeypatch.setitem(
+        cast(dict[str, Any], config["interface"]["preview_text"]),
+        "max_file_size",
+        6,
+    )
+    app = PreviewTestApp()
+
+    async with app.run_test(size=(80, 20)) as pilot:
+        preview = app.query_one(PreviewContainer)
+        preview._current_file_path = str(source)
+        token = preview._active_preview_token
+
+        def show_preview() -> None:
+            context_token = preview_token.set(token)
+            try:
+                preview.show_normal_file_preview()
+            finally:
+                preview_token.reset(context_token)
+
+        with (
+            patch("rovr.core.preview_container.load_from_cache", return_value=None),
+            patch("rovr.core.preview_container.save_to_cache") as save,
+        ):
+            await asyncio.to_thread(show_preview)
+        await pilot.pause()
+
+        cached_content = save.call_args.args[4]
+        assert cached_content == "first\n(2 lines/13 bytes ignored)"
+
+        with (
+            patch(
+                "rovr.core.preview_container.load_from_cache",
+                return_value=cached_content,
+            ),
+            patch("rovr.core.preview_container.save_to_cache") as save,
+        ):
+            await asyncio.to_thread(show_preview)
+        assert not save.called
+
+
+def test_truncated_multibyte_character_is_counted_as_ignored() -> None:
+    assert _decode_text_preview("é".encode()[:1], truncated=True) == ("", 1)

--- a/tests/test_preview_container.py
+++ b/tests/test_preview_container.py
@@ -130,7 +130,7 @@ async def test_truncated_preview_is_cached(
         await pilot.pause()
 
         cached_content = save.call_args.args[4]
-        assert cached_content == "first\n(1+ lines/13 bytes ignored)"
+        assert cached_content == "first\n---\n(~0 lines/13 bytes ignored)"
 
         with (
             patch(

--- a/tests/test_preview_container.py
+++ b/tests/test_preview_container.py
@@ -130,7 +130,7 @@ async def test_truncated_preview_is_cached(
         await pilot.pause()
 
         cached_content = save.call_args.args[4]
-        assert cached_content == "first\n(2 lines/13 bytes ignored)"
+        assert cached_content == "first\n(1+ lines/13 bytes ignored)"
 
         with (
             patch(


### PR DESCRIPTION
ah right, custom scrollable container

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Add efficient, configurable scrolling for text previews with bounded loading and truncation reporting.

New Features:
- Add a scrollable text preview that renders only the visible content while supporting syntax highlighting, line numbers, horizontal scrolling, and keyboard navigation.

Bug Fixes:
- Prevent oversized text files from being loaded beyond the configured preview limit and report ignored bytes and lines for truncated previews.
- Handle truncated multibyte text safely during preview decoding.

Enhancements:
- Cache windowed text previews independently of viewport dimensions and improve preview language detection using sampled content.

Tests:
- Add coverage for visible-window rendering, scrolling, preview mounting, truncation metadata, caching, and multibyte decoding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable text preview limits now default to 2 MB.
  * Large previews show ignored line and byte counts.
  * Text previews render efficiently in scrollable windows with syntax highlighting and line numbers.
  * Preview navigation supports scrolling.
  * Oversized `bat` previews are rejected before loading.
* **Bug Fixes**
  * Improved handling of large and multibyte text files.
  * Resizing previews no longer unnecessarily re-renders content.
* **Style**
  * Refined preview spacing, wrapping and scrollbar presentation for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->