### PR TITLE
fix: more consistent button colors

### DIFF
--- a/src/rovr/screens/paste_drop.py
+++ b/src/rovr/screens/paste_drop.py
@@ -45,7 +45,7 @@ class PasteDropScreen(Actionable, ModalScreen["PasteDropScreen.ReturnType | None
             yield Button(f"\\[{copy_bind}] Copy", id="copy", variant="success")
             yield Button(f"\\[{move_bind}] Move", id="move", variant="warning")
             with HorizontalGroup():
-                yield Button(f"\\[{cancel_bind}] Cancel", id="cancel", variant="error")
+                yield Button(f"\\[{cancel_bind}] Cancel", id="cancel", variant="primary")
 
     def on_mount(self) -> None:
         self.query_one(Grid).border_title = "Drag and Drop"

--- a/src/rovr/screens/trash.py
+++ b/src/rovr/screens/trash.py
@@ -201,7 +201,7 @@ class TrashScreen(Actionable, ModalScreen):
                 disabled=True,
             )
             yield Button(
-                f"\\[{purge_bind}] Purge", variant="error", id="purge", disabled=True
+                f"\\[{purge_bind}] Purge", variant="warning", id="purge", disabled=True
             )
             yield Button(
                 f"\\[{empty_bind}] Empty", variant="error", id="empty", disabled=True

--- a/src/rovr/style.tcss
+++ b/src/rovr/style.tcss
@@ -1087,9 +1087,9 @@ ShellExec {
 
 PasteDropScreen #dialog {
   border: $border-style $border-focused;
-  padding: 0 1;
+  padding: 1 3;
   grid-size: 2 3;
-  grid-gutter: 0 1;
+  grid-gutter: 1 2;
   grid-rows: 1fr 3 3;
   max-height: 100vh;
   height: 60vh;


### PR DESCRIPTION
<!--describe your pull request-->
Reworked buttons in `TrashScreen` and `PasteDropScreen`.

Some [details](https://github.com/NSPC911/rovr/discussions/347#discussioncomment-18393972) in discussion thread.
 
<!--also include videos, screenshots or gifs if applicable if it is a new feature-->

---

by submitting this pull request, i agree that

- [x] i have run `poe check` to check for any style issues and fixed them
- [x] i have tested rovr (and also ran `poe test` if applicable) to make sure my changes do not break anything
- [x] cache, logs, dotfiles and/or others were not accidentally added to git's tracking history
- [x] my commits (or at least the pr title) follow the conventional commits format as much as possible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and layout in the paste-and-drop dialog for a clearer, more comfortable presentation.

* **User Interface**
  * Updated the Cancel button in the paste-and-drop dialog to use a standard primary style.
  * Updated the Purge button in the trash screen to use a warning style, better reflecting its action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->