### PR TITLE
fix: follow symlinks

### DIFF
--- a/src/rovr/core/file_list_right_click_menu.py
+++ b/src/rovr/core/file_list_right_click_menu.py
@@ -108,7 +108,10 @@ def give_me_an_option(
         case "rovr:follow_symlinks":
             return PartialOption(
                 id="follow_symlinks",
-                disabled=app.file_list.highlighted_option is None or no_items,
+                disabled=not (
+                        hasattr(app.file_list.highlighted_option, "dir_entry")
+                        and app.file_list.highlighted_option.dir_entry.is_symlink()
+                ),
             )
         case "system:copy_highlighted":
             return PartialOption(id="copy_highlighted", disabled=no_items)

--- a/src/rovr/core/file_list_right_click_menu.py
+++ b/src/rovr/core/file_list_right_click_menu.py
@@ -248,7 +248,10 @@ class FileListRightClickMenu(PopupOptionList, inherit_bindings=False):
             highlighted = self.app.file_list.highlighted_option
             if highlighted is None:
                 return
-            resolved_path = os.readlink(highlighted.dir_entry.path)
+            try:
+                resolved_path = os.readlink(highlighted.dir_entry.path)
+            except OSError:
+                return
             if not os.path.lexists(resolved_path):
                 self.notify(
                     f"Path {resolved_path} does not exist\nTaking you to the closest parent directory",

--- a/src/rovr/core/file_list_right_click_menu.py
+++ b/src/rovr/core/file_list_right_click_menu.py
@@ -245,8 +245,8 @@ class FileListRightClickMenu(PopupOptionList, inherit_bindings=False):
             highlighted = self.app.file_list.highlighted_option
             if highlighted is None:
                 return
-            resolved_path = os.path.realpath(highlighted.dir_entry.path)
-            if not os.path.exists(resolved_path):
+            resolved_path = os.readlink(highlighted.dir_entry.path)
+            if not os.path.lexists(resolved_path):
                 self.notify(
                     f"Path {resolved_path} does not exist\nTaking you to the closest parent directory",
                     severity="warning",

--- a/src/rovr/core/file_list_right_click_menu.py
+++ b/src/rovr/core/file_list_right_click_menu.py
@@ -254,14 +254,15 @@ class FileListRightClickMenu(PopupOptionList, inherit_bindings=False):
                     f"Path {resolved_path} does not exist\nTaking you to the closest parent directory",
                     severity="warning",
                 )
+            is_real_dir = os.path.isdir(resolved_path) and not os.path.islink(resolved_path)
 
             self.call_next(
                 self.app.cd,
                 resolved_path
-                if highlighted.dir_entry.is_dir()
+                if is_real_dir
                 else os.path.dirname(resolved_path),
                 focus_on=None
-                if highlighted.dir_entry.is_dir()
+                if is_real_dir
                 else os.path.basename(resolved_path),
             )
         elif hasattr(self.app.file_list, f"action_{event.option.id}"):


### PR DESCRIPTION
<!--describe your pull request-->

fixes for this two [issues](https://github.com/NSPC911/rovr/pull/351#issuecomment-5512511103).


<!--also include videos, screenshots or gifs if applicable if it is a new feature-->

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Bug Fixes:
- Correct symlink navigation by enabling the follow-symlinks action only for symlink entries and resolving their targets safely, including broken links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The **Follow Symlink** right-click option is now shown only for highlighted symbolic-link entries.
  - Improved navigation when following symbolic links to directories or unavailable targets.
  - Broken links are detected reliably, and selecting an unreadable link no longer causes an error or unexpected navigation.
  - The file browser now opens the appropriate destination or containing folder and focuses the correct entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->