### PR TITLE
fix: false quotes in first launch config

### DIFF
--- a/src/rovr/first_launch.py
+++ b/src/rovr/first_launch.py
@@ -453,7 +453,7 @@ enabled = {str(self.query_one("#plugins-fd Switch", Switch).value).lower()}
 
 [plugins.bat]
 enabled = {str(self.query_one("#plugins-bat Switch", Switch).value).lower()}
-{f'"executable" = {"batcat" if which("batcat") is not None else "bat"}' if self.query_one("#plugins-bat Switch", Switch).value else ""}
+{f'executable = "{"batcat" if which("batcat") is not None else "bat"}"' if self.query_one("#plugins-bat Switch", Switch).value else ""}
 
 [plugins.zoxide]
 enabled = {str(self.query_one("#plugins-zoxide Switch", Switch).value).lower()}


### PR DESCRIPTION
<!--describe your pull request-->
The quotes in `config.toml` should go the other way around:

`"executable" = batcat` -> `executable = "batcat"`


<!--also include videos, screenshots or gifs if applicable if it is a new feature-->

---

by submitting this pull request, i agree that

- [ ] i have run `poe check` to check for any style issues and fixed them
- [ ] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [ ] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [ ] my commits (or at least the pr title) follow the conventional commits format as much as possible

## Summary by Sourcery

Bug Fixes:
- Correct the first-launch configuration output so the bat plugin’s executable setting uses valid TOML key and value quoting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected generated bat plugin configuration so the executable setting uses valid TOML syntax.
  - Ensures generated configurations are correctly recognised when using either `bat` or `batcat`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->