### PR TITLE
feat: follow symlinks

### DIFF
--- a/docs/src/content/docs/dev/reference/schema.mdx
+++ b/docs/src/content/docs/dev/reference/schema.mdx
@@ -1193,6 +1193,7 @@ Must be one of:
 - "rovr:delete"
 - "rovr:zip"
 - "rovr:unzip"
+- "rovr:follow_symlinks"
 - "system:copy_highlighted"
 - "system:copy_current_directory"
 - "system:copy_to_system_clip"

--- a/src/rovr/app.py
+++ b/src/rovr/app.py
@@ -606,7 +606,7 @@ class Application(
             if normalise(getcwd()) == normalise(directory) or directory == "":
                 add_to_history = False
             else:
-                chdir(directory)
+                chdir(directory, self.file_list._follow_links_next)
                 self.last_available_cd = directory
         except PermissionError as exc:
             self.notify(

--- a/src/rovr/assets/config.toml
+++ b/src/rovr/assets/config.toml
@@ -88,6 +88,7 @@ right_click = [
     "%rcwd",
     "%rnh",
   ], run_type = "background", shell = false }, if = { os = ["Windows"] } },
+  { label = "\uf481 follow link", action = "rovr:follow_symlinks" }
   # { label = " Get SHA256", action = { run = 'pwsh -nop -c "(Get-FileHash -Algorithm SHA256 \"${highlighted_file}\").Hash"', run_type = "background" }, if = { directory = false }}
 ]
 drive_exclude = ["/var/*"]

--- a/src/rovr/assets/schema.json
+++ b/src/rovr/assets/schema.json
@@ -31,6 +31,7 @@
             "rovr:delete",
             "rovr:zip",
             "rovr:unzip",
+            "rovr:follow_symlinks",
             "system:copy_highlighted",
             "system:copy_current_directory",
             "system:copy_to_system_clip"

