### PR TITLE
fix: consistent button colors

### DIFF
--- a/src/rovr/screens/common_file_name_do_what.py
+++ b/src/rovr/screens/common_file_name_do_what.py
@@ -47,8 +47,8 @@ class FileNameConflict(ModalScreen):
                 yield Button(
                     f"\\[{overwrite_bind}] Overwrite", variant="error", id="overwrite"
                 )
-            yield Button(f"\\[{rename_bind}] Rename", variant="warning", id="rename")
-            yield Button(f"\\[{skip_bind}] Skip", variant="success", id="skip")
+            yield Button(f"\\[{rename_bind}] Rename", variant="success", id="rename")
+            yield Button(f"\\[{skip_bind}] Skip", variant="warning", id="skip")
             if not self.allow_overwrite:
                 with Container():
                     yield Button(

--- a/src/rovr/screens/delete_files.py
+++ b/src/rovr/screens/delete_files.py
@@ -37,12 +37,12 @@ class DeleteFiles(ModalScreen):
                 yield Button(f"\\[{delete_bind}] Delete", variant="error", id="delete")
                 with Container():
                     yield Button(
-                        f"\\[{cancel_bind}] Cancel", variant="success", id="cancel"
+                        f"\\[{cancel_bind}] Cancel", variant="primary", id="cancel"
                     )
             else:
                 yield Button(f"\\[{delete_bind}] Delete", variant="error", id="delete")
                 yield Button(
-                    f"\\[{cancel_bind}] Cancel", variant="success", id="cancel"
+                    f"\\[{cancel_bind}] Cancel", variant="primary", id="cancel"
                 )
 
     def on_mount(self) -> None:

--- a/src/rovr/screens/file_in_use.py
+++ b/src/rovr/screens/file_in_use.py
@@ -34,10 +34,10 @@ class FileInUse(ModalScreen):
         )
         with Grid(id="dialog"):
             yield Label(escape(self.message), classes="question")
-            yield Button(f"\\[{retry_bind}] Retry", variant="primary", id="try_again")
+            yield Button(f"\\[{retry_bind}] Retry", variant="success", id="try_again")
             yield Button(f"\\[{skip_bind}] Skip", variant="warning", id="skip")
             with Container():
-                yield Button(f"\\[{cancel_bind}] Cancel", variant="error", id="cancel")
+                yield Button(f"\\[{cancel_bind}] Cancel", variant="primary", id="cancel")
             with HorizontalGroup(id="dontAskAgain"):
                 yield Switch()
                 yield Label(f"\\[{dont_ask_bind}] Don't ask again")


### PR DESCRIPTION
<!--describe your pull request-->
I mentioned the color problem of modal dialog buttons in this #347 discussion. This is the implementation of the proposal.

<!--also include videos, screenshots or gifs if applicable if it is a new feature-->

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Bug Fixes:
- Standardize modal dialog button colors so each action uses a consistent semantic variant across file-operation prompts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated modal button styling for clearer action distinction:
    * Rename uses a success style and Skip uses a warning style.
    * Cancel uses a primary style in delete-file dialogs.
    * Retry uses a success style and Cancel uses a primary style when files are in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->