### PR TITLE
fix(preview): add fallback title for special files in preview pane

### DIFF
--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -64,7 +64,6 @@ titles = PreviewContainerTitles()
 
 PREVIEWER_GROUP = "previewers"
 TEXT_PREVIEW_CACHE_VERSION = "windowed-v2"
-FONT_PREVIEW_CACHE_VERSION = "font-v2"
 BAT_PREVIEW_CACHE_VERSION = "paged-v2"
 BAT_PREVIEW_PAGE_SIZE = 256
 BAT_PREVIEWER_GROUP = "bat-pages"
@@ -359,9 +358,15 @@ class PreviewContainer(Actionable, Container):
             return
         try:
             if dir_entry.is_symlink():
-                await self.mount(
-                    Static("The symlink target is not found!", classes="special")
-                )
+                self.set_border("title", "Broken Symlink")
+                try:
+                    target_path = os.readlink(location)
+                    msg = f"The symlink target is not found!\nTarget: {target_path}"
+                except OSError:
+                    msg = "The symlink target is not found!"
+
+                await self.mount(Static(msg, classes="special", markup=False))
+
                 # also update option if necessary
                 if isinstance(
                     highlighted_option, FileListSelectionWidget
@@ -411,7 +416,7 @@ class PreviewContainer(Actionable, Container):
             )
             return
         signature = (
-            f"{FONT_PREVIEW_CACHE_VERSION}:{preview_utils.MAX_FONT_SIZE}:{config['interface']['font_preview']['font_size']}",
+            f"{preview_utils.MAX_FONT_SIZE}:{config['interface']['font_preview']['font_size']}",
             f"{self._preview_texts['font_text']}:{fg_color.hex}:{bg_color.hex}:{NewImage.func.__name__}",
         )
         img = _load_cached_image(realpath, "font", stat_result, signature)
@@ -1160,7 +1165,12 @@ class PreviewContainer(Actionable, Container):
         if should_cancel():
             return
 
-        self.set_border("title", titles.file)
+        self.set_border(
+            "title",
+            f"{titles.file} ({self._mime_type.method})"
+            if self._mime_type
+            else titles.file,
+        )
 
         assert self._current_file_path is not None
         realpath = path.realpath(self._current_file_path)
@@ -1652,8 +1662,7 @@ class PreviewContainer(Actionable, Container):
             return
         self.log(self._mime_type)
         assert isinstance(self._current_content, str)
-        title = self._mime_type.method if self._mime_type else "Preview"
-        self.set_border("title", title)
+        self.set_border("title", self._mime_type.method if self._mime_type else "Preview")
 
         display_content: str = self._current_content
         if self._mime_type:

--- a/src/rovr/core/preview_container.py
+++ b/src/rovr/core/preview_container.py
@@ -64,6 +64,7 @@ titles = PreviewContainerTitles()
 
 PREVIEWER_GROUP = "previewers"
 TEXT_PREVIEW_CACHE_VERSION = "windowed-v2"
+FONT_PREVIEW_CACHE_VERSION = "font-v2"
 BAT_PREVIEW_CACHE_VERSION = "paged-v2"
 BAT_PREVIEW_PAGE_SIZE = 256
 BAT_PREVIEWER_GROUP = "bat-pages"
@@ -410,7 +411,7 @@ class PreviewContainer(Actionable, Container):
             )
             return
         signature = (
-            f"{preview_utils.MAX_FONT_SIZE}:{config['interface']['font_preview']['font_size']}",
+            f"{FONT_PREVIEW_CACHE_VERSION}:{preview_utils.MAX_FONT_SIZE}:{config['interface']['font_preview']['font_size']}",
             f"{self._preview_texts['font_text']}:{fg_color.hex}:{bg_color.hex}:{NewImage.func.__name__}",
         )
         img = _load_cached_image(realpath, "font", stat_result, signature)
@@ -1651,7 +1652,8 @@ class PreviewContainer(Actionable, Container):
             return
         self.log(self._mime_type)
         assert isinstance(self._current_content, str)
-        self.set_border("title", "")
+        title = self._mime_type.method if self._mime_type else "Preview"
+        self.set_border("title", title)
 
         display_content: str = self._current_content
         if self._mime_type:


### PR DESCRIPTION
## Description
Fixed an issue where the dynamic title of the preview pane was empty for special files or binary files (like `.so`, `fifo`, sockets). 

Updated `mount_special_messages` in `preview_container.py` so that it sets the `border_title` dynamically using `mime_type.method`, or defaults to `"Preview"` if detection fails.

Fixes #185

Bug Fixes:
- Ensure the preview pane displays a meaningful dynamic title for special and binary files, falling back to “Preview” when MIME detection is unavailable.

## Summary by Sourcery

Improve preview pane titles and broken-symlink messaging so previews remain informative across file types.

Bug Fixes:
- Ensure preview pane titles remain meaningful for special, binary, and otherwise undetected file types by using the detected MIME method or a generic fallback.
- Show broken symlink targets in the preview message when the target can be read, while labeling the pane accordingly.

Enhancements:
- Add MIME detection methods to normal file preview titles for clearer file context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Broken symlink previews now display a “Broken Symlink” title and, where available, the target path.
  - Special-message previews now show the detected MIME method as the title, or “Preview” when no MIME information is available.
  - Font previews now use consistent caching behaviour, reducing the likelihood of stale or incorrectly reused preview results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->