### PR TITLE
feat: arrange scrollbars on border

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,3 +96,20 @@ New features are welcome!
 If you've created a cool theme for rovr, we'd love to see it! Please make a pull request with your theme, following the `custom_theme` schema. Don't forget to include screenshots as described in the documentation.
 
 Thank you for your contribution!
+
+<!-- Notes for maintainers:
+To update screenshots, ensure the following commands are ran if a major UI change is made.
+Run this only before a stable release is made:
+
+<code>
+ls docs/public/screenshots/*.svg | % {
+    Write-Host $_.Name is next
+    $delay = Read-Host "Delay?"
+    if ($delay -ne "") {
+       poe snip --delay $delay $_.FullName
+       Read-Host "Ok?"
+    }
+}
+</code>
+
+Use appropriate versions for zsh, NSPC911 uses powershell -->

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -868,7 +868,7 @@ class Application(
         self,
         *,
         title: str | None = None,
-        simplify: bool = False,
+        simplify: bool = True,
     ) -> str:
         """super version but without title because i hate the title"""  # noqa: DOC201
         import io

--- a/src/rovr/monkey_patches/_textual.py
+++ b/src/rovr/monkey_patches/_textual.py
@@ -113,6 +113,8 @@ _arrange_scrollbars = Widget._arrange_scrollbars
 def arrange_scrollbars(self: Widget, region: Region) -> Iterable[tuple[Widget, Region]]:
     scrollbars = list(_arrange_scrollbars(self, region))
     parent = self.parent
+    # fun fact: setting border: none still provides  ("", Color(0,0,0,255))
+    # as a border, so theres no point in checking for none
     border_bottom = bool(
         self.styles.border_bottom[0]
         or isinstance(parent, Widget)

--- a/src/rovr/monkey_patches/_textual.py
+++ b/src/rovr/monkey_patches/_textual.py
@@ -4,9 +4,14 @@ from typing import Iterable
 
 from rich.segment import Segment
 from textual import _border as border
+from textual._compositor import Compositor
 from textual.content import Content
 from textual.css.types import EdgeType
+from textual.geometry import Region, Size
+from textual.map_geometry import MapGeometry
+from textual.scrollbar import ScrollBar
 from textual.style import Style
+from textual.widget import Widget
 from textual.widgets import Input
 
 
@@ -100,6 +105,66 @@ border.BORDER_CHARS["dashed"] = (
     ("┆", " ", "┆"),
     ("└", "╌", "┘"),
 )
+
+
+_arrange_scrollbars = Widget._arrange_scrollbars
+
+
+def arrange_scrollbars(self: Widget, region: Region) -> Iterable[tuple[Widget, Region]]:
+    scrollbars = list(_arrange_scrollbars(self, region))
+    parent = self.parent
+    border_bottom = bool(
+        self.styles.border_bottom[0]
+        or isinstance(parent, Widget)
+        and parent.styles.border_bottom[0]
+    )
+    border_right = bool(
+        self.styles.border_right[0]
+        or isinstance(parent, Widget)
+        and parent.styles.border_right[0]
+    )
+    both_on_border = border_bottom and border_right and len(scrollbars) == 3
+
+    for scrollbar, scrollbar_region in scrollbars:
+        if both_on_border and not hasattr(scrollbar, "vertical"):
+            continue
+        if getattr(scrollbar, "vertical", False) and border_right:
+            scrollbar_region = Region(
+                scrollbar_region.x + 1,
+                scrollbar_region.y,
+                scrollbar_region.width,
+                scrollbar_region.height + both_on_border,
+            )
+        elif not getattr(scrollbar, "vertical", True) and border_bottom:
+            scrollbar_region = Region(
+                scrollbar_region.x,
+                scrollbar_region.y + 1,
+                scrollbar_region.width + both_on_border,
+                scrollbar_region.height,
+            )
+        yield scrollbar, scrollbar_region
+
+
+Widget._arrange_scrollbars = arrange_scrollbars  # ty: ignore[invalid-assignment]
+
+_arrange_root = Compositor._arrange_root
+
+
+def arrange_root(
+    self: Compositor, root: Widget, size: Size, visible_only: bool = True
+) -> tuple[dict[Widget, MapGeometry], set[Widget]]:
+    widget_map, widgets = _arrange_root(self, root, size, visible_only)
+    for widget, geometry in widget_map.items():
+        if isinstance(widget, ScrollBar) and not geometry.clip.contains_region(
+            geometry.region
+        ):
+            widget_map[widget] = geometry._replace(
+                clip=geometry.clip.union(geometry.region)
+            )
+    return widget_map, widgets
+
+
+Compositor._arrange_root = arrange_root  # ty: ignore[invalid-assignment]
 
 # with the current implementation it just checks if the character is printable
 # problem is that kitty kp sends ctrl+a as a, which is printable, but we don't want

--- a/src/rovr/style.tcss
+++ b/src/rovr/style.tcss
@@ -559,6 +559,10 @@ CommandList:ansi {
   }
 }
 
+CommandList {
+  scrollbar-size: 1 1;
+}
+
 FileList {
   .selection-list--option-checked,
   .selection-list--option-checked--hovered {
@@ -1022,7 +1026,7 @@ CommandPalette {
   CommandList {
     border: $border-style $border-focused;
     border-top: none;
-    max-height: 60vh;
+    max-height: 50vh;
   }
   SearchIcon {
     margin-left: 2;

--- a/tests/test_textual_monkey_patch.py
+++ b/tests/test_textual_monkey_patch.py
@@ -1,0 +1,44 @@
+import pytest
+from textual.app import App, ComposeResult
+from textual.containers import ScrollableContainer, VerticalGroup
+from textual.widgets import Static
+
+import rovr.monkey_patches._textual  # noqa: F401
+
+
+class ScrollbarApp(App):
+    CSS = """
+    #border {
+        width: 20;
+        height: 10;
+        border: round red;
+    }
+    ScrollableContainer {
+        width: 1fr;
+        height: 1fr;
+        scrollbar-size: 1 1;
+    }
+    Static { width: 40; height: 20; }
+    """
+
+    def compose(self) -> ComposeResult:
+        with VerticalGroup(id="border"):
+            yield ScrollableContainer(Static(), id="scrollable")
+
+
+@pytest.mark.asyncio
+async def test_scrollbars_overlay_border() -> None:
+    async with ScrollbarApp().run_test() as pilot:
+        await pilot.pause()
+        scrollable = pilot.app.query_one("#scrollable", ScrollableContainer)
+        border = pilot.app.query_one("#border", VerticalGroup)
+
+        assert scrollable.horizontal_scrollbar.region.bottom == border.region.bottom
+        assert scrollable.vertical_scrollbar.region.right == border.region.right
+        assert not scrollable.scrollbar_corner.region
+        for scrollbar in (
+            scrollable.horizontal_scrollbar,
+            scrollable.vertical_scrollbar,
+        ):
+            geometry = pilot.app.screen._compositor.full_map[scrollbar]
+            assert geometry.visible_region == geometry.region


### PR DESCRIPTION
@derVedro you might be interested in this a bit

<img width="729" height="454" alt="image" src="https://github.com/user-attachments/assets/e75793ef-ab0d-44f6-9ddb-86fbfce30d5a" />

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Align scrollbars with container borders while preserving correct visibility and coverage.

Bug Fixes:
- Position scrollbars on the container border so they align with the surrounding UI and remain fully visible.

Enhancements:
- Update screenshot export defaults and add maintainer guidance for regenerating screenshots.

Tests:
- Add coverage verifying scrollbar alignment, corner handling, and visible compositor geometry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Screenshots now use simplified output by default.
  - Improved Command Palette layout with a shorter command list and clearer scrollbar sizing.

- **Bug Fixes**
  - Improved scrollbar placement in bordered, scrollable layouts.
  - Scrollbars now overlay bottom and right borders correctly.
  - Removed the unnecessary scrollbar corner when both borders are present.
  - Improved content visibility around scrollbar clipping regions.

- **Tests**
  - Added regression coverage for scrollbar positioning and layout geometry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->