--- a/src/rovr/classes/config.pyi
+++ b/src/rovr/classes/config.pyi
@@ -345,6 +345,7 @@ _RightClickActionOneof0 = (
     | Literal["rovr:delete"]
     | Literal["rovr:zip"]
     | Literal["rovr:unzip"]
+    | Literal["rovr:follow_symlinks"]
     | Literal["system:copy_highlighted"]
     | Literal["system:copy_current_directory"]
     | Literal["system:copy_to_system_clip"]
@@ -364,6 +365,10 @@ r"""The values for the '_RightClickActionOneof0' enum"""
 _RIGHTCLICKACTIONONEOF0_ROVR_COLON_ZIP: Literal["rovr:zip"] = "rovr:zip"
 r"""The values for the '_RightClickActionOneof0' enum"""
 _RIGHTCLICKACTIONONEOF0_ROVR_COLON_UNZIP: Literal["rovr:unzip"] = "rovr:unzip"
+r"""The values for the '_RightClickActionOneof0' enum"""
+_RIGHTCLICKACTIONONEOF0_ROVR_COLON_FOLLOW_SYMLINKS: Literal["rovr:follow_symlinks"] = (
+    "rovr:follow_symlinks"
+)
 r"""The values for the '_RightClickActionOneof0' enum"""
 _RIGHTCLICKACTIONONEOF0_SYSTEM_COLON_COPY_HIGHLIGHTED: Literal[
     "system:copy_highlighted"

--- a/src/rovr/core/file_list.py
+++ b/src/rovr/core/file_list.py
@@ -154,6 +154,7 @@ class FileList(
         self._ignore_next_click: bool = False
         self._in_git_repo: bool = False
         self._folder_item_counts: dict[str, tuple[int, int]] = {}
+        self._follow_links_next: bool = False
 
     def on_mount(self) -> None:
         if not self.dummy and self.parent:
@@ -1076,7 +1077,8 @@ class FileList(
             new = self.highlighted or 0
             await self.select_range(old, new)
 
-    def action_select(self) -> None:
+    def action_select(self, follow_symlinks: bool = False) -> None:
+        self._follow_links_next = follow_symlinks
         super().action_select()
         self.call_later(self.call_later, self.implicit_selector, "post")
 

--- a/src/rovr/core/file_list_right_click_menu.py
+++ b/src/rovr/core/file_list_right_click_menu.py
@@ -1,5 +1,6 @@
 import os
 from functools import partial
+from os.path import realpath
 from subprocess import Popen
 from typing import ClassVar, Literal
 
@@ -104,6 +105,11 @@ def give_me_an_option(
                     hasattr(app.file_list.highlighted_option, "dir_entry")
                     and is_archive(app.file_list.highlighted_option.dir_entry.path)
                 ),
+            )
+        case "rovr:follow_symlinks":
+            return PartialOption(
+                id="follow_symlinks",
+                disabled=app.file_list.highlighted_option is None or no_items,
             )
         case "system:copy_highlighted":
             return PartialOption(id="copy_highlighted", disabled=no_items)
@@ -236,6 +242,21 @@ class FileListRightClickMenu(PopupOptionList, inherit_bindings=False):
                     f"{event.option.id}",
                 )
             )
+        elif event.option.id == "follow_symlinks":
+            highlighted = self.app.file_list.highlighted_option
+            if highlighted is None:
+                return
+            resolved_path = realpath(highlighted.dir_entry.path)
+            self.call_next(
+                self.app.cd,
+                resolved_path
+                if highlighted.dir_entry.is_dir()
+                else os.path.dirname(resolved_path),
+                focus_on=None
+                if highlighted.dir_entry.is_dir()
+                else os.path.basename(resolved_path),
+            )
+            self._resolve_symlinks = False
         elif hasattr(self.app.file_list, f"action_{event.option.id}"):
             self.call_next(
                 getattr(

--- a/src/rovr/core/file_list_right_click_menu.py
+++ b/src/rovr/core/file_list_right_click_menu.py
@@ -1,6 +1,5 @@
 import os
 from functools import partial
-from os.path import realpath
 from subprocess import Popen
 from typing import ClassVar, Literal
 
@@ -246,7 +245,13 @@ class FileListRightClickMenu(PopupOptionList, inherit_bindings=False):
             highlighted = self.app.file_list.highlighted_option
             if highlighted is None:
                 return
-            resolved_path = realpath(highlighted.dir_entry.path)
+            resolved_path = os.path.realpath(highlighted.dir_entry.path)
+            if not os.path.exists(resolved_path):
+                self.notify(
+                    f"Path {resolved_path} does not exist\nTaking you to the closest parent directory",
+                    severity="warning",
+                )
+
             self.call_next(
                 self.app.cd,
                 resolved_path
@@ -256,7 +261,6 @@ class FileListRightClickMenu(PopupOptionList, inherit_bindings=False):
                 if highlighted.dir_entry.is_dir()
                 else os.path.basename(resolved_path),
             )
-            self._resolve_symlinks = False
         elif hasattr(self.app.file_list, f"action_{event.option.id}"):
             self.call_next(
                 getattr(

--- a/src/rovr/functions/cwd.py
+++ b/src/rovr/functions/cwd.py
@@ -65,21 +65,30 @@ class _WorkingDirectory:
 _working_directory = _WorkingDirectory()
 
 
-def getcwd() -> str:
+def getcwd(follow_symlinks: bool = False) -> str:
     """Return the logical current working directory.
+
+    Args:
+        follow_symlinks: If True, resolve symlinks in the path before returning.
 
     Returns:
         The logical current working directory.
     """
-    return _working_directory.getcwd()
+    cwd = _working_directory.getcwd()
+    if follow_symlinks:
+        cwd = path.realpath(cwd)
+    return cwd
 
 
-def chdir(directory: str) -> None:
+def chdir(directory: str, follow_symlinks: bool = False) -> None:
     """Change the process and logical working directories.
 
     Args:
         directory: An absolute path or a path relative to the logical cwd.
+        follow_symlinks: If True, resolve symlinks in the path before changing
     """
+    if follow_symlinks:
+        directory = path.realpath(directory)
     _working_directory.chdir(directory)
 
 


### PR DESCRIPTION
resolves #348 

https://github.com/user-attachments/assets/912728ec-65e6-4427-af66-d271289d1481

also noticed a problem with the popup, will work on it later trust

i cant make it depend on the file type, that requires a breaking change of removing `if = { directory = bool }` in favour of `if = { type = ["directory", "file", "fifo", ...] }`

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Add optional symbolic-link traversal for file navigation and expose it through the right-click menu.

New Features:
- Add a context-menu action for navigating through symbolic links to their resolved targets.

Enhancements:
- Allow directory changes and current-working-directory resolution to optionally follow symbolic links.

Documentation:
- Document the new `rovr:follow_symlinks` right-click action in the schema reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Follow link” right-click action for navigating through symbolic links.
  * Directory changes can optionally resolve symbolic links when opening linked files or folders.
  * Unresolvable links now provide a warning instead of navigating unexpectedly.

* **Documentation**
  * Updated the configuration reference and schema to include the new right-click action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->