### PR TITLE
feat: chord keys

### DIFF
--- a/docs/src/content/docs/dev/reference/keybindings.mdx
+++ b/docs/src/content/docs/dev/reference/keybindings.mdx
@@ -323,6 +323,15 @@ The `keybinds` context also supports `focus_search`. `shell_exec` supports `cycl
 
 These actions apply only while their corresponding modal is open.
 
+## Description substitution
+
+Certain actions support expansions based on their state.
+
+#### `sort_order.toggle_custom_sort`
+- `%state`: returns "enable" if the sort order set is for that folder only. "disable" otherwise
+- `%nextstate`: opposite of `%state`
+- `%State` and `%Nextstate`: same as above, but capitalized
+
 ## Finding the key names
 
 Run `rovr --show-keys` to display the key name that will be used.

--- a/src/rovr/action_buttons/sort_order.py
+++ b/src/rovr/action_buttons/sort_order.py
@@ -122,6 +122,29 @@ class SortOrderButton(Button):
             descending = not state_manager.get_sort_prefs()[1]
         self.action_set(state_manager.get_sort_prefs()[0], descending)
 
+    def action_toggle_custom_sort(self) -> None:
+        self.app.query_one(StateManager).toggle_custom_sort()
+        self.app.file_list.update_file_list(add_to_session=False)
+        self.update_icon()
+
+    def describe_key_chord_action(self, action: str, description: str) -> str:
+        if action == "sort_order.toggle_custom_sort":
+            enabled = self.app.query_one(StateManager).custom_sort_enabled
+            old_desc = description
+            state = "enable" if enabled else "disable"
+            nstate = "disable" if enabled else "enable"
+            description = (
+                description
+                .replace("%state", state)
+                .replace("%nextstate", nstate)
+                .replace("%State", state.capitalize())
+                .replace("%Nextstate", nstate.capitalize())
+            )
+            return f"{description}" + (
+                " (currently enabled)" if enabled and old_desc == description else ""
+            )
+        return description
+
 
 class SortOrderPopup(PopupOptionList):
     key_contexts = ("sort_menu", "popup_list", "lists")
@@ -208,15 +231,10 @@ class SortOrderPopup(PopupOptionList):
         )
 
     def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
-        state_manager: StateManager = self.app.query_one(StateManager)
-
         if event.option.id == "descending":
             self.button.action_descending()
         elif event.option.id == "custom_sort":
-            # Toggle custom sort for this folder
-            state_manager.toggle_custom_sort()
-            self.app.file_list.update_file_list(add_to_session=False)
-            self.button.update_icon()
+            self.button.action_toggle_custom_sort()
         else:
             self.button.action_set(cast(SortByOptions, event.option.id))
 

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -49,7 +49,7 @@ from rovr.action_buttons import (
     ZipButton,
 )
 from rovr.action_buttons.sort_order import SortOrderButton
-from rovr.classes.app_mixins import DragAndDrop, KeyHandler, ThemeHandler
+from rovr.classes.app_mixins import DragAndDrop, KeyChordPopup, KeyHandler, ThemeHandler
 from rovr.classes.mixins import Action, Actionable
 from rovr.classes.theme import RovrStylesheet
 from rovr.classes.type_aliases import KeysConfig, ShellRunTypes
@@ -325,6 +325,7 @@ class Application(
                 yield ProcessContainer().data_bind(Application.theme)
                 yield MetadataContainer()
                 yield self.Clipboard
+            yield KeyChordPopup()
             yield StateManager()
 
     def on_mount(self) -> None:

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -49,7 +49,7 @@ from rovr.action_buttons import (
     ZipButton,
 )
 from rovr.action_buttons.sort_order import SortOrderButton
-from rovr.classes.app_mixins import DragAndDrop, KeyChordPopup, KeyHandler, ThemeHandler
+from rovr.classes.app_mixins import DragAndDrop, KeyHandler, ThemeHandler
 from rovr.classes.mixins import Action, Actionable
 from rovr.classes.theme import RovrStylesheet
 from rovr.classes.type_aliases import KeysConfig, ShellRunTypes
@@ -325,7 +325,6 @@ class Application(
                 yield ProcessContainer().data_bind(Application.theme)
                 yield MetadataContainer()
                 yield self.Clipboard
-            yield KeyChordPopup()
             yield StateManager()
 
     def on_mount(self) -> None:

--- a/src/rovr/assets/keys.toml
+++ b/src/rovr/assets/keys.toml
@@ -73,8 +73,23 @@
 "o" = { action = "open", desc = "Open selected files" }
 "e" = { action = "open_editor", desc = "Open the current file in an editor" }
 "shift+f10" = { action = "open_right_click_menu", desc = "Open the context menu" }
-"Y" = { action = "copy.open_popup", desc = "Open the copy menu" }
-"," = { action = "sort_order.open_popup", desc = "Open the sort menu" }
+
+[file_list.Y]
+desc = "Copy"
+"y" = { action = "copy.to_rovr", desc = "Copy files to the rovr clipboard" }
+"p" = { action = "copy.highlighted", desc = "Copy the highlighted file path" }
+"s" = { action = "copy.to_system_clip", desc = "Copy files to the system clipboard" }
+"d" = { action = "copy.current_directory", desc = "Copy the current directory path" }
+
+[file_list.","]
+desc = "Sort order"
+"a" = { action = "sort_order.name", desc = "Sort by name" }
+"e" = { action = "sort_order.extension", desc = "Sort by extension" }
+"n" = { action = "sort_order.natural", desc = "Sort naturally" }
+"s" = { action = "sort_order.size", desc = "Sort by size" }
+"c" = { action = "sort_order.created", desc = "Sort by creation time" }
+"m" = { action = "sort_order.modified", desc = "Sort by modification time" }
+"d" = { action = "sort_order.descending", desc = "Toggle descending order" }
 
 [pinned_sidebar]
 "/" = { action = "focus_search", desc = "Search pinned directories" }

--- a/src/rovr/assets/keys.toml
+++ b/src/rovr/assets/keys.toml
@@ -227,7 +227,7 @@ desc = "Sort order"
 "?" = "exit"
 
 [yes_or_no]
-"y" = "yes"
+y.y = "yes"
 "n" = "no"
 "escape" = "no"
 "a" = "dont_ask_again"

--- a/src/rovr/assets/keys.toml
+++ b/src/rovr/assets/keys.toml
@@ -90,6 +90,7 @@ desc = "Sort order"
 "c" = { action = "sort_order.created", desc = "Sort by creation time" }
 "m" = { action = "sort_order.modified", desc = "Sort by modification time" }
 "d" = { action = "sort_order.descending", desc = "Toggle descending order" }
+"p" = { action = "sort_order.toggle_custom_sort", desc = "%Nextstate sorting for this path only" }
 
 [pinned_sidebar]
 "/" = { action = "focus_search", desc = "Search pinned directories" }

--- a/src/rovr/assets/keys.toml
+++ b/src/rovr/assets/keys.toml
@@ -227,7 +227,7 @@ desc = "Sort order"
 "?" = "exit"
 
 [yes_or_no]
-y.y = "yes"
+"y" = "yes"
 "n" = "no"
 "escape" = "no"
 "a" = "dont_ask_again"

--- a/src/rovr/assets/presets/sane.toml
+++ b/src/rovr/assets/presets/sane.toml
@@ -62,8 +62,23 @@
 "o" = { action = "open", desc = "Open selected files" }
 "ctrl+o" = { action = "open_editor", desc = "Open the current file in an editor" }
 "shift+f10" = { action = "open_right_click_menu", desc = "Open the context menu" }
-"C" = { action = "copy.open_popup", desc = "Open the copy menu" }
-"," = { action = "sort_order.open_popup", desc = "Open the sort menu" }
+
+[file_list.C]
+desc = "Copy"
+"r" = { action = "copy.to_rovr", desc = "Copy files to the rovr clipboard" }
+"p" = { action = "copy.highlighted", desc = "Copy the highlighted file path" }
+"s" = { action = "copy.to_system_clip", desc = "Copy files to the system clipboard" }
+"u" = { action = "copy.current_directory", desc = "Copy the current directory path" }
+
+[file_list.","]
+desc = "Sort order"
+"a" = { action = "sort_order.name", desc = "Sort by name" }
+"e" = { action = "sort_order.extension", desc = "Sort by extension" }
+"n" = { action = "sort_order.natural", desc = "Sort naturally" }
+"s" = { action = "sort_order.size", desc = "Sort by size" }
+"c" = { action = "sort_order.created", desc = "Sort by creation time" }
+"m" = { action = "sort_order.modified", desc = "Sort by modification time" }
+"d" = { action = "sort_order.descending", desc = "Toggle descending order" }
 
 [pinned_sidebar]
 "ctrl+f" = { action = "focus_search", desc = "Search pinned directories" }

--- a/src/rovr/assets/presets/vim.toml
+++ b/src/rovr/assets/presets/vim.toml
@@ -63,8 +63,23 @@
 "o" = { action = "open", desc = "Open selected files" }
 "e" = { action = "open_editor", desc = "Open the current file in an editor" }
 "shift+f10" = { action = "open_right_click_menu", desc = "Open the context menu" }
-"Y" = { action = "copy.open_popup", desc = "Open the copy menu" }
-"," = { action = "sort_order.open_popup", desc = "Open the sort menu" }
+
+[file_list.Y]
+desc = "Copy"
+"y" = { action = "copy.to_rovr", desc = "Copy files to the rovr clipboard" }
+"c" = { action = "copy.highlighted", desc = "Copy the highlighted file path" }
+"s" = { action = "copy.to_system_clip", desc = "Copy files to the system clipboard" }
+"d" = { action = "copy.current_directory", desc = "Copy the current directory path" }
+
+[file_list.","]
+desc = "Sort order"
+"a" = { action = "sort_order.name", desc = "Sort by name" }
+"e" = { action = "sort_order.extension", desc = "Sort by extension" }
+"n" = { action = "sort_order.natural", desc = "Sort naturally" }
+"s" = { action = "sort_order.size", desc = "Sort by size" }
+"c" = { action = "sort_order.created", desc = "Sort by creation time" }
+"m" = { action = "sort_order.modified", desc = "Sort by modification time" }
+"d" = { action = "sort_order.descending", desc = "Toggle descending order" }
 
 [pinned_sidebar]
 "/" = { action = "focus_search", desc = "Search pinned directories" }

--- a/src/rovr/classes/app_mixins.py
+++ b/src/rovr/classes/app_mixins.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from importlib import resources
 from os import path
 from time import perf_counter
-from typing import ClassVar, Iterable, cast
+from typing import Any, ClassVar, Iterable, cast
 
 from rich.table import Table
 from rich.text import Text
@@ -752,6 +752,18 @@ class KeyChordPopup(Static):
 class KeyHandler:
     _key_chord: KeyMap | None = None
     _key_chord_namespace: DOMNode | None = None
+    _key_chord_popup: KeyChordPopup | None = None
+
+    def push_screen(
+        self: App,
+        screen: Any,
+        callback: Any = None,
+        wait_for_dismiss: bool = False,
+        *,
+        mode: str | None = None,
+    ) -> Any:
+        self._cancel_key_chord()
+        return App.push_screen(self, screen, callback, wait_for_dismiss, mode=mode)
 
     @lru_cache(maxsize=128)
     @staticmethod
@@ -786,7 +798,7 @@ class KeyHandler:
             if isinstance(binding, dict):
                 if "action" not in binding:
                     self._key_chord = cast(KeyMap, binding)
-                    self.query_one(KeyChordPopup).show_chord(self._key_chord)
+                    self._key_chord_popup.show_chord(self._key_chord)
                     return True
                 namespace = self._key_chord_namespace
                 action = cast(KeyBinding, binding)["action"]
@@ -817,7 +829,9 @@ class KeyHandler:
             if "action" not in binding:
                 self._key_chord = cast(KeyMap, binding)
                 self._key_chord_namespace = namespace
-                self.query_one(KeyChordPopup).show_chord(self._key_chord)
+                self._key_chord_popup = KeyChordPopup()
+                await self.screen.mount(self._key_chord_popup)
+                self._key_chord_popup.show_chord(self._key_chord)
                 return True
             action = cast(KeyBinding, binding)["action"]
             if action == "noop":
@@ -833,7 +847,10 @@ class KeyHandler:
     def _cancel_key_chord(self: App) -> None:
         self._key_chord = None
         self._key_chord_namespace = None
-        self.query_one(KeyChordPopup).hide_chord()
+        if self._key_chord_popup is not None:
+            self._key_chord_popup.hide_chord()
+            self._key_chord_popup.remove()
+            self._key_chord_popup = None
 
     def _active_key_contexts(self: App) -> list[tuple[str, DOMNode]]:
         contexts: list[tuple[str, DOMNode]] = []

--- a/src/rovr/classes/app_mixins.py
+++ b/src/rovr/classes/app_mixins.py
@@ -7,8 +7,9 @@ from functools import lru_cache
 from importlib import resources
 from os import path
 from time import perf_counter
-from typing import ClassVar, Iterable
+from typing import ClassVar, Iterable, cast
 
+from rich.table import Table
 from rich.text import Text
 from textual import events, on, work
 from textual.app import App
@@ -16,6 +17,7 @@ from textual.css.errors import StylesheetError
 from textual.css.stylesheet import StylesheetParseError
 from textual.dom import DOMNode
 from textual.geometry import Offset
+from textual.widgets import Static
 from textual_drivers.dnd import (
     DNDDragIn,
     DNDDragInOperation,
@@ -32,6 +34,7 @@ from rovr.classes.textual_validators import (
     AllowsExistingFiles,
     IsValidFilePath,
 )
+from rovr.classes.type_aliases import KeyBinding, KeyMap
 from rovr.core import (
     PinnedSidebar,
     PinnedSidebarContainer,
@@ -703,7 +706,46 @@ class DragAndDrop:
                     )
 
 
+class KeyChordPopup(Static):
+    def __init__(self) -> None:
+        super().__init__(id="key_chord")
+        self.display = False
+
+    def show_chord(self, bindings: KeyMap) -> None:
+        columns = (
+            1
+            if "-filelist-only" in self.screen.classes
+            else 2
+            if "-no-preview" in self.screen.classes
+            else 3
+        )
+        table = Table.grid(expand=True, padding=(0, 1))
+        for _ in range(columns):
+            table.add_column(ratio=1)
+
+        cells = []
+        for key, binding in bindings.items():
+            if key == "desc" or not isinstance(binding, dict):
+                continue
+            display_key = f"<{key}>" if "+" in key else key
+            description = cast(str, binding.get("desc") or binding.get("action") or key)
+            cells.append(Text.assemble((display_key, "bold"), f"  {description}"))
+        for index in range(0, len(cells), columns):
+            table.add_row(*cells[index : index + columns])
+
+        title = bindings.get("desc")
+        self.border_title = title if isinstance(title, str) else "Key chord"
+        self.update(table)
+        self.display = True
+
+    def hide_chord(self) -> None:
+        self.display = False
+
+
 class KeyHandler:
+    _key_chord: KeyMap | None = None
+    _key_chord_namespace: DOMNode | None = None
+
     @lru_cache(maxsize=128)
     @staticmethod
     def shorten_key(key: str) -> str:
@@ -727,21 +769,49 @@ class KeyHandler:
     async def _check_bindings(self: App, key: str, priority: bool = False) -> bool:
         if not self.keys or self.screen.id == "--command-palette":
             return await App._check_bindings(self, key, priority)
+        key = KeyHandler.shorten_key(key)
+        namespaces = self._key_namespaces()
+        if priority and self._key_chord is not None:
+            if key == "escape":
+                self._cancel_key_chord()
+                return True
+            binding = self._key_chord.get(key)
+            if isinstance(binding, dict):
+                if "action" not in binding:
+                    self._key_chord = cast(KeyMap, binding)
+                    self.query_one(KeyChordPopup).show_chord(self._key_chord)
+                    return True
+                namespace = self._key_chord_namespace
+                action = cast(KeyBinding, binding)["action"]
+                self._cancel_key_chord()
+                if action == "noop":
+                    return True
+                return namespace is not None and await self.run_action(
+                    action,
+                    default_namespace=namespace,
+                    namespaces=namespaces,
+                )
+            self._cancel_key_chord()
+
         if (
             priority
             and self.focused is not None
-            and self.focused.check_consume_key(key, KeyHandler.shorten_key(key))
+            and self.focused.check_consume_key(key, key)
         ):
             return False
 
-        namespaces = self._key_namespaces()
         contexts = [("global", self)] if priority else self._active_key_contexts()
         for context, namespace in contexts:
             context = self.keys.get(context, {})
-            binding = context.get(KeyHandler.shorten_key(key))
+            binding = context.get(key)
             if not isinstance(binding, dict):
                 continue
-            action = binding["action"]
+            if "action" not in binding:
+                self._key_chord = cast(KeyMap, binding)
+                self._key_chord_namespace = namespace
+                self.query_one(KeyChordPopup).show_chord(self._key_chord)
+                return True
+            action = cast(KeyBinding, binding)["action"]
             if action == "noop":
                 return True
             if action is not None and await self.run_action(
@@ -751,6 +821,11 @@ class KeyHandler:
             ):
                 return True
         return False
+
+    def _cancel_key_chord(self: App) -> None:
+        self._key_chord = None
+        self._key_chord_namespace = None
+        self.query_one(KeyChordPopup).hide_chord()
 
     def _active_key_contexts(self: App) -> list[tuple[str, DOMNode]]:
         contexts: list[tuple[str, DOMNode]] = []

--- a/src/rovr/classes/app_mixins.py
+++ b/src/rovr/classes/app_mixins.py
@@ -729,7 +729,14 @@ class KeyChordPopup(Static):
                 continue
             display_key = f"<{key}>" if "+" in key else key
             description = cast(str, binding.get("desc") or binding.get("action") or key)
-            cells.append(Text.assemble((display_key, "bold"), f"  {description}"))
+            cells.append(
+                Text.assemble(
+                    (display_key, "bold"),
+                    f"  {description}",
+                    overflow="ellipsis",
+                    no_wrap=True,
+                )
+            )
         for index in range(0, len(cells), columns):
             table.add_row(*cells[index : index + columns])
 
@@ -792,6 +799,7 @@ class KeyHandler:
                     namespaces=namespaces,
                 )
             self._cancel_key_chord()
+            return True
 
         if (
             priority

--- a/src/rovr/classes/app_mixins.py
+++ b/src/rovr/classes/app_mixins.py
@@ -711,7 +711,12 @@ class KeyChordPopup(Static):
         super().__init__(id="key_chord")
         self.display = False
 
-    def show_chord(self, bindings: KeyMap) -> None:
+    def show_chord(
+        self,
+        bindings: KeyMap,
+        default_namespace: DOMNode,
+        namespaces: dict[str, DOMNode],
+    ) -> None:
         columns = (
             1
             if "-filelist-only" in self.screen.classes
@@ -729,6 +734,15 @@ class KeyChordPopup(Static):
                 continue
             display_key = f"<{key}>" if "+" in key else key
             description = cast(str, binding.get("desc") or binding.get("action") or key)
+            action = binding.get("action")
+            namespace = (
+                namespaces.get(action.partition(".")[0], default_namespace)
+                if action is not None
+                else default_namespace
+            )
+            describe = getattr(namespace, "describe_key_chord_action", None)
+            if callable(describe) and action is not None:
+                description = describe(action, description)
             cells.append(
                 Text.assemble(
                     (display_key, "bold"),
@@ -798,7 +812,9 @@ class KeyHandler:
             if isinstance(binding, dict):
                 if "action" not in binding:
                     self._key_chord = cast(KeyMap, binding)
-                    self._key_chord_popup.show_chord(self._key_chord)
+                    self._key_chord_popup.show_chord(
+                        self._key_chord, self._key_chord_namespace, namespaces
+                    )
                     return True
                 namespace = self._key_chord_namespace
                 action = cast(KeyBinding, binding)["action"]
@@ -831,7 +847,7 @@ class KeyHandler:
                 self._key_chord_namespace = namespace
                 self._key_chord_popup = KeyChordPopup()
                 await self.screen.mount(self._key_chord_popup)
-                self._key_chord_popup.show_chord(self._key_chord)
+                self._key_chord_popup.show_chord(self._key_chord, namespace, namespaces)
                 return True
             action = cast(KeyBinding, binding)["action"]
             if action == "noop":

--- a/src/rovr/classes/type_aliases.py
+++ b/src/rovr/classes/type_aliases.py
@@ -16,10 +16,13 @@ class KeyBinding(TypedDict):
     desc: NotRequired[str]
 
 
+KeyMap: TypeAlias = "dict[str, KeyBinding | KeyMap | str]"
+
+
 SortByOptions: TypeAlias = Literal[
     "name", "size", "modified", "created", "extension", "natural"
 ]
 
 ShellRunTypes: TypeAlias = Literal["suspend", "background", "orphan"]
 
-KeysConfig: TypeAlias = dict[str, dict[str, KeyBinding]]
+KeysConfig: TypeAlias = dict[str, KeyMap]

--- a/src/rovr/functions/config.py
+++ b/src/rovr/functions/config.py
@@ -17,7 +17,7 @@ from textual.keys import Keys
 
 from rovr import RESOURCE_PACKAGE, pprint
 from rovr.classes.config import RovrConfig
-from rovr.classes.type_aliases import KeysConfig
+from rovr.classes.type_aliases import KeyMap, KeysConfig
 from rovr.variables.maps import VALID_KEY_CONTEXTS
 
 try:
@@ -660,11 +660,10 @@ def validate_keys(keys: KeysConfig) -> list[str]:
     valid_modifiers = {"alt", "ctrl", "hyper", "meta", "shift", "super"}
     errors = []
 
-    for context, bindings in keys.items():
-        if context not in VALID_KEY_CONTEXTS:
-            errors.append(f"Unknown context [{context}]")
-
-        for key in bindings:
+    def validate_bindings(bindings: KeyMap, section: str) -> None:
+        for key, binding in bindings.items():
+            if key == "desc":
+                continue
             *modifiers, name = [key] if len(key) == 1 else key.split("+")
             valid_name = (len(name) == 1 and name.isprintable() and name != " ") or (
                 name in valid_key_names
@@ -674,7 +673,14 @@ def validate_keys(keys: KeysConfig) -> list[str]:
                 and set(modifiers) <= valid_modifiers
             )
             if not valid_name or not valid_modifier_list:
-                errors.append(f'Invalid key "{key}" in [{context}]')
+                errors.append(f'Invalid key "{key}" in [{section}]')
+            if isinstance(binding, dict) and "action" not in binding:
+                validate_bindings(binding, f"{section}.{key}")
+
+    for context, bindings in keys.items():
+        if context not in VALID_KEY_CONTEXTS:
+            errors.append(f"Unknown context [{context}]")
+        validate_bindings(bindings, context)
 
     return errors
 
@@ -731,26 +737,38 @@ def load_keys() -> KeysConfig:
     # check it manually
     schema = {
         "type": "object",
-        "patternProperties": {
-            "^.*$": {
-                "type": "object",
-                "patternProperties": {
-                    "^.*$": {
-                        "oneOf": [
-                            {"type": "string"},
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "action": {"type": "string"},
-                                    "desc": {"type": "string"},
-                                },
-                                "required": ["action"],
-                                "additionalProperties": False,
-                            },
-                        ]
+        "definitions": {
+            "binding": {
+                "oneOf": [
+                    {"type": "string"},
+                    {
+                        "type": "object",
+                        "properties": {
+                            "action": {"type": "string"},
+                            "desc": {"type": "string"},
+                        },
+                        "required": ["action"],
+                        "additionalProperties": False,
                     },
-                },
+                ]
             },
+            "chord": {
+                "type": "object",
+                "properties": {"desc": {"type": "string"}},
+                "patternProperties": {
+                    "^(?!desc$).+$": {
+                        "anyOf": [
+                            {"$ref": "#/definitions/binding"},
+                            {"$ref": "#/definitions/chord"},
+                        ]
+                    }
+                },
+                "additionalProperties": False,
+                "not": {"required": ["action"]},
+            },
+        },
+        "patternProperties": {
+            "^.*$": {"$ref": "#/definitions/chord"},
         },
     }
     try:
@@ -787,10 +805,20 @@ def load_keys() -> KeysConfig:
             pprint(Padding(to_print, (0, 4, 0, 3), expand=False))
         exit(1)
 
-    return {
-        context: {
-            key: {"action": binding} if isinstance(binding, str) else binding
-            for key, binding in context_keys.items()
+    def normalize(bindings: KeyMap) -> KeyMap:
+        return {
+            key: (
+                binding
+                if key == "desc"
+                else {"action": binding}
+                if isinstance(binding, str)
+                else binding
+                if "action" in binding
+                else normalize(binding)
+            )
+            for key, binding in bindings.items()
         }
-        for context, context_keys in keys_dict.items()
+
+    return {
+        context: normalize(context_keys) for context, context_keys in keys_dict.items()
     }

--- a/src/rovr/functions/utils.py
+++ b/src/rovr/functions/utils.py
@@ -142,10 +142,26 @@ def get_shortcut(
     from rovr.variables.constants import config, keys
 
     if keys:
+
+        def find_bindings(
+            bindings: dict[str, Any], prefix: tuple[str, ...] = ()
+        ) -> list[tuple[str, ...]]:
+            matches = []
+            for key, binding in bindings.items():
+                if not isinstance(binding, dict):
+                    continue
+                sequence = prefix + (key,)
+                if binding.get("action") == action:
+                    matches.append(sequence)
+                elif "action" not in binding:
+                    matches.extend(find_bindings(binding, sequence))
+            return matches
+
         binds = [
-            key
-            for key, binding in keys.get(context, {}).items()
-            if binding["action"] == action
+            sequence[0]
+            if len(sequence) == 1
+            else "".join(f"<{key}>" if "+" in key else key for key in sequence)
+            for sequence in find_bindings(keys.get(context, {}))
         ]
     else:
         legacy = cast(Any, config)["keybinds"]

--- a/src/rovr/screens/keybinds.py
+++ b/src/rovr/screens/keybinds.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar, Iterable, cast
 
 from textual import events
 from textual.app import ComposeResult
@@ -9,7 +9,7 @@ from textual.widgets import OptionList
 
 from rovr.classes.mixins import CursorNavigationMixin
 from rovr.classes.textual_options import KeybindOption
-from rovr.classes.type_aliases import KeysConfig
+from rovr.classes.type_aliases import KeyBinding, KeyMap, KeysConfig
 from rovr.components import SearchInput
 from rovr.functions import icons
 from rovr.functions.utils import check_key, dismiss
@@ -226,28 +226,47 @@ class ScopedKeybindList(KeybindList):
         keybind_data: list[tuple[str, str]] = []
         primary_keys: list[str] = []
         for context, context_bindings in self.keys.items():
-            grouped: dict[str, tuple[list[str], str]] = {}
-            for key, binding in context_bindings.items():
+            grouped: dict[tuple[str, str], list[tuple[str, ...]]] = {}
+            for sequence, binding in self._walk_bindings(context_bindings):
                 action = binding["action"]
                 if action == "noop":
                     continue
-                keys, description = grouped.setdefault(action, ([], action))
-                keys.append(key)
-                description = binding.get("desc") or description
-                grouped[action] = (keys, description)
+                description = binding.get("desc") or action
+                grouped.setdefault((action, description), []).append(sequence)
 
             if not grouped:
                 continue
             keybind_data.append(("--section--", context.replace("_", " ").title()))
             primary_keys.append("")
-            for keys, description in grouped.values():
-                keybind_data.append((" ".join(f"<{key}>" for key in keys), description))
-                primary_keys.append(keys[0])
+            for (_, description), sequences in grouped.items():
+                formatted = " ".join(
+                    self._format_sequence(sequence) for sequence in sequences
+                )
+                keybind_data.append((formatted, description))
+                primary_keys.append(sequences[0][0])
 
         if not keybind_data:
             keybind_data.append(("<disabled>", "No keybindings"))
             primary_keys.append("")
         return keybind_data, primary_keys
+
+    @classmethod
+    def _walk_bindings(
+        cls, bindings: KeyMap, prefix: tuple[str, ...] = ()
+    ) -> Iterable[tuple[tuple[str, ...], KeyBinding]]:
+        for key, binding in bindings.items():
+            if key == "desc" or not isinstance(binding, dict):
+                continue
+            if "action" in binding:
+                yield prefix + (key,), cast(KeyBinding, binding)
+            else:
+                yield from cls._walk_bindings(cast(KeyMap, binding), prefix + (key,))
+
+    @staticmethod
+    def _format_sequence(sequence: tuple[str, ...]) -> str:
+        if len(sequence) == 1:
+            return f"<{sequence[0]}>"
+        return "".join(f"<{key}>" if "+" in key else key for key in sequence)
 
 
 class ScopedKeybinds(Keybinds):
@@ -270,7 +289,7 @@ class ScopedKeybinds(Keybinds):
             key
             for context in ("keybinds", "filter_modal")
             for key, binding in cast(Any, self.app).keys.get(context, {}).items()
-            if binding["action"] == "exit"
+            if isinstance(binding, dict) and binding.get("action") == "exit"
         ]
         close_with = " or ".join(exit_keys) if exit_keys else "outside"
         self.container.border_subtitle = f"Press {close_with} to close"

--- a/src/rovr/style.tcss
+++ b/src/rovr/style.tcss
@@ -468,6 +468,21 @@ Tooltip {
   }
 }
 
+KeyChordPopup {
+  layer: toastLayer;
+  dock: bottom;
+  width: 80%;
+  height: auto;
+  offset: 10% 0;
+  padding: 0 1;
+  margin-bottom: 5;
+  background: $panel;
+  border: $border-style $accent;
+  &:ansi {
+    background: transparent;
+  }
+}
+
 #processes { padding: 0 0 0 1 }
 
 #metadata {
@@ -1192,6 +1207,14 @@ Screen.-filelist-only,
 Screen.-no-preview {
   #preview_sidebar,
   #below_menu Button { display: none !important }
+}
+Screen.-no-preview KeyChordPopup {
+  width: 90%;
+  offset: 5% 0;
+}
+Screen.-filelist-only KeyChordPopup {
+  width: 100%;
+  offset: 0 0;
 }
 Screen.-no-menu-at-all #menu_wrapper,
 Screen.-middle-only #menu_wrapper { display: none }

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -133,11 +133,13 @@ def test_get_shortcut_uses_active_keys(monkeypatch: pytest.MonkeyPatch) -> None:
                 "ctrl+d": {"action": "delete"},
                 "D": {"action": "delete"},
                 "x": {"action": "noop"},
+                "y": {"y": {"action": "confirm"}},
             }
         },
     )
 
     assert utils.get_shortcut("delete_files", "delete") == "D"
+    assert utils.get_shortcut("delete_files", "confirm") == "yy"
     assert utils.get_shortcut("delete_files", "cancel") == ""
 
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -103,7 +103,12 @@ async def test_contextual_key_dispatch(
 
         app.keys["file_list"] = {
             "s": {"action": "sort_order.extension(True)"},
-            ",": {"p": {"action": "sort_order.toggle_custom_sort"}},
+            ",": {
+                "p": {
+                    "action": "sort_order.toggle_custom_sort",
+                    "desc": "Toggle custom sort (%stated)",
+                }
+            },
         }
         await pilot.press("s")
         state_manager = app.query_one(StateManager)

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -71,7 +71,9 @@ def test_load_key_chords(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.mark.asyncio
-async def test_contextual_key_dispatch(tmp_path: Path) -> None:
+async def test_contextual_key_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     (tmp_path / "a").touch()
     (tmp_path / "b").touch()
     app = Application(startup_path=tmp_path.as_posix())
@@ -99,11 +101,33 @@ async def test_contextual_key_dispatch(tmp_path: Path) -> None:
         await pilot.press("j")
         assert app.file_list.highlighted == 1
 
-        app.keys["file_list"] = {"s": {"action": "sort_order.extension(True)"}}
+        app.keys["file_list"] = {
+            "s": {"action": "sort_order.extension(True)"},
+            ",": {"p": {"action": "sort_order.toggle_custom_sort"}},
+        }
         await pilot.press("s")
-        assert app.query_one(StateManager).get_sort_prefs() == ("extension", True)
-
         state_manager = app.query_one(StateManager)
+        assert state_manager.get_sort_prefs() == ("extension", True)
+        button = app.query_one(SortOrderButton)
+        descriptions = []
+        describe = button.describe_key_chord_action
+        monkeypatch.setattr(
+            button,
+            "describe_key_chord_action",
+            lambda action, description: (
+                descriptions.append(describe(action, description)) or descriptions[-1]
+            ),
+        )
+
+        assert not state_manager.custom_sort_enabled
+        await pilot.press(",")
+        assert descriptions[-1].endswith("(disabled)")
+        await pilot.press("p")
+        assert state_manager.custom_sort_enabled
+        await pilot.press(",")
+        assert descriptions[-1].endswith("(enabled)")
+        await pilot.press("escape")
+
         pinned_sidebar_visible = state_manager.pinned_sidebar_visible
         app.keys = {"main": {"S": {"action": "toggle_pinned_sidebar"}}}
         await pilot.press("S")

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -5,7 +5,7 @@ import pytest
 from rovr.action_buttons import CopyButton
 from rovr.action_buttons.sort_order import SortOrderButton
 from rovr.app import Application
-from rovr.classes.app_mixins import KeyHandler
+from rovr.classes.app_mixins import KeyChordPopup, KeyHandler
 from rovr.classes.textual_options import KeybindOption
 from rovr.functions.config import load_keys, validate_keys
 from rovr.navigation_widgets import PathInput
@@ -184,7 +184,8 @@ async def test_key_chords(tmp_path: Path) -> None:
                 "ctrl+x": {"action": "cursor(1)"},
                 "n": {"action": "noop"},
             },
-        }
+        },
+        "dismissible": {"c": {"x": {"action": "screen.dismiss"}}},
     }
 
     async with app.run_test(size=(143, 37)) as pilot:
@@ -216,6 +217,20 @@ async def test_key_chords(tmp_path: Path) -> None:
         await pilot.press("a", "j")
         assert app.file_list.highlighted == 0
         assert not popup.display
+
+        await pilot.press("a")
+        app.push_screen(Dismissible("Modal"))
+        assert app._key_chord is None
+        assert not popup.display
+        await pilot.pause()
+        await pilot.press("x")
+        assert isinstance(app.screen, Dismissible)
+
+        await pilot.press("c")
+        popup = app.screen.query_one(KeyChordPopup)
+        assert popup.parent is app.screen
+        await pilot.press("x")
+        assert not isinstance(app.screen, Dismissible)
 
 
 def test_key_chord_display() -> None:

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -214,7 +214,7 @@ async def test_key_chords(tmp_path: Path) -> None:
         assert not popup.display
 
         await pilot.press("a", "j")
-        assert app.file_list.highlighted == 1
+        assert app.file_list.highlighted == 0
         assert not popup.display
 
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -7,9 +7,10 @@ from rovr.action_buttons.sort_order import SortOrderButton
 from rovr.app import Application
 from rovr.classes.app_mixins import KeyHandler
 from rovr.classes.textual_options import KeybindOption
-from rovr.functions.config import validate_keys
+from rovr.functions.config import load_keys, validate_keys
 from rovr.navigation_widgets import PathInput
 from rovr.screens import Dismissible, ScopedKeybinds
+from rovr.screens.keybinds import ScopedKeybindList
 from rovr.state_manager import StateManager
 
 from .conftest import iter_until
@@ -39,6 +40,34 @@ def test_validate_keys() -> None:
         'Invalid key "ctrl+no_such_key" in [unknown]',
         'Invalid key "shift+ctrl+a" in [main]',
     ]
+    assert validate_keys({
+        "file_list": {
+            "Y": {
+                "desc": "Copy",
+                "y": {"action": "copy.to_rovr"},
+                "ctrl+no_such_key": {"action": "noop"},
+            }
+        }
+    }) == ['Invalid key "ctrl+no_such_key" in [file_list.Y]']
+
+
+def test_load_key_chords(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ROVR_CONFIG_FOLDER", str(tmp_path))
+    (tmp_path / "keys.toml").write_text(
+        '[main]\ng.x = "focus_file_list"\n'
+        '[file_list.Y]\ndesc = "Copy"\n'
+        'p = { action = "copy.highlighted", desc = "Copy path" }\n',
+        encoding="utf-8",
+    )
+
+    keys = load_keys()
+    chord = keys["file_list"]["Y"]
+    assert isinstance(chord, dict)
+    assert chord == {
+        "desc": "Copy",
+        "p": {"action": "copy.highlighted", "desc": "Copy path"},
+    }
+    assert keys["main"]["g"] == {"x": {"action": "focus_file_list"}}
 
 
 @pytest.mark.asyncio
@@ -114,7 +143,15 @@ async def test_input_consumes_printable_globals_and_uses_input_context(
 @pytest.mark.asyncio
 async def test_scoped_keybinds_screen(tmp_path: Path) -> None:
     app = Application(startup_path=tmp_path.as_posix())
-    app.keys = {"main": {"?": {"action": "show_keybinds", "desc": "Show keybindings"}}}
+    app.keys = {
+        "main": {
+            "?": {"action": "show_keybinds", "desc": "Show keybindings"},
+            "a": {
+                "x": {"b": {"action": "focus_file_list", "desc": "Plain chord"}},
+                "ctrl+x": {"action": "toggle_footer", "desc": "Modified chord"},
+            },
+        }
+    }
 
     async with app.run_test(size=(143, 37)) as pilot:
         app.action_show_keybinds()
@@ -124,3 +161,63 @@ async def test_scoped_keybinds_screen(tmp_path: Path) -> None:
         option = app.screen.keybinds_list.options[1]
         assert isinstance(option, KeybindOption)
         assert "Show keybindings" in option.label
+        labels = " ".join(
+            str(option.label)
+            for option in app.screen.keybinds_list.options
+            if isinstance(option, KeybindOption)
+        )
+        assert "axb" in labels
+        assert "a<ctrl+x>" in labels
+
+
+@pytest.mark.asyncio
+async def test_key_chords(tmp_path: Path) -> None:
+    (tmp_path / "a").touch()
+    (tmp_path / "b").touch()
+    app = Application(startup_path=tmp_path.as_posix())
+    app.keys = {
+        "file_list": {
+            "j": {"action": "cursor(1)"},
+            "a": {
+                "desc": "Move",
+                "x": {"b": {"action": "cursor(1)", "desc": "Move down"}},
+                "ctrl+x": {"action": "cursor(1)"},
+                "n": {"action": "noop"},
+            },
+        }
+    }
+
+    async with app.run_test(size=(143, 37)) as pilot:
+        await iter_until(pilot, lambda: app.file_list.option_count == 2)
+        app.file_list.focus()
+        app.file_list.highlighted = 0
+
+        await pilot.press("a")
+        popup = app.query_one("#key_chord")
+        assert popup.display
+        assert popup.border_title == "Move"
+        await pilot.press("x", "b")
+        assert app.file_list.highlighted == 1
+        assert not popup.display
+
+        app.file_list.highlighted = 0
+        await pilot.press("a", "ctrl+x")
+        assert app.file_list.highlighted == 1
+
+        app.file_list.highlighted = 0
+        await pilot.press("a", "escape")
+        assert app.file_list.highlighted == 0
+        assert not popup.display
+
+        await pilot.press("a", "n")
+        assert app.file_list.highlighted == 0
+        assert not popup.display
+
+        await pilot.press("a", "j")
+        assert app.file_list.highlighted == 1
+        assert not popup.display
+
+
+def test_key_chord_display() -> None:
+    assert ScopedKeybindList._format_sequence(("a", "x", "b")) == "axb"
+    assert ScopedKeybindList._format_sequence(("a", "ctrl+x")) == "a<ctrl+x>"


### PR DESCRIPTION
closes #237, the final issue of the three-part #234 

<img width="1066" height="164" alt="image" src="https://github.com/user-attachments/assets/6a2a7d45-5ba4-4a67-bd7a-ac24db9f7c01" />

i still havent considered how to convey 'this path only' to the person though...

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Support multi-key keybinding chords and dynamic action descriptions throughout configuration, runtime handling, presets, and documentation.

New Features:
- Add multi-key chord bindings with an in-app popup that displays available continuations and supports cancellation.
- Add state-aware descriptions for custom sort toggling, including enable/disable substitutions and current-state indication.

Enhancements:
- Update keybinding configuration, shortcut discovery, validation, normalization, and keybinding screens to support nested chord definitions.
- Convert copy and sort menus in the default presets to chord-based keybindings.

Documentation:
- Document state substitutions supported by the custom sort toggle action.

Tests:
- Add coverage for nested key loading and validation, chord dispatch and display, state-aware descriptions, and chord shortcut formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-key shortcuts with an on-screen guide showing available follow-up keys.
  * Copy and sorting actions can now be accessed directly through key sequences, without opening menus.
  * Added support for nested key sequences in custom configurations and shortcut lists.
  * Added a shortcut for toggling custom sorting, with state-aware descriptions.
* **Bug Fixes**
  * Improved multi-key shortcut labels and cancelled active sequences when changing screens or pressing Escape.
* **Documentation**
  * Documented state-aware descriptions for custom sorting shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